### PR TITLE
feat: add automatic migration from com.amantus to sh.vibetunnel

### DIFF
--- a/mac/VibeTunnel/Core/Services/PreferenceMigrationService.swift
+++ b/mac/VibeTunnel/Core/Services/PreferenceMigrationService.swift
@@ -1,0 +1,91 @@
+import Foundation
+import os.log
+
+/// Service responsible for migrating preferences and cleaning up old com.amantus files
+final class PreferenceMigrationService {
+    private let logger = Logger(subsystem: "sh.vibetunnel", category: "PreferenceMigration")
+    
+    private let oldBundleIdentifier = "com.amantus.vibetunnel"
+    private let currentBundleIdentifier = Bundle.main.bundleIdentifier ?? "sh.vibetunnel.vibetunnel"
+    
+    /// Performs one-time migration from old bundle identifier to new one
+    func performMigrationIfNeeded() {
+        // Check if migration has already been performed
+        let migrationKey = "hasPerformedComAmantusMigration"
+        guard !UserDefaults.standard.bool(forKey: migrationKey) else {
+            logger.debug("Migration already performed, skipping")
+            return
+        }
+        
+        logger.info("Starting preference migration from \(self.oldBundleIdentifier) to \(self.currentBundleIdentifier)")
+        
+        // Migrate preferences
+        migratePreferences()
+        
+        // Clean up old files
+        cleanupOldFiles()
+        
+        // Mark migration as complete
+        UserDefaults.standard.set(true, forKey: migrationKey)
+        logger.info("Migration completed successfully")
+    }
+    
+    private func migratePreferences() {
+        // Get old preferences
+        guard let oldDefaults = UserDefaults(suiteName: oldBundleIdentifier) else {
+            logger.debug("No old preferences found to migrate")
+            return
+        }
+        
+        let currentDefaults = UserDefaults.standard
+        var migratedCount = 0
+        
+        // Get all keys from old preferences
+        if let oldPrefs = oldDefaults.dictionaryRepresentation() as? [String: Any] {
+            for (key, value) in oldPrefs {
+                // Skip system keys
+                if key.hasPrefix("NS") || key.hasPrefix("Apple") {
+                    continue
+                }
+                
+                // Only migrate if the key doesn't already exist in new preferences
+                if currentDefaults.object(forKey: key) == nil {
+                    currentDefaults.set(value, forKey: key)
+                    migratedCount += 1
+                    logger.debug("Migrated preference: \(key)")
+                }
+            }
+        }
+        
+        if migratedCount > 0 {
+            currentDefaults.synchronize()
+            logger.info("Migrated \(migratedCount) preferences")
+        } else {
+            logger.debug("No preferences needed migration")
+        }
+    }
+    
+    private func cleanupOldFiles() {
+        let fileManager = FileManager.default
+        let libraryURL = fileManager.urls(for: .libraryDirectory, in: .userDomainMask).first!
+        
+        // Define paths to clean up
+        let pathsToClean = [
+            libraryURL.appendingPathComponent("Preferences/\(oldBundleIdentifier).plist"),
+            libraryURL.appendingPathComponent("Caches/\(oldBundleIdentifier)"),
+            libraryURL.appendingPathComponent("Saved Application State/\(oldBundleIdentifier).savedState"),
+            libraryURL.appendingPathComponent("Application Support/\(oldBundleIdentifier)")
+        ]
+        
+        for path in pathsToClean {
+            if fileManager.fileExists(atPath: path.path) {
+                do {
+                    try fileManager.removeItem(at: path)
+                    logger.info("Removed old file/directory: \(path.lastPathComponent)")
+                } catch {
+                    logger.error("Failed to remove \(path.path): \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+}

--- a/mac/VibeTunnel/VibeTunnelApp.swift
+++ b/mac/VibeTunnel/VibeTunnelApp.swift
@@ -132,6 +132,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, @preconcurrency UNUser
                 .contains("libMainThreadChecker.dylib") ?? false ||
                 processInfo.environment["__XCODE_BUILT_PRODUCTS_DIR_PATHS"] != nil
         #endif
+        
+        // Perform preference migration as early as possible
+        if !isRunningInTests && !isRunningInPreview {
+            let migrationService = PreferenceMigrationService()
+            migrationService.performMigrationIfNeeded()
+        }
 
         // Handle single instance check before doing anything else
         #if DEBUG

--- a/web/.husky/pre-commit
+++ b/web/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm test


### PR DESCRIPTION
## Summary
- Adds automatic preference migration from old bundle identifier `com.amantus.vibetunnel` to new `sh.vibetunnel.vibetunnel`
- Cleans up old files left behind by previous installations
- This migration is only relevant for users upgrading from very old versions of VibeTunnel

## Context
The bundle identifier was changed from `com.amantus.vibetunnel` to `sh.vibetunnel.vibetunnel` some time ago. This migration service is specifically for users who:
- Are still running an old version with the `com.amantus` bundle ID
- Are upgrading directly to the latest version
- May have preferences and cached data under the old bundle ID that should be preserved

For most users who have been keeping up with updates, this migration will detect that there's nothing to migrate and skip the process entirely.

## Changes
- Created `PreferenceMigrationService` that handles one-time migration on app startup
- Migrates all user preferences from old bundle ID to new one (preserving existing settings)
- Removes old files and directories:
  - `~/Library/Preferences/com.amantus.vibetunnel.plist`
  - `~/Library/Caches/com.amantus.vibetunnel/`
  - `~/Library/Saved Application State/com.amantus.vibetunnel.savedState/`
  - `~/Library/Application Support/com.amantus.vibetunnel/`
- Integration happens early in app launch, before any other services start

## Note
The `web/.husky/pre-commit` file was accidentally included in this commit. It's from a previous PR that added git hooks for code quality and runs `pnpm test` before commits.

## Test plan
- [ ] Build and run the app
- [ ] Check that old com.amantus files are removed from Library directories (if they exist)
- [ ] Verify existing preferences are preserved
- [ ] Confirm migration only runs once (subsequent launches skip it)
- [ ] Verify that for users without old preferences, the migration is skipped entirely