### PR TITLE
fix: Configure iOS team ID via xcconfig to prevent project file conflicts

### DIFF
--- a/ios/VibeTunnel-iOS.xcodeproj/project.pbxproj
+++ b/ios/VibeTunnel-iOS.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		78868B612DFF808300B22C15 /* Exceptions for "VibeTunnel" folder in "VibeTunnel" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Local.xcconfig,
 				Resources/Info.plist,
 				Shared.xcconfig,
 				version.xcconfig,


### PR DESCRIPTION
## Summary

Fixes team ID configuration issues that were causing  changes every time developers opened Xcode.

## Changes

- **Removed hardcoded ** from  (2 locations)
- **Fixed xcconfig inheritance order** in  to properly handle overrides
- **Set proper fallback** to CI team ID () when  doesn't exist
- **Maintained git-ignored ** for individual developer team IDs

## Benefits

- ✅ **No more project file conflicts** when switching between developers
- ✅ **No more "Unknown Name" warnings** in Xcode
- ✅ **Each developer uses their own team ID** via 
- ✅ **CI continues to work** with fallback team ID
- ✅ **Standard iOS team workflow** used by professional teams

## How it works

1. **Local development**: Uses team ID from  (git-ignored)
2. **CI/Default**: Uses fallback team ID  from 
3. **No project file changes**: Team ID comes from xcconfig, not project settings

## Test plan

- [x] Verified team ID inheritance works correctly
- [x] Tested with and without  file
- [x] Confirmed no  changes when switching team IDs
- [x] Build settings show correct team ID in both scenarios