### PR TITLE
fix: respect top safe area

### DIFF
--- a/web/src/client/components/app-header.ts
+++ b/web/src/client/components/app-header.ts
@@ -73,7 +73,10 @@ export class AppHeader extends LitElement {
     }
 
     return html`
-      <div class="app-header bg-dark-bg-secondary border-b border-dark-border p-6">
+      <div
+        class="app-header bg-dark-bg-secondary border-b border-dark-border p-6"
+        style="padding-top: max(env(safe-area-inset-top), 1.5rem);"
+      >
         <!-- Mobile layout -->
         <div class="flex flex-col gap-4 sm:hidden">
           <!-- Centered VibeTunnel title with stats -->

--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -1042,6 +1042,7 @@ export class SessionView extends LitElement {
         <!-- Compact Header -->
         <div
           class="flex items-center justify-between px-3 py-2 border-b border-dark-border text-sm min-w-0 bg-dark-bg-secondary"
+          style="padding-top: max(env(safe-area-inset-top), 0.5rem);"
         >
           <div class="flex items-center gap-3 min-w-0 flex-1">
             <button


### PR DESCRIPTION
Adds safe area padding to app header and session header.

Note that `0.5rem == Tailwind's pt-2`.

Screenshots in PWA iOS 18.5:

| Before | After |
|--------|-------|
| ![Before 1](https://github.com/user-attachments/assets/c04242aa-5883-4f59-bc92-43ad65d7792a) | ![After 1](https://github.com/user-attachments/assets/ab07ef2d-aa74-4dcb-85e4-f0ca51394295) |
| ![Before 2](https://github.com/user-attachments/assets/ea870a4b-d6fc-407a-bc89-ac3fd051b3c1) | ![After 2](https://github.com/user-attachments/assets/b89eb5fe-a4b8-40cc-a75f-68f434b62fd8) |

Outside of PWA mode, paddings remain unchanged:

| Before | After |
|--------|-------|
| ![Before 1](https://github.com/user-attachments/assets/fd32238a-6837-4c8b-baf0-7cb99f748151) | ![After 1](https://github.com/user-attachments/assets/ea454a98-7a9f-40ce-be74-da6253f6f442) |
| ![Before 2](https://github.com/user-attachments/assets/7ade45d3-4002-4fb5-a122-9de8d15cba2b) | ![After 2](https://github.com/user-attachments/assets/50f891e0-2d15-4ebd-b205-376cd6a681a4) |


