### PR TITLE
Add magic wand button to JavaScript frontend

### DIFF
--- a/mac/VibeTunnel/Presentation/Components/Menu/SessionRow.swift
+++ b/mac/VibeTunnel/Presentation/Components/Menu/SessionRow.swift
@@ -101,23 +101,27 @@ struct SessionRow: View {
 
                         // Edit button (pencil icon) - only show on hover
                         if isHovered && !isEditing {
-                            Button(action: startEditing) {
-                                Image(systemName: "square.and.pencil")
-                                    .font(.system(size: 11))
-                                    .foregroundColor(.primary)
-                            }
-                            .buttonStyle(.plain)
-                            .help("Rename session")
-
-                            // Magic wand button for AI assistant sessions
-                            if isAIAssistantSession {
-                                Button(action: sendAIPrompt) {
-                                    Image(systemName: "wand.and.rays")
+                            HStack(spacing: 6) {
+                                Button(action: startEditing) {
+                                    Image(systemName: "square.and.pencil")
                                         .font(.system(size: 11))
                                         .foregroundColor(.primary)
                                 }
                                 .buttonStyle(.plain)
-                                .help("Send prompt to update terminal title")
+                                .help("Rename session")
+                                .modifier(HoverOpacityModifier())
+
+                                // Magic wand button for AI assistant sessions
+                                if isAIAssistantSession {
+                                    Button(action: sendAIPrompt) {
+                                        Image(systemName: "wand.and.rays")
+                                            .font(.system(size: 11))
+                                            .foregroundColor(.primary)
+                                    }
+                                    .buttonStyle(.plain)
+                                    .help("Send prompt to update terminal title")
+                                    .modifier(HoverOpacityModifier())
+                                }
                             }
                         }
                     }
@@ -523,5 +527,20 @@ struct SessionRow: View {
             let days = Int(elapsed / 86_400)
             return "\(days)d"
         }
+    }
+}
+
+/// Modifier that makes an element fully opaque on hover
+struct HoverOpacityModifier: ViewModifier {
+    @State private var isHovering = false
+    
+    func body(content: Content) -> some View {
+        content
+            .opacity(isHovering ? 1.0 : 0.5)
+            .scaleEffect(isHovering ? 1.0 : 0.95)
+            .animation(.easeInOut(duration: 0.15), value: isHovering)
+            .onHover { hovering in
+                isHovering = hovering
+            }
     }
 }

--- a/mac/VibeTunnel/Presentation/Components/Menu/SessionRow.swift
+++ b/mac/VibeTunnel/Presentation/Components/Menu/SessionRow.swift
@@ -392,12 +392,15 @@ struct SessionRow: View {
 
     private var isAIAssistantSession: Bool {
         // Check if this is an AI assistant session by looking at the command
+        let aiAssistants = ["claude", "gemini", "openhands", "aider", "codex"]
         let cmd = commandName.lowercased()
-        return cmd == "claude" || cmd.contains("claude") ||
-               cmd == "gemini" || cmd.contains("gemini") ||
-               cmd == "openhands" || cmd.contains("openhands") ||
-               cmd == "aider" || cmd.contains("aider") ||
-               cmd == "codex" || cmd.contains("codex")
+        
+        // Match exact executable names or at word boundaries
+        return aiAssistants.contains { ai in
+            cmd == ai ||
+            cmd.hasPrefix(ai + ".") || // e.g., claude.exe
+            cmd.hasPrefix(ai + "-wrapper") // e.g., claude-wrapper
+        }
     }
 
     private var sessionName: String {

--- a/web/src/client/components/magic-wand-button.ts
+++ b/web/src/client/components/magic-wand-button.ts
@@ -1,0 +1,132 @@
+/**
+ * Magic Wand Button Component
+ *
+ * Reusable button for sending prompts to AI assistant sessions
+ * to encourage them to update their terminal titles.
+ */
+import { html, LitElement } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import type { AuthClient } from '../services/auth-client.js';
+import { sendAIPrompt } from '../utils/ai-sessions.js';
+import { createLogger } from '../utils/logger.js';
+
+const logger = createLogger('magic-wand-button');
+
+@customElement('magic-wand-button')
+export class MagicWandButton extends LitElement {
+  // Disable shadow DOM to use Tailwind
+  createRenderRoot() {
+    return this;
+  }
+
+  @property({ type: String }) sessionId!: string;
+  @property({ type: Object }) authClient!: AuthClient;
+  @property({ type: String }) size: 'small' | 'medium' = 'small';
+  @property({ type: Boolean }) showText = false;
+
+  @state() private sending = false;
+
+  private async handleClick(e: Event) {
+    e.stopPropagation();
+    e.preventDefault();
+
+    if (this.sending) return;
+
+    this.sending = true;
+
+    try {
+      await sendAIPrompt(this.sessionId, this.authClient);
+
+      // Dispatch success event
+      this.dispatchEvent(
+        new CustomEvent('prompt-sent', {
+          detail: { sessionId: this.sessionId },
+          bubbles: true,
+          composed: true,
+        })
+      );
+    } catch (error) {
+      logger.error('Failed to send AI prompt', error);
+
+      // Dispatch error event
+      this.dispatchEvent(
+        new CustomEvent('prompt-error', {
+          detail: {
+            sessionId: this.sessionId,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          },
+          bubbles: true,
+          composed: true,
+        })
+      );
+    } finally {
+      this.sending = false;
+    }
+  }
+
+  render() {
+    const sizeClasses = {
+      small: 'w-4 h-4',
+      medium: 'w-5 h-5',
+    };
+
+    const buttonClasses = this.size === 'small' ? 'p-1.5' : 'p-1';
+
+    return html`
+      <button
+        class="btn-ghost text-accent-primary ${buttonClasses} rounded-md transition-all hover:bg-dark-bg-elevated hover:shadow-sm hover:scale-110 disabled:opacity-50"
+        @click=${this.handleClick}
+        ?disabled=${this.sending}
+        title="Send prompt to update terminal title"
+      >
+        ${
+          this.sending
+            ? html`
+            <svg
+              class="${sizeClasses[this.size]} animate-spin"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                class="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+              ></circle>
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              ></path>
+            </svg>
+          `
+            : html`
+            <svg
+              class="${sizeClasses[this.size]}"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+              />
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M12 8l-2 2m4-2l-2 2m4 0l-2 2"
+                opacity="0.6"
+              />
+            </svg>
+          `
+        }
+        ${this.showText ? html`<span class="ml-2">Update Title</span>` : ''}
+      </button>
+    `;
+  }
+}

--- a/web/src/client/components/session-list.ts
+++ b/web/src/client/components/session-list.ts
@@ -39,6 +39,24 @@ export class SessionList extends LitElement {
     return this;
   }
 
+  // Check if session is an AI assistant based on command
+  private isAIAssistantSession(session: Session): boolean {
+    const cmd =
+      (Array.isArray(session.command) ? session.command[0] : session.command)?.toLowerCase() || '';
+    return (
+      cmd === 'claude' ||
+      cmd.includes('claude') ||
+      cmd === 'gemini' ||
+      cmd.includes('gemini') ||
+      cmd === 'openhands' ||
+      cmd.includes('openhands') ||
+      cmd === 'aider' ||
+      cmd.includes('aider') ||
+      cmd === 'codex' ||
+      cmd.includes('codex')
+    );
+  }
+
   @property({ type: Array }) sessions: Session[] = [];
   @property({ type: Boolean }) loading = false;
   @property({ type: Boolean }) hideExited = true;
@@ -147,6 +165,36 @@ export class SessionList extends LitElement {
       })
     );
   };
+
+  private async sendAIPrompt(sessionId: string) {
+    try {
+      const prompt =
+        "use vt title to update the terminal title with what you're currently working on";
+      const response = await fetch(`/api/sessions/${sessionId}/input`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...this.authClient.getAuthHeader(),
+        },
+        body: JSON.stringify({ data: prompt + '\n' }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.text();
+        logger.error('Failed to send AI prompt', { errorData, sessionId });
+        throw new Error(`Failed to send prompt: ${response.status}`);
+      }
+
+      logger.log(`AI prompt sent to session ${sessionId}`);
+    } catch (error) {
+      logger.error('Error sending AI prompt', { error, sessionId });
+      this.dispatchEvent(
+        new CustomEvent('error', {
+          detail: `Failed to send AI prompt: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        })
+      );
+    }
+  }
 
   public async handleCleanupExited() {
     if (this.cleaningExited) return;
@@ -414,60 +462,100 @@ export class SessionList extends LitElement {
                                 ${session.startedAt ? formatSessionDuration(session.startedAt) : ''}
                               </div>
                               
-                              <!-- Close button (overlaps duration on hover) -->
-                              ${
-                                session.status === 'running' || session.status === 'exited'
-                                  ? html`
-                                    <button
-                                      class="btn-ghost text-status-error p-1.5 rounded-md transition-all ${
-                                        'ontouchstart' in window
-                                          ? 'opacity-100 flex-shrink-0'
-                                          : 'opacity-0 group-hover:opacity-100 absolute right-0'
-                                      } hover:bg-dark-bg-elevated hover:shadow-sm hover:scale-110"
-                                      @click=${async (e: Event) => {
-                                        e.stopPropagation();
-                                        // Kill the session
-                                        try {
-                                          const endpoint =
-                                            session.status === 'exited'
-                                              ? `/api/sessions/${session.id}/cleanup`
-                                              : `/api/sessions/${session.id}`;
-                                          const response = await fetch(endpoint, {
-                                            method: 'DELETE',
-                                            headers: this.authClient.getAuthHeader(),
-                                          });
-                                          if (response.ok) {
-                                            this.handleSessionKilled({
-                                              detail: { sessionId: session.id },
-                                            } as CustomEvent);
-                                          }
-                                        } catch (error) {
-                                          logger.error('Failed to kill session', error);
-                                        }
-                                      }}
-                                      title="${
-                                        session.status === 'running'
-                                          ? 'Kill session'
-                                          : 'Clean up session'
-                                      }"
-                                    >
-                                      <svg
-                                        class="w-4 h-4"
-                                        fill="none"
-                                        stroke="currentColor"
-                                        viewBox="0 0 24 24"
+                              <!-- Buttons container -->
+                              <div class="flex items-center gap-1 ${
+                                'ontouchstart' in window
+                                  ? 'opacity-100'
+                                  : 'opacity-0 group-hover:opacity-100'
+                              } transition-opacity absolute right-0">
+                                <!-- Magic wand button for AI sessions -->
+                                ${
+                                  session.status === 'running' && this.isAIAssistantSession(session)
+                                    ? html`
+                                      <button
+                                        class="btn-ghost text-accent-primary p-1.5 rounded-md transition-all hover:bg-dark-bg-elevated hover:shadow-sm hover:scale-110"
+                                        @click=${async (e: Event) => {
+                                          e.stopPropagation();
+                                          await this.sendAIPrompt(session.id);
+                                        }}
+                                        title="Send prompt to update terminal title"
                                       >
-                                        <path
-                                          stroke-linecap="round"
-                                          stroke-linejoin="round"
-                                          stroke-width="2"
-                                          d="M6 18L18 6M6 6l12 12"
-                                        />
-                                      </svg>
-                                    </button>
-                                  `
-                                  : ''
-                              }
+                                        <svg
+                                          class="w-4 h-4"
+                                          fill="none"
+                                          stroke="currentColor"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            stroke-linecap="round"
+                                            stroke-linejoin="round"
+                                            stroke-width="2"
+                                            d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+                                          />
+                                          <path
+                                            stroke-linecap="round"
+                                            stroke-linejoin="round"
+                                            stroke-width="1.5"
+                                            d="M12 8l-2 2m4-2l-2 2m4 0l-2 2"
+                                            opacity="0.6"
+                                          />
+                                        </svg>
+                                      </button>
+                                    `
+                                    : ''
+                                }
+                                
+                                <!-- Close button -->
+                                ${
+                                  session.status === 'running' || session.status === 'exited'
+                                    ? html`
+                                      <button
+                                        class="btn-ghost text-status-error p-1.5 rounded-md transition-all hover:bg-dark-bg-elevated hover:shadow-sm hover:scale-110"
+                                        @click=${async (e: Event) => {
+                                          e.stopPropagation();
+                                          // Kill the session
+                                          try {
+                                            const endpoint =
+                                              session.status === 'exited'
+                                                ? `/api/sessions/${session.id}/cleanup`
+                                                : `/api/sessions/${session.id}`;
+                                            const response = await fetch(endpoint, {
+                                              method: 'DELETE',
+                                              headers: this.authClient.getAuthHeader(),
+                                            });
+                                            if (response.ok) {
+                                              this.handleSessionKilled({
+                                                detail: { sessionId: session.id },
+                                              } as CustomEvent);
+                                            }
+                                          } catch (error) {
+                                            logger.error('Failed to kill session', error);
+                                          }
+                                        }}
+                                        title="${
+                                          session.status === 'running'
+                                            ? 'Kill session'
+                                            : 'Clean up session'
+                                        }"
+                                      >
+                                        <svg
+                                          class="w-4 h-4"
+                                          fill="none"
+                                          stroke="currentColor"
+                                          viewBox="0 0 24 24"
+                                        >
+                                          <path
+                                            stroke-linecap="round"
+                                            stroke-linejoin="round"
+                                            stroke-width="2"
+                                            d="M6 18L18 6M6 6l12 12"
+                                          />
+                                        </svg>
+                                      </button>
+                                    `
+                                    : ''
+                                }
+                              </div>
                             </div>
                           </div>
                         `

--- a/web/src/client/utils/ai-sessions.ts
+++ b/web/src/client/utils/ai-sessions.ts
@@ -1,0 +1,48 @@
+import type { Session } from '../../shared/types.js';
+import type { AuthClient } from '../services/auth-client.js';
+import { createLogger } from './logger.js';
+
+const logger = createLogger('ai-sessions');
+
+const AI_ASSISTANTS = ['claude', 'gemini', 'openhands', 'aider', 'codex'];
+
+/**
+ * Check if a session is an AI assistant based on command
+ * Uses precise matching to avoid false positives
+ */
+export function isAIAssistantSession(session: Session): boolean {
+  const commands = Array.isArray(session.command) ? session.command : [session.command];
+  return commands.some((cmd) => {
+    const executableName = cmd?.split('/').pop()?.toLowerCase() || '';
+    // Match exact executable names or at word boundaries
+    return AI_ASSISTANTS.some(
+      (ai) =>
+        executableName === ai ||
+        executableName.startsWith(ai + '.') || // e.g., claude.exe
+        executableName.startsWith(ai + '-wrapper') // e.g., claude-wrapper
+    );
+  });
+}
+
+/**
+ * Send a prompt to an AI assistant session to update terminal title
+ */
+export async function sendAIPrompt(sessionId: string, authClient: AuthClient): Promise<void> {
+  const prompt = "use vt title to update the terminal title with what you're currently working on";
+  const response = await fetch(`/api/sessions/${sessionId}/input`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...authClient.getAuthHeader(),
+    },
+    body: JSON.stringify({ data: `${prompt}\n` }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.text();
+    logger.error('Failed to send AI prompt', { sessionId, status: response.status, errorData });
+    throw new Error(`Failed to send prompt: ${response.status} - ${errorData}`);
+  }
+
+  logger.log(`AI prompt sent to session ${sessionId}`);
+}


### PR DESCRIPTION
## Summary
- Brings the magic wand feature from the Mac app to the JavaScript frontend
- Adds a magic wand button that appears on hover for AI assistant sessions (Claude, Gemini, Aider, OpenHands, Codex)
- When clicked, sends a prompt to the AI to use `vt title` to update the terminal title

## Implementation Details
- Added `isAIAssistantSession()` method to detect AI sessions based on command name
- Added `sendAIPrompt()` method to send the prompt via the `/api/sessions/:id/input` endpoint
- Implemented magic wand button UI in both compact mode (sidebar) and full card view
- Button appears next to the close/kill button on hover
- Uses the same pencil/wand icon and styling as the Mac app

## Test plan
- [x] Start a Claude session: `vt claude --dangerously-allow-web-ui`
- [x] Hover over the session in the sidebar - magic wand button should appear
- [x] Click the magic wand button
- [x] Claude should receive the prompt and update the terminal title
- [x] Test with other AI assistants (Gemini, Aider, etc.)
- [x] Verify non-AI sessions don't show the magic wand button
- [x] Test in both compact mode (sidebar) and full card view