### PR TITLE
feat: Add build output filtering to remove non-actionable warnings

### DIFF
--- a/mac/scripts/build-web-frontend.sh
+++ b/mac/scripts/build-web-frontend.sh
@@ -1,5 +1,6 @@
 #!/bin/zsh
 set -e  # Exit on any error
+set -o pipefail  # Exit if any command in a pipeline fails
 
 # Get the project directory
 if [ -z "${SRCROOT}" ]; then

--- a/mac/scripts/build-web-frontend.sh
+++ b/mac/scripts/build-web-frontend.sh
@@ -110,7 +110,7 @@ export CC="${CC:-clang}"
 # Function to filter warnings from build output
 filter_build_output() {
     grep -v -E '(missing field .* initializer|is deprecated.*Use.*instead|expanded from macro|has been explicitly marked deprecated|converts to incompatible function type|instantiation of function template|npm warn Unknown.*config|warn - Your.*content.*configuration|warn - Pattern:.*\*\.js|warn - See our documentation)' | \
-    grep -v -E '(gyp info spawn args|\.\.\.\/node_modules\/.*install:)'
+    grep -v -E '(gyp info spawn args|\.\.\.\/node_modules\/.*install:)' || true
 }
 
 # Run pnpm install with filtered output


### PR DESCRIPTION
## Summary
- Add `filter_build_output()` function to build script to remove common non-actionable warnings
- Apply filtering to all pnpm commands to reduce build log noise while preserving important errors

## What warnings are filtered
- Deprecated API warnings from Node.js native modules 
- Xcode C++ warnings about field initializers
- npm configuration warnings
- Tailwind CSS glob pattern warnings  
- gyp build information messages

## Why this matters
The macOS build process was generating hundreds of warnings from third-party dependencies and build tools that developers can't fix. This noise made it difficult to spot actual issues in the build output.

## Test plan
- [ ] Build the project with Xcode and verify warnings are filtered
- [ ] Verify actual errors still appear in the output
- [ ] Test both Debug and Release configurations