### PR TITLE
Prevent recursive VibeTunnel sessions (GitHub #95)

### DIFF
--- a/mac/VibeTunnel/vt
+++ b/mac/VibeTunnel/vt
@@ -2,8 +2,8 @@
 # VibeTunnel CLI wrapper
 
 # Check if we're already inside a VibeTunnel session
-if [ -n "$INSIDE_VIBETUNNEL" ] || [ "$VIBETUNNEL_SESSION" = "true" ]; then
-    echo "Error: Already inside a VibeTunnel session. Recursive VibeTunnel sessions are not supported." >&2
+if [ -n "$VIBETUNNEL_SESSION_ID" ]; then
+    echo "Error: Already inside a VibeTunnel session (ID: $VIBETUNNEL_SESSION_ID). Recursive VibeTunnel sessions are not supported." >&2
     echo "If you need to run commands, use them directly without the 'vt' prefix." >&2
     exit 1
 fi

--- a/mac/VibeTunnel/vt
+++ b/mac/VibeTunnel/vt
@@ -1,6 +1,13 @@
 #!/bin/bash
 # VibeTunnel CLI wrapper
 
+# Check if we're already inside a VibeTunnel session
+if [ -n "$INSIDE_VIBETUNNEL" ] || [ "$VIBETUNNEL_SESSION" = "true" ]; then
+    echo "Error: Already inside a VibeTunnel session. Recursive VibeTunnel sessions are not supported." >&2
+    echo "If you need to run commands, use them directly without the 'vt' prefix." >&2
+    exit 1
+fi
+
 # Try standard locations first, but verify the binary exists
 APP_PATH=""
 for TRY_PATH in "/Applications/VibeTunnel.app" "$HOME/Applications/VibeTunnel.app"; do

--- a/web/src/server/pty/pty-manager.ts
+++ b/web/src/server/pty/pty-manager.ts
@@ -237,9 +237,8 @@ export class PtyManager extends EventEmitter {
         const ptyEnv = {
           ...process.env,
           TERM: term,
-          // Mark this as a VibeTunnel session to prevent recursive vt calls
-          INSIDE_VIBETUNNEL: '1',
-          VIBETUNNEL_SESSION: 'true',
+          // Set session ID to prevent recursive vt calls and for debugging
+          VIBETUNNEL_SESSION_ID: sessionId,
         };
 
         // Debug log the spawn parameters

--- a/web/src/server/pty/pty-manager.ts
+++ b/web/src/server/pty/pty-manager.ts
@@ -237,6 +237,9 @@ export class PtyManager extends EventEmitter {
         const ptyEnv = {
           ...process.env,
           TERM: term,
+          // Mark this as a VibeTunnel session to prevent recursive vt calls
+          INSIDE_VIBETUNNEL: '1',
+          VIBETUNNEL_SESSION: 'true',
         };
 
         // Debug log the spawn parameters


### PR DESCRIPTION
## Summary
- Added detection and prevention of nested VibeTunnel sessions
- Sets environment variables to mark VibeTunnel context
- vt script now checks for these variables and shows helpful error message

## Problem
Users could run 'vt' command inside a VibeTunnel session, creating recursive/nested terminal instances. This led to confusing behavior as shown in the screenshot where 'vt' was executed within an existing VibeTunnel session.

## Solution
1. **Environment Variables**: When creating PTY sessions, we now set:
   - INSIDE_VIBETUNNEL=1
   - VIBETUNNEL_SESSION=true

2. **vt Script Check**: Added detection at the start of the vt wrapper script that:
   - Checks if these environment variables are set
   - Shows a clear error message if recursive session is attempted
   - Exits with code 1 to prevent nested execution

## Code Changes
- **src/server/pty/pty-manager.ts**: Added environment variables to PTY sessions
- **mac/VibeTunnel/vt**: Added recursive session detection

## Test Plan
- Run VibeTunnel and create a new session
- Inside that session, try running 'vt' or 'vt <command>'
- Verify you get the error message instead of creating a nested session
- Verify normal commands still work fine

## Impact
✅ Fixes GitHub issue #95
✅ Prevents confusing nested VibeTunnel sessions
✅ Provides clear user feedback
✅ No breaking changes to normal usage

🤖 Generated with [Claude Code](https://claude.ai/code)