### PR TITLE
fix: correct CLI installation verification after title mode args update

### DIFF
--- a/mac/VibeTunnel/Utilities/CLIInstaller.swift
+++ b/mac/VibeTunnel/Utilities/CLIInstaller.swift
@@ -27,24 +27,36 @@ final class CLIInstaller {
     // MARK: - Properties
 
     private let logger = Logger(subsystem: "sh.vibetunnel.vibetunnel", category: "CLIInstaller")
+    private let binDirectory: String
+
+    private var vtTargetPath: String {
+        return URL(fileURLWithPath: binDirectory).appendingPathComponent("vt").path
+    }
 
     var isInstalled = false
     var isInstalling = false
     var lastError: String?
+
+    // MARK: - Initialization
+
+    /// Creates a CLI installer
+    /// - Parameters:
+    ///   - binDirectory: Directory for installation (defaults to /usr/local/bin)
+    init(binDirectory: String = "/usr/local/bin") {
+        self.binDirectory = binDirectory
+    }
 
     // MARK: - Public Interface
 
     /// Checks if the CLI tool is installed
     func checkInstallationStatus() {
         Task { @MainActor in
-            let vtPath = "/usr/local/bin/vt"
-
             // Check if vt script exists and is configured correctly
             var isCorrectlyInstalled = false
 
-            if FileManager.default.fileExists(atPath: vtPath) {
+            if FileManager.default.fileExists(atPath: vtTargetPath) {
                 // Check if it contains the correct app path reference
-                if let content = try? String(contentsOfFile: vtPath, encoding: .utf8) {
+                if let content = try? String(contentsOfFile: vtTargetPath, encoding: .utf8) {
                     // Verify it's our wrapper script with all expected components
                     isCorrectlyInstalled = content.contains("VibeTunnel CLI wrapper") &&
                         content.contains("$TRY_PATH/Contents/Resources/vibetunnel") &&
@@ -116,9 +128,6 @@ final class CLIInstaller {
             isInstalling = false
             return
         }
-
-        let vtTargetPath = "/usr/local/bin/vt"
-        let binDirectory = "/usr/local/bin"
 
         // Create the installation script
         let script = """

--- a/mac/VibeTunnel/Utilities/CLIInstaller.swift
+++ b/mac/VibeTunnel/Utilities/CLIInstaller.swift
@@ -48,7 +48,7 @@ final class CLIInstaller {
                     // Verify it's our wrapper script with all expected components
                     isCorrectlyInstalled = content.contains("VibeTunnel CLI wrapper") &&
                         content.contains("$TRY_PATH/Contents/Resources/vibetunnel") &&
-                        content.contains("exec \"$VIBETUNNEL_BIN\" fwd \"$@\"")
+                        content.contains("exec \"$VIBETUNNEL_BIN\" fwd")
                 }
             }
 

--- a/mac/VibeTunnel/Utilities/CLIInstaller.swift
+++ b/mac/VibeTunnel/Utilities/CLIInstaller.swift
@@ -30,7 +30,7 @@ final class CLIInstaller {
     private let binDirectory: String
 
     private var vtTargetPath: String {
-        return URL(fileURLWithPath: binDirectory).appendingPathComponent("vt").path
+        URL(fileURLWithPath: binDirectory).appendingPathComponent("vt").path
     }
 
     var isInstalled = false

--- a/mac/VibeTunnelTests/CLIInstallerTests.swift
+++ b/mac/VibeTunnelTests/CLIInstallerTests.swift
@@ -441,6 +441,9 @@ struct CLIInstallerTests {
         let installer = CLIInstaller(binDirectory: tempDirectory.path)
         installer.checkInstallationStatus()
 
-        #expect(installer.isInstalled == true)
+        // Wait for the async Task in checkInstallationStatus to complete
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(installer.isInstalled)
     }
 }

--- a/mac/VibeTunnelTests/CLIInstallerTests.swift
+++ b/mac/VibeTunnelTests/CLIInstallerTests.swift
@@ -421,11 +421,6 @@ struct CLIInstallerTests {
 
     @Test("Script with TITLE_MODE_ARGS detected correctly", .tags(.regression))
     func scriptWithTitleModeArgsDetection() async throws {
-        let tempDir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("VibeTunnelTest-\(UUID().uuidString)")
-        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tempDir) }
-
         let script = """
         #!/bin/bash
         # VibeTunnel CLI wrapper
@@ -440,10 +435,10 @@ struct CLIInstallerTests {
         exec "$VIBETUNNEL_BIN" fwd $TITLE_MODE_ARGS "$@"
         """
 
-        try script.write(toFile: tempDir.appendingPathComponent("vt").path,
-                         atomically: true, encoding: .utf8)
+        let vtPath = tempDirectory.appendingPathComponent("vt").path
+        try script.write(toFile: vtPath, atomically: true, encoding: .utf8)
 
-        let installer = CLIInstaller(binDirectory: tempDir.path)
+        let installer = CLIInstaller(binDirectory: tempDirectory.path)
         installer.checkInstallationStatus()
 
         #expect(installer.isInstalled == true)


### PR DESCRIPTION
## Summary
- Fixed CLI installation verification to handle the updated vt script format
- The verification now checks for `exec "$VIBETUNNEL_BIN" fwd` without requiring exact argument matching

## Problem
After tapping 'OK' on the "CLI Tools Installed Successfully" popup, the AdvancedSettingsView incorrectly showed the CLI tool as not installed, even though the installation was successful.

## Root Cause
The `checkInstallationStatus()` method was checking for an exact string match:
```swift
content.contains("exec \"$VIBETUNNEL_BIN\" fwd \"$@\"")
```

However, the vt script was updated to include `$TITLE_MODE_ARGS`:
```bash
exec "$VIBETUNNEL_BIN" fwd $TITLE_MODE_ARGS "$@"
```

This mismatch caused the verification to fail.

## Solution
Updated the verification to check only for the presence of `exec "$VIBETUNNEL_BIN" fwd`, making it compatible with any argument variations in the vt script.

Fixes #152