### PR TITLE
Remove unnecessary iOS CI triggers on web changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,5 +67,5 @@ jobs:
       always() && 
       !contains(needs.*.result, 'failure') && 
       !contains(needs.*.result, 'cancelled') &&
-      (needs.changes.outputs.ios == 'true' || needs.changes.outputs.web == 'true' || github.event_name == 'workflow_dispatch')
+      (needs.changes.outputs.ios == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/ios.yml


### PR DESCRIPTION
## Summary
- Removed the condition that triggers iOS CI builds when web files change
- iOS app is a native client that doesn't embed web code, so it doesn't need rebuilding on web changes
- This optimization will save CI time and resources

## Details
The iOS app:
- Is a native SwiftUI client for connecting to remote VibeTunnel servers
- Uses WKWebView with xterm.js (loaded from CDN) for terminal display
- Communicates via REST API and WebSocket to the server
- Has no web build dependencies or embedded web code

Unlike the Mac app which embeds and serves the web content, the iOS app only consumes the server's API endpoints. Routine web UI changes don't affect the iOS app's functionality.

## Test plan
- [x] Verify CI config syntax is valid
- [ ] Confirm iOS CI still runs on iOS-specific changes
- [ ] Confirm iOS CI still runs on manual workflow dispatch
- [ ] Verify iOS CI doesn't run on web-only changes

🤖 Generated with [Claude Code](https://claude.ai/code)