### PR TITLE
Add terminal max width control and fix WebSocket panic

### DIFF
--- a/web/src/client/components/file-browser.ts
+++ b/web/src/client/components/file-browser.ts
@@ -238,8 +238,12 @@ export class FileBrowser extends LitElement {
             : ''}
 
           <div class="p-4 border-t border-dark-border flex gap-4 flex-shrink-0">
-            <button class="btn-ghost font-mono flex-1 py-3" @click=${this.handleCancel}>Cancel</button>
-            <button class="btn-primary font-mono flex-1 py-3" @click=${this.handleSelect}>Select</button>
+            <button class="btn-ghost font-mono flex-1 py-3" @click=${this.handleCancel}>
+              Cancel
+            </button>
+            <button class="btn-primary font-mono flex-1 py-3" @click=${this.handleSelect}>
+              Select
+            </button>
           </div>
         </div>
       </div>

--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -4,7 +4,10 @@ import type { Session } from './session-list.js';
 import './terminal.js';
 import type { Terminal } from './terminal.js';
 import { CastConverter } from '../utils/cast-converter.js';
-import { TerminalPreferencesManager } from '../utils/terminal-preferences.js';
+import {
+  TerminalPreferencesManager,
+  COMMON_TERMINAL_WIDTHS,
+} from '../utils/terminal-preferences.js';
 
 @customElement('session-view')
 export class SessionView extends LitElement {
@@ -30,6 +33,8 @@ export class SessionView extends LitElement {
   @state() private showCtrlAlpha = false;
   @state() private terminalFitHorizontally = false;
   @state() private terminalMaxCols = 0;
+  @state() private showWidthSelector = false;
+  @state() private customWidth = '';
 
   private preferencesManager = TerminalPreferencesManager.getInstance();
   @state() private reconnectCount = 0;
@@ -119,6 +124,19 @@ export class SessionView extends LitElement {
     }
   };
 
+  private handleClickOutside = (e: Event) => {
+    if (this.showWidthSelector) {
+      const target = e.target as HTMLElement;
+      const widthSelector = this.querySelector('.width-selector-container');
+      const widthButton = this.querySelector('.width-selector-button');
+
+      if (!widthSelector?.contains(target) && !widthButton?.contains(target)) {
+        this.showWidthSelector = false;
+        this.customWidth = '';
+      }
+    }
+  };
+
   connectedCallback() {
     super.connectedCallback();
     this.connected = true;
@@ -129,6 +147,9 @@ export class SessionView extends LitElement {
     // Make session-view focusable
     this.tabIndex = 0;
     this.addEventListener('click', () => this.focus());
+
+    // Add click outside handler for width selector
+    document.addEventListener('click', this.handleClickOutside);
 
     // Show loading animation if no session yet
     if (!this.session) {
@@ -155,6 +176,9 @@ export class SessionView extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this.connected = false;
+
+    // Remove click outside handler
+    document.removeEventListener('click', this.handleClickOutside);
 
     // Remove click handler
     this.removeEventListener('click', () => this.focus());
@@ -758,10 +782,13 @@ export class SessionView extends LitElement {
   }
 
   private handleMaxWidthToggle() {
-    // Toggle between no limit (0) and 80 columns
-    const newMaxCols = this.terminalMaxCols === 0 ? 80 : 0;
+    this.showWidthSelector = !this.showWidthSelector;
+  }
+
+  private handleWidthSelect(newMaxCols: number) {
     this.terminalMaxCols = newMaxCols;
     this.preferencesManager.setMaxCols(newMaxCols);
+    this.showWidthSelector = false;
 
     // Update the terminal component
     const terminal = this.querySelector('vibe-terminal') as Terminal;
@@ -770,6 +797,34 @@ export class SessionView extends LitElement {
       // Trigger a resize to apply the new constraint
       terminal.requestUpdate();
     }
+  }
+
+  private handleCustomWidthInput(e: Event) {
+    const input = e.target as HTMLInputElement;
+    this.customWidth = input.value;
+  }
+
+  private handleCustomWidthSubmit() {
+    const width = parseInt(this.customWidth, 10);
+    if (!isNaN(width) && width >= 20 && width <= 500) {
+      this.handleWidthSelect(width);
+      this.customWidth = '';
+    }
+  }
+
+  private handleCustomWidthKeydown(e: KeyboardEvent) {
+    if (e.key === 'Enter') {
+      this.handleCustomWidthSubmit();
+    } else if (e.key === 'Escape') {
+      this.customWidth = '';
+      this.showWidthSelector = false;
+    }
+  }
+
+  private getCurrentWidthLabel(): string {
+    if (this.terminalMaxCols === 0) return '∞';
+    const commonWidth = COMMON_TERMINAL_WIDTHS.find((w) => w.value === this.terminalMaxCols);
+    return commonWidth ? commonWidth.label : this.terminalMaxCols.toString();
   }
 
   private async sendInputText(text: string) {
@@ -908,16 +963,65 @@ export class SessionView extends LitElement {
               </div>
             </div>
           </div>
-          <div class="flex items-center gap-2 text-xs flex-shrink-0 ml-2">
+          <div class="flex items-center gap-2 text-xs flex-shrink-0 ml-2 relative">
             <button
-              class="btn-secondary font-mono text-xs px-2 py-1 flex-shrink-0"
+              class="btn-secondary font-mono text-xs px-2 py-1 flex-shrink-0 width-selector-button"
               @click=${this.handleMaxWidthToggle}
-              title="${this.terminalMaxCols === 0
-                ? 'Limit width to 80 columns'
-                : 'Remove width limit (full width)'}"
+              title="Terminal width: ${this.terminalMaxCols === 0
+                ? 'Unlimited'
+                : this.terminalMaxCols + ' columns'}"
             >
-              ${this.terminalMaxCols === 0 ? '∞' : '80'}
+              ${this.getCurrentWidthLabel()}
             </button>
+            ${this.showWidthSelector
+              ? html`
+                  <div
+                    class="width-selector-container absolute top-8 right-0 bg-dark-bg-secondary border border-dark-border rounded-md shadow-lg z-50 min-w-48"
+                  >
+                    <div class="p-2">
+                      <div class="text-xs text-dark-text-muted mb-2 px-2">Terminal Width</div>
+                      ${COMMON_TERMINAL_WIDTHS.map(
+                        (width) => html`
+                          <button
+                            class="w-full text-left px-2 py-1 text-xs hover:bg-dark-border rounded-sm flex justify-between items-center
+                              ${this.terminalMaxCols === width.value
+                              ? 'bg-dark-border text-accent-green'
+                              : 'text-dark-text'}"
+                            @click=${() => this.handleWidthSelect(width.value)}
+                          >
+                            <span class="font-mono">${width.label}</span>
+                            <span class="text-dark-text-muted text-xs">${width.description}</span>
+                          </button>
+                        `
+                      )}
+                      <div class="border-t border-dark-border mt-2 pt-2">
+                        <div class="text-xs text-dark-text-muted mb-1 px-2">Custom (20-500)</div>
+                        <div class="flex gap-1">
+                          <input
+                            type="number"
+                            min="20"
+                            max="500"
+                            placeholder="80"
+                            .value=${this.customWidth}
+                            @input=${this.handleCustomWidthInput}
+                            @keydown=${this.handleCustomWidthKeydown}
+                            class="flex-1 bg-dark-bg border border-dark-border rounded px-2 py-1 text-xs font-mono text-dark-text"
+                          />
+                          <button
+                            class="btn-secondary text-xs px-2 py-1"
+                            @click=${this.handleCustomWidthSubmit}
+                            ?disabled=${!this.customWidth ||
+                            parseInt(this.customWidth) < 20 ||
+                            parseInt(this.customWidth) > 500}
+                          >
+                            Set
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                `
+              : ''}
             <div class="flex flex-col items-end gap-0">
               <span class="${this.getStatusColor()} text-xs flex items-center gap-1">
                 <div class="w-2 h-2 rounded-full ${this.getStatusDotColor()}"></div>

--- a/web/src/client/utils/terminal-preferences.ts
+++ b/web/src/client/utils/terminal-preferences.ts
@@ -1,0 +1,92 @@
+/**
+ * Terminal preferences management
+ * Handles saving and loading terminal-related user preferences
+ */
+
+export interface TerminalPreferences {
+  maxCols: number; // 0 means no limit, positive numbers set max width
+  fontSize: number;
+  fitHorizontally: boolean;
+}
+
+const DEFAULT_PREFERENCES: TerminalPreferences = {
+  maxCols: 0, // No limit by default - take as much as possible
+  fontSize: 14,
+  fitHorizontally: false,
+};
+
+const STORAGE_KEY_TERMINAL_PREFS = 'vibetunnel_terminal_preferences';
+
+export class TerminalPreferencesManager {
+  private static instance: TerminalPreferencesManager;
+  private preferences: TerminalPreferences;
+
+  private constructor() {
+    this.preferences = this.loadPreferences();
+  }
+
+  static getInstance(): TerminalPreferencesManager {
+    if (!TerminalPreferencesManager.instance) {
+      TerminalPreferencesManager.instance = new TerminalPreferencesManager();
+    }
+    return TerminalPreferencesManager.instance;
+  }
+
+  private loadPreferences(): TerminalPreferences {
+    try {
+      const saved = localStorage.getItem(STORAGE_KEY_TERMINAL_PREFS);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        // Merge with defaults to handle new properties
+        return { ...DEFAULT_PREFERENCES, ...parsed };
+      }
+    } catch (error) {
+      console.warn('Failed to load terminal preferences:', error);
+    }
+    return { ...DEFAULT_PREFERENCES };
+  }
+
+  private savePreferences() {
+    try {
+      localStorage.setItem(STORAGE_KEY_TERMINAL_PREFS, JSON.stringify(this.preferences));
+    } catch (error) {
+      console.warn('Failed to save terminal preferences:', error);
+    }
+  }
+
+  getMaxCols(): number {
+    return this.preferences.maxCols;
+  }
+
+  setMaxCols(maxCols: number) {
+    this.preferences.maxCols = Math.max(0, maxCols); // Ensure non-negative
+    this.savePreferences();
+  }
+
+  getFontSize(): number {
+    return this.preferences.fontSize;
+  }
+
+  setFontSize(fontSize: number) {
+    this.preferences.fontSize = Math.max(8, Math.min(32, fontSize)); // Reasonable bounds
+    this.savePreferences();
+  }
+
+  getFitHorizontally(): boolean {
+    return this.preferences.fitHorizontally;
+  }
+
+  setFitHorizontally(fitHorizontally: boolean) {
+    this.preferences.fitHorizontally = fitHorizontally;
+    this.savePreferences();
+  }
+
+  getPreferences(): TerminalPreferences {
+    return { ...this.preferences };
+  }
+
+  resetToDefaults() {
+    this.preferences = { ...DEFAULT_PREFERENCES };
+    this.savePreferences();
+  }
+}

--- a/web/src/client/utils/terminal-preferences.ts
+++ b/web/src/client/utils/terminal-preferences.ts
@@ -9,6 +9,16 @@ export interface TerminalPreferences {
   fitHorizontally: boolean;
 }
 
+// Common terminal widths
+export const COMMON_TERMINAL_WIDTHS = [
+  { value: 0, label: '∞', description: 'Unlimited (full width)' },
+  { value: 80, label: '80', description: 'Classic terminal' },
+  { value: 100, label: '100', description: 'Modern standard' },
+  { value: 120, label: '120', description: 'Wide terminal' },
+  { value: 132, label: '132', description: 'Mainframe width' },
+  { value: 160, label: '160', description: 'Ultra-wide' },
+] as const;
+
 const DEFAULT_PREFERENCES: TerminalPreferences = {
   maxCols: 0, // No limit by default - take as much as possible
   fontSize: 14,


### PR DESCRIPTION
## Summary
- Add terminal max width control with common presets (80, 100, 120, 132, 160) and custom input
- Fix WebSocket "send on closed channel" panic with graceful error handling
- Maintain backward compatibility with unlimited width as default

## Test plan
- [ ] Test terminal width selector with different presets
- [ ] Verify custom width input validation and persistence
- [ ] Confirm WebSocket connections handle closures without panic
- [ ] Test --no-spawn flag functionality

🤖 Generated with [Claude Code](https://claude.ai/code)