### PR TITLE
fix: prevent keyboard capture when overlays are active

### DIFF
--- a/web/src/client/components/session-view/lifecycle-event-manager.ts
+++ b/web/src/client/components/session-view/lifecycle-event-manager.ts
@@ -72,6 +72,12 @@ export class LifecycleEventManager extends ManagerEventEmitter {
   keyboardHandler = (e: KeyboardEvent): void => {
     if (!this.callbacks) return;
 
+    // Check if focus management is disabled (e.g., when overlays/modals are active)
+    if (this.callbacks.getDisableFocusManagement()) {
+      // Don't capture keyboard input when overlays are active
+      return;
+    }
+
     // Handle Cmd+O / Ctrl+O to open file browser
     if ((e.metaKey || e.ctrlKey) && e.key === 'o') {
       e.preventDefault();


### PR DESCRIPTION
- Add focus management check in lifecycle keyboard handler
- Skip keyboard capture when overlays/modals are displayed
- Prevents keyboard conflicts with form inputs in overlays