### PR TITLE
Add vibetunnel binary path and version info to vt help

### DIFF
--- a/mac/VibeTunnel/vt
+++ b/mac/VibeTunnel/vt
@@ -118,6 +118,29 @@ NOTE:
     This script automatically uses the vibetunnel executable bundled with
     VibeTunnel from the app bundle.
 EOF
+    
+    # Show path and version info
+    echo
+    echo "VIBETUNNEL BINARY:"
+    echo "    Path: $VIBETUNNEL_BIN"
+    if [ -f "$VIBETUNNEL_BIN" ]; then
+        # Extract version from the vibetunnel output
+        VERSION_INFO=$("$VIBETUNNEL_BIN" --version 2>&1 | grep "^VibeTunnel Server" | head -n 1)
+        BUILD_INFO=$("$VIBETUNNEL_BIN" --version 2>&1 | grep "^Built:" | head -n 1)
+        PLATFORM_INFO=$("$VIBETUNNEL_BIN" --version 2>&1 | grep "^Platform:" | head -n 1)
+        
+        if [ -n "$VERSION_INFO" ]; then
+            echo "    Version: ${VERSION_INFO#VibeTunnel Server }"
+        fi
+        if [ -n "$BUILD_INFO" ]; then
+            echo "    ${BUILD_INFO}"
+        fi
+        if [ -n "$PLATFORM_INFO" ]; then
+            echo "    ${PLATFORM_INFO}"
+        fi
+    else
+        echo "    Status: Not found"
+    fi
 }
 
 # Function to resolve command through user's shell


### PR DESCRIPTION
## Summary

This PR enhances the `vt` script to display the path and version information of the vibetunnel binary at the bottom of the help menu.

## Changes

- Added a new section at the bottom of the help output showing:
  - Full path to the vibetunnel binary being used
  - Version number (e.g., v1.0.0-beta.6)
  - Build date and time
  - Platform information (e.g., darwin/arm64)
- Enhanced the app discovery logic to include project build directories for development scenarios

## Example Output

```
VIBETUNNEL BINARY:
    Path: /Users/steipete/Projects/vibetunnel/mac/build/Build/Products/Debug/VibeTunnel.app/Contents/Resources/vibetunnel
    Version: v1.0.0-beta.6
    Built: 2025-07-02T07:08:11+01:00
    Platform: darwin/arm64
```

## Benefits

- Users can easily verify which VibeTunnel binary is being used
- Helpful for debugging version-related issues
- Developers can quickly check build information
- Makes it clear when using development vs. production builds