### PR TITLE
docs: add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,14 @@ Ever wanted to check on your AI agents while you're away? Need to monitor that l
 
 ### 1. Download & Install
 
+#### Option 1: Direct Download
 [Download VibeTunnel](https://github.com/amantus-ai/vibetunnel/releases/latest) and drag it to your Applications folder.
+
+#### Option 2: Homebrew
+```bash
+# Install the beta version
+brew install --cask vibetunnel@beta
+```
 
 ### 2. Launch VibeTunnel
 


### PR DESCRIPTION
## Summary
Add installation option via Homebrew cask for users who prefer package managers.

## Details
- Added Homebrew as an alternative installation method in the README
- The beta version is now available through homebrew-cask as `vibetunnel@beta`
- Users can install with: `brew install --cask vibetunnel@beta`

## Related
- Closes #9
- Homebrew cask PR: https://github.com/Homebrew/homebrew-cask/pull/217402