### PR TITLE
SessionCardView: Fix initial brightness making the card invisible

### DIFF
--- a/ios/VibeTunnel/Views/Sessions/SessionCardView.swift
+++ b/ios/VibeTunnel/Views/Sessions/SessionCardView.swift
@@ -15,7 +15,7 @@ struct SessionCardView: View {
     @State private var opacity: Double = 1.0
     @State private var scale: CGFloat = 1.0
     @State private var rotation: Double = 0
-    @State private var brightness: Double = 1.0
+    @State private var brightness: Double = 0
 
     @Environment(\.livePreviewSubscription) private var livePreview
 


### PR DESCRIPTION
We can now properly see the cards in the sessions list 
![image](https://github.com/user-attachments/assets/2c289d44-f92f-4160-a5fe-206db22e283a)
