### PR TITLE
Add Apple Silicon Homebrew path check for VT tool

### DIFF
--- a/mac/VibeTunnel/Utilities/CLIInstaller.swift
+++ b/mac/VibeTunnel/Utilities/CLIInstaller.swift
@@ -54,13 +54,25 @@ final class CLIInstaller {
             // Check if vt script exists and is configured correctly
             var isCorrectlyInstalled = false
 
-            if FileManager.default.fileExists(atPath: vtTargetPath) {
-                // Check if it contains the correct app path reference
-                if let content = try? String(contentsOfFile: vtTargetPath, encoding: .utf8) {
-                    // Verify it's our wrapper script with all expected components
-                    isCorrectlyInstalled = content.contains("VibeTunnel CLI wrapper") &&
-                        content.contains("$TRY_PATH/Contents/Resources/vibetunnel") &&
-                        content.contains("exec \"$VIBETUNNEL_BIN\" fwd")
+            // Check both /usr/local/bin and Apple Silicon Homebrew path
+            let pathsToCheck = [
+                vtTargetPath,
+                "/opt/homebrew/bin/vt"
+            ]
+            
+            for path in pathsToCheck {
+                if FileManager.default.fileExists(atPath: path) {
+                    // Check if it contains the correct app path reference
+                    if let content = try? String(contentsOfFile: path, encoding: .utf8) {
+                        // Verify it's our wrapper script with all expected components
+                        if content.contains("VibeTunnel CLI wrapper") &&
+                           content.contains("$TRY_PATH/Contents/Resources/vibetunnel") &&
+                           content.contains("exec \"$VIBETUNNEL_BIN\" fwd") {
+                            isCorrectlyInstalled = true
+                            logger.info("CLIInstaller: Found valid vt script at \(path)")
+                            break
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
I installed vibetunnel via homebrew casks and noticed that the button for installing the vt cli was clickable, even though I was already able to run 'vt' in the terminal.

## Summary
- Adds support for detecting VT tool installations in Apple Silicon Homebrew location
- Checks both `/usr/local/bin/vt` and `/opt/homebrew/bin/vt` paths
- Improves user experience for M1/M2 Mac users who installed VT via Homebrew

## Changes
Updated `CLIInstaller.checkInstallationStatus()` to check multiple paths:
- `/usr/local/bin/vt` (default location, Intel Macs)  
- `/opt/homebrew/bin/vt` (Apple Silicon Homebrew location)

This ensures users who have installed the VT command via Homebrew on Apple Silicon Macs will see it as already installed in the welcome flow, avoiding unnecessary reinstallation prompts.

## Test plan
- [ ] Test default install with VT in `/usr/local/bin`
- [ ] Test on Apple Silicon Mac with VT installed via brew cask, in `/opt/homebrew/bin`
- [ ] Verify welcome flow correctly detects existing installations
- [ ] Confirm installation still works when VT is not found

🤖 Generated with [Claude Code](https://claude.ai/code)