### PR TITLE
Fix magic wand prompt to enforce vt title usage

### DIFF
--- a/web/src/client/utils/ai-sessions.ts
+++ b/web/src/client/utils/ai-sessions.ts
@@ -28,7 +28,8 @@ export function isAIAssistantSession(session: Session): boolean {
  * Send a prompt to an AI assistant session to update terminal title
  */
 export async function sendAIPrompt(sessionId: string, authClient: AuthClient): Promise<void> {
-  const prompt = "use vt title to update the terminal title with what you're currently working on";
+  const prompt =
+    'IMPORTANT: You MUST use the \'vt title\' command to update the terminal title. DO NOT use terminal escape sequences. Run: vt title "Brief description of current task"';
   const response = await fetch(`/api/sessions/${sessionId}/input`, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
## Summary
- Updated the magic wand feature prompt to be more explicit and forceful
- Prevents AI assistants (especially Claude) from injecting terminal escape sequences directly
- Ensures they always use the `vt title` command as intended

## Changes
The prompt has been changed from:
> "use vt title to update the terminal title with what you're currently working on"

To:
> "IMPORTANT: You MUST use the 'vt title' command to update the terminal title. DO NOT use terminal escape sequences. Run: vt title \"Brief description of current task\""

This more emphatic wording:
- Uses strong language ("IMPORTANT", "MUST")
- Explicitly forbids terminal escape sequences
- Provides the exact command format with example syntax

## Test plan
- [ ] Test the magic wand button with Claude
- [ ] Verify Claude uses `vt title` command instead of escape sequences
- [ ] Test with other AI assistants (Gemini, etc.)
- [ ] Ensure the title updates correctly

Fixes #248