### PR TITLE
Fix title injection race conditions

### DIFF
--- a/web/src/server/pty/types.ts
+++ b/web/src/server/pty/types.ts
@@ -97,6 +97,7 @@ export interface PtySession {
   lastWriteTimestamp?: number;
   titleInjectionTimer?: NodeJS.Timeout;
   pendingTitleToInject?: string;
+  titleInjectionInProgress?: boolean;
 }
 
 export class PtyError extends Error {


### PR DESCRIPTION
## Summary

This PR fixes two critical race conditions in the terminal title injection logic:

1. **Lost title updates**: Titles were being lost when `pendingTitleToInject` was cleared before the async write operation executed
2. **Quiet period violations**: The injection timer was cleared before `lastWriteTimestamp` was updated, allowing new injections to start too soon

## Changes

- Added `titleInjectionInProgress` flag to prevent concurrent injections
- Update `lastWriteTimestamp` immediately before enqueueing (not in async callback) to prevent quiet period violations  
- Clear `pendingTitleToInject` only after successful write completion
- Compare titles before clearing to avoid losing newer updates during the write
- Stop injection timer only when no pending titles remain
- Use try-finally to ensure in-progress flag is always cleared

## Technical Details

The race conditions occurred because:
- The title value was set to `undefined` synchronously while the write happened asynchronously
- The timestamp was updated inside the async callback, creating a window where new injections could start

The fix ensures:
- Title values are captured before any state changes
- Timestamps are updated synchronously to maintain quiet period guarantees
- State cleanup happens only after operations complete
- Concurrent injections are prevented with explicit tracking

## Testing

The changes maintain all existing functionality while preventing the race conditions. The quiet period (50ms) is now properly enforced, and rapid title updates no longer result in lost titles.