### PR TITLE
fix: implement socket status broadcasting to all connected clients

### DIFF
--- a/web/src/server/pty/types.ts
+++ b/web/src/server/pty/types.ts
@@ -4,6 +4,7 @@
  * These types match the tty-fwd format to ensure compatibility
  */
 
+import type * as fs from 'fs';
 import type * as net from 'net';
 import type { IPty } from 'node-pty';
 import type { SessionInfo, TitleMode } from '../../shared/types.js';
@@ -95,6 +96,17 @@ export interface PtySession {
   titleInjectionTimer?: NodeJS.Timeout;
   pendingTitleToInject?: string;
   titleInjectionInProgress?: boolean;
+  // File watcher for session.json changes
+  sessionJsonWatcher?: fs.FSWatcher;
+  // Activity status for external tracking
+  activityStatus?: {
+    specificStatus?: {
+      app: string;
+      status: string;
+    };
+  };
+  // Connected socket clients for broadcasting
+  connectedClients?: Set<net.Socket>;
 }
 
 export class PtyError extends Error {


### PR DESCRIPTION
## Summary
- Fixes failing test "should broadcast status to other clients" 
- Implements proper broadcasting of STATUS_UPDATE messages to all connected socket clients
- Adds cleanup for socket connections when sessions are terminated

## Changes
1. **Added `connectedClients` field to PtySession interface** - Tracks all connected socket clients for each session
2. **Implemented client tracking** - Add/remove clients from the set as they connect/disconnect
3. **Added STATUS_UPDATE broadcasting** - When a client sends a status update, broadcast it to all other connected clients
4. **Added proper cleanup** - Ensure all socket connections are closed when a session is cleaned up
5. **Updated listSessions** - Check socket-based status updates first before falling back to activity detector

## Test Results
The previously failing test now passes:
```
✓ Socket Protocol Integration > Claude status tracking > should broadcast status to other clients  992ms
```

All socket protocol integration tests are passing.