### PR TITLE
Add Shift+Tab key to mobile QuickKeyboard

### DIFF
--- a/web/src/client/components/terminal-quick-keys.ts
+++ b/web/src/client/components/terminal-quick-keys.ts
@@ -9,6 +9,7 @@ const TERMINAL_QUICK_KEYS = [
   { key: 'CtrlExpand', label: '⌃', toggle: true, row: 1 },
   { key: 'F', label: 'F', toggle: true, row: 1 },
   { key: 'Tab', label: 'Tab', row: 1 },
+  { key: 'shift_tab', label: '⇤', row: 1 },
   { key: 'ArrowUp', label: '↑', arrow: true, row: 1 },
   { key: 'ArrowDown', label: '↓', arrow: true, row: 1 },
   { key: 'ArrowLeft', label: '←', arrow: true, row: 1 },


### PR DESCRIPTION
## Summary
• Implement Peter's feedback from PR #105 to add Shift+Tab key to mobile QuickKeyboard
• Added shift_tab key with ⇤ symbol to TERMINAL_QUICK_KEYS array in row 1
• Enhances Claude Code planning mode support on mobile devices

## Test plan
- [ ] Test mobile quick keyboard displays Shift+Tab key
- [ ] Verify Shift+Tab key sends correct shift_tab input to terminal
- [ ] Confirm Claude Code mode switching works on mobile

🤖 Generated with [Claude Code](https://claude.ai/code)