### PR TITLE
Add WSL2 support for VibeTunnel

### DIFF
--- a/web/src/server/pty/session-manager.ts
+++ b/web/src/server/pty/session-manager.ts
@@ -69,8 +69,9 @@ export class SessionManager {
    */
   private createStdinPipe(stdinPath: string): void {
     try {
-      // Try to create FIFO pipe (Unix-like systems)
-      if (process.platform !== 'win32') {
+      // Try to create FIFO pipe (Unix-like systems including WSL2)
+      const platformType = ProcessUtils.getPlatformType();
+      if (platformType !== 'win32') {
         const result = spawnSync('mkfifo', [stdinPath], { stdio: 'ignore' });
         if (result.status === 0) {
           logger.debug(`FIFO pipe created: ${stdinPath}`);

--- a/web/src/server/services/process-tree-analyzer.ts
+++ b/web/src/server/services/process-tree-analyzer.ts
@@ -1,6 +1,7 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { createLogger } from '../utils/logger.js';
+import { ProcessUtils } from '../pty/process-utils.js';
 
 const logger = createLogger('process-tree-analyzer');
 
@@ -31,7 +32,8 @@ export class ProcessTreeAnalyzer {
    */
   async getProcessTree(rootPid: number): Promise<ProcessInfo[]> {
     try {
-      if (process.platform === 'win32') {
+      const platformType = ProcessUtils.getPlatformType();
+      if (platformType === 'win32') {
         return await this.getWindowsProcessTree(rootPid);
       } else {
         return await this.getUnixProcessTree(rootPid);
@@ -43,10 +45,11 @@ export class ProcessTreeAnalyzer {
   }
 
   /**
-   * Get process tree on Unix-like systems (macOS, Linux)
+   * Get process tree on Unix-like systems (macOS, Linux, WSL2)
    */
   private async getUnixProcessTree(rootPid: number): Promise<ProcessInfo[]> {
-    const isMacOS = process.platform === 'darwin';
+    const platformType = ProcessUtils.getPlatformType();
+    const isMacOS = platformType === 'darwin';
 
     // Always use the recursive approach since process groups aren't working reliably
     logger.log(


### PR DESCRIPTION
## Summary
Implements comprehensive WSL2 support to enable Windows users to run VibeTunnel through WSL2.

## Key Features Added
- **🔍 WSL2 Detection**: Automatic detection via `/proc/version` and environment variables
- **🌐 Platform Abstraction**: New `getPlatformType()` method returning `'wsl2'` for WSL2 environments
- **🔗 Network Configuration**: Automatic `0.0.0.0` binding for Windows host browser access
- **🐚 Shell Resolution**: WSL2-optimized shell detection (bash priority)
- **⚙️ Process Monitoring**: WSL2-compatible process management

## Files Modified
- `src/server/pty/process-utils.ts` - WSL2 detection, platform abstraction, shell resolution
- `src/server/server.ts` - WSL2 network binding, startup messages  
- `src/server/pty/session-manager.ts` - WSL2-compatible pipe creation
- `src/server/services/process-tree-analyzer.ts` - Platform-aware process analysis

## Usage
WSL2 users can now run VibeTunnel server and access it from Windows browser at `http://localhost:4020`

## Testing
- ✅ Lint and typecheck pass
- ✅ WSL2 detection works correctly
- ✅ Platform abstraction implemented across all relevant files
- ✅ Network binding configured for WSL2 compatibility

## Breaking Changes
None - all changes are additive and backward compatible.

🤖 Generated with [Claude Code](https://claude.ai/code)