### PR TITLE
feat: add Option/Alt keyboard shortcuts for word navigation and deletion

### DIFF
--- a/web/src/client/components/session-view/input-manager.test.ts
+++ b/web/src/client/components/session-view/input-manager.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Session } from '../session-list.js';
+import { InputManager } from './input-manager.js';
+
+// Mock fetch globally
+global.fetch = vi.fn();
+
+describe('InputManager', () => {
+  let inputManager: InputManager;
+  let mockSession: Session;
+  let mockCallbacks: { requestUpdate: vi.Mock };
+
+  beforeEach(() => {
+    inputManager = new InputManager();
+    mockSession = {
+      id: 'test-session-id',
+      name: 'Test Session',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      lastActivity: new Date().toISOString(),
+      command: 'bash',
+      pid: 12345,
+    };
+
+    mockCallbacks = {
+      requestUpdate: vi.fn(),
+    };
+
+    inputManager.setSession(mockSession);
+    inputManager.setCallbacks(mockCallbacks);
+
+    // Reset fetch mock
+    vi.mocked(global.fetch).mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Option/Alt + Arrow key navigation', () => {
+    it('should send Escape+b for Alt+Left arrow', async () => {
+      const mockResponse = { ok: true, json: vi.fn().mockResolvedValue({}) };
+      vi.mocked(global.fetch).mockResolvedValueOnce(mockResponse as Response);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'ArrowLeft',
+        altKey: true,
+      });
+
+      await inputManager.handleKeyboardInput(event);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/sessions/test-session-id/input',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({ text: '\x1bb' }),
+        })
+      );
+    });
+
+    it('should send Escape+f for Alt+Right arrow', async () => {
+      const mockResponse = { ok: true, json: vi.fn().mockResolvedValue({}) };
+      vi.mocked(global.fetch).mockResolvedValueOnce(mockResponse as Response);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'ArrowRight',
+        altKey: true,
+      });
+
+      await inputManager.handleKeyboardInput(event);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/sessions/test-session-id/input',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({ text: '\x1bf' }),
+        })
+      );
+    });
+
+    it('should send regular arrow keys without Alt modifier', async () => {
+      const mockResponse = { ok: true, json: vi.fn().mockResolvedValue({}) };
+      vi.mocked(global.fetch).mockResolvedValueOnce(mockResponse as Response);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'ArrowLeft',
+        altKey: false,
+      });
+
+      await inputManager.handleKeyboardInput(event);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/sessions/test-session-id/input',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({ key: 'arrow_left' }),
+        })
+      );
+    });
+
+    it('should work with metaKey (Cmd on macOS) as well', async () => {
+      const mockResponse = { ok: true, json: vi.fn().mockResolvedValue({}) };
+      vi.mocked(global.fetch).mockResolvedValueOnce(mockResponse as Response);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'ArrowRight',
+        metaKey: true,
+      });
+
+      await inputManager.handleKeyboardInput(event);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/sessions/test-session-id/input',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({ text: '\x1bf' }),
+        })
+      );
+    });
+  });
+
+  describe('Option/Alt + Backspace/Delete word deletion', () => {
+    it('should send Ctrl+W for Alt+Backspace', async () => {
+      const mockResponse = { ok: true, json: vi.fn().mockResolvedValue({}) };
+      vi.mocked(global.fetch).mockResolvedValueOnce(mockResponse as Response);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'Backspace',
+        altKey: true,
+      });
+
+      await inputManager.handleKeyboardInput(event);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/sessions/test-session-id/input',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({ text: '\x17' }),
+        })
+      );
+    });
+
+    it('should send Escape+d for Alt+Delete', async () => {
+      const mockResponse = { ok: true, json: vi.fn().mockResolvedValue({}) };
+      vi.mocked(global.fetch).mockResolvedValueOnce(mockResponse as Response);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'Delete',
+        altKey: true,
+      });
+
+      await inputManager.handleKeyboardInput(event);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/sessions/test-session-id/input',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({ text: '\x1bd' }),
+        })
+      );
+    });
+
+    it('should send regular Backspace without Alt modifier', async () => {
+      const mockResponse = { ok: true, json: vi.fn().mockResolvedValue({}) };
+      vi.mocked(global.fetch).mockResolvedValueOnce(mockResponse as Response);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'Backspace',
+        altKey: false,
+      });
+
+      await inputManager.handleKeyboardInput(event);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/sessions/test-session-id/input',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({ key: 'backspace' }),
+        })
+      );
+    });
+
+    it('should send regular Delete without Alt modifier', async () => {
+      const mockResponse = { ok: true, json: vi.fn().mockResolvedValue({}) };
+      vi.mocked(global.fetch).mockResolvedValueOnce(mockResponse as Response);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'Delete',
+        altKey: false,
+      });
+
+      await inputManager.handleKeyboardInput(event);
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/sessions/test-session-id/input',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            'Content-Type': 'application/json',
+          }),
+          body: JSON.stringify({ key: 'delete' }),
+        })
+      );
+    });
+  });
+
+  describe('Cross-platform consistency', () => {
+    it('should handle both altKey and metaKey consistently', async () => {
+      const mockResponse = { ok: true, json: vi.fn().mockResolvedValue({}) };
+
+      // Test Alt+Left
+      vi.mocked(global.fetch).mockResolvedValueOnce(mockResponse as Response);
+      await inputManager.handleKeyboardInput(
+        new KeyboardEvent('keydown', { key: 'ArrowLeft', altKey: true })
+      );
+
+      // Test Meta+Left (Cmd on macOS)
+      vi.mocked(global.fetch).mockResolvedValueOnce(mockResponse as Response);
+      await inputManager.handleKeyboardInput(
+        new KeyboardEvent('keydown', { key: 'ArrowLeft', metaKey: true })
+      );
+
+      // Both should send the same escape sequence
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        1,
+        expect.any(String),
+        expect.objectContaining({
+          body: JSON.stringify({ text: '\x1bb' }),
+        })
+      );
+      expect(global.fetch).toHaveBeenNthCalledWith(
+        2,
+        expect.any(String),
+        expect.objectContaining({
+          body: JSON.stringify({ text: '\x1bb' }),
+        })
+      );
+    });
+
+    it('should not interfere with standard copy/paste shortcuts', async () => {
+      const _mockResponse = { ok: true, json: vi.fn().mockResolvedValue({}) };
+
+      // Mock navigator.platform for macOS
+      Object.defineProperty(navigator, 'platform', {
+        value: 'MacIntel',
+        configurable: true,
+      });
+
+      // Test Cmd+C on macOS (should not send anything)
+      const copyEvent = new KeyboardEvent('keydown', {
+        key: 'c',
+        metaKey: true,
+      });
+      await inputManager.handleKeyboardInput(copyEvent);
+
+      // Test Cmd+V on macOS (should not send anything)
+      const pasteEvent = new KeyboardEvent('keydown', {
+        key: 'v',
+        metaKey: true,
+      });
+      await inputManager.handleKeyboardInput(pasteEvent);
+
+      // Should not have called fetch for copy/paste
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Session state handling', () => {
+    it('should not send input to exited sessions', async () => {
+      mockSession.status = 'exited';
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'ArrowLeft',
+        altKey: true,
+      });
+
+      await inputManager.handleKeyboardInput(event);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should update session status when receiving 400 response', async () => {
+      const mockResponse = {
+        ok: false,
+        status: 400,
+        json: vi.fn().mockResolvedValue({}),
+      };
+      vi.mocked(global.fetch).mockResolvedValueOnce(mockResponse as Response);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'a',
+      });
+
+      await inputManager.handleKeyboardInput(event);
+
+      expect(mockSession.status).toBe('exited');
+      expect(mockCallbacks.requestUpdate).toHaveBeenCalled();
+    });
+  });
+});

--- a/web/src/client/components/session-view/input-manager.ts
+++ b/web/src/client/components/session-view/input-manager.ts
@@ -100,19 +100,39 @@ export class InputManager {
         inputText = 'arrow_down';
         break;
       case 'ArrowLeft':
-        inputText = 'arrow_left';
+        if (e.altKey || e.metaKey) {
+          // Alt/Option + Left: Move word left (Escape + b in terminal)
+          inputText = '\x1bb';
+        } else {
+          inputText = 'arrow_left';
+        }
         break;
       case 'ArrowRight':
-        inputText = 'arrow_right';
+        if (e.altKey || e.metaKey) {
+          // Alt/Option + Right: Move word right (Escape + f in terminal)
+          inputText = '\x1bf';
+        } else {
+          inputText = 'arrow_right';
+        }
         break;
       case 'Tab':
         inputText = e.shiftKey ? 'shift_tab' : 'tab';
         break;
       case 'Backspace':
-        inputText = 'backspace';
+        if (e.altKey || e.metaKey) {
+          // Alt/Option + Backspace: Delete word backward (Ctrl+W in terminal)
+          inputText = '\x17';
+        } else {
+          inputText = 'backspace';
+        }
         break;
       case 'Delete':
-        inputText = 'delete';
+        if (e.altKey || e.metaKey) {
+          // Alt/Option + Delete: Delete word forward (Escape + d in terminal)
+          inputText = '\x1bd';
+        } else {
+          inputText = 'delete';
+        }
         break;
       case ' ':
         inputText = ' ';

--- a/web/src/client/components/session-view/lifecycle-event-manager.test.ts
+++ b/web/src/client/components/session-view/lifecycle-event-manager.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { LifecycleEventManager } from './lifecycle-event-manager.js';
+
+describe('LifecycleEventManager', () => {
+  let manager: LifecycleEventManager;
+
+  beforeEach(() => {
+    manager = new LifecycleEventManager();
+  });
+
+  describe('preventAndStopEvent helper', () => {
+    it('should call preventDefault and stopPropagation on events', () => {
+      const mockEvent = {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+      } as unknown as Event;
+
+      // Access private method through type assertion for testing
+      (manager as unknown as { preventAndStopEvent(e: Event): void }).preventAndStopEvent(
+        mockEvent
+      );
+
+      expect(mockEvent.preventDefault).toHaveBeenCalledOnce();
+      expect(mockEvent.stopPropagation).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('keyboard event handling', () => {
+    it('should use preventAndStopEvent helper for keyboard shortcuts', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        setShowFileBrowser: vi.fn(),
+        getInputManager: vi.fn().mockReturnValue({
+          isKeyboardShortcut: vi.fn().mockReturnValue(false),
+        }),
+        handleKeyboardInput: vi.fn(),
+        getIsMobile: vi.fn().mockReturnValue(false),
+      };
+
+      const mockSession = {
+        id: 'test-session',
+        status: 'running',
+      };
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+      manager.setSession(mockSession as Parameters<typeof manager.setSession>[0]);
+
+      const preventAndStopEventSpy = vi.spyOn(
+        manager as unknown as { preventAndStopEvent(e: Event): void },
+        'preventAndStopEvent'
+      );
+
+      // Test Cmd+O shortcut
+      const cmdOEvent = new KeyboardEvent('keydown', {
+        key: 'o',
+        metaKey: true,
+      });
+
+      manager.keyboardHandler(cmdOEvent);
+
+      expect(preventAndStopEventSpy).toHaveBeenCalledWith(cmdOEvent);
+      expect(mockCallbacks.setShowFileBrowser).toHaveBeenCalledWith(true);
+
+      // Test regular key handling
+      const regularKeyEvent = new KeyboardEvent('keydown', {
+        key: 'a',
+      });
+
+      manager.keyboardHandler(regularKeyEvent);
+
+      expect(preventAndStopEventSpy).toHaveBeenCalledWith(regularKeyEvent);
+      expect(mockCallbacks.handleKeyboardInput).toHaveBeenCalledWith(regularKeyEvent);
+    });
+
+    it('should not prevent browser shortcuts', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        getInputManager: vi.fn().mockReturnValue({
+          isKeyboardShortcut: vi.fn().mockReturnValue(true), // This is a browser shortcut
+        }),
+        getIsMobile: vi.fn().mockReturnValue(false),
+      };
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+
+      const preventAndStopEventSpy = vi.spyOn(
+        manager as unknown as { preventAndStopEvent(e: Event): void },
+        'preventAndStopEvent'
+      );
+
+      // Test browser shortcut (e.g., Ctrl+C)
+      const browserShortcut = new KeyboardEvent('keydown', {
+        key: 'c',
+        ctrlKey: true,
+      });
+
+      manager.keyboardHandler(browserShortcut);
+
+      // Should not call preventAndStopEvent for browser shortcuts
+      expect(preventAndStopEventSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/web/src/client/components/session-view/lifecycle-event-manager.ts
+++ b/web/src/client/components/session-view/lifecycle-event-manager.ts
@@ -65,6 +65,14 @@ export class LifecycleEventManager extends ManagerEventEmitter {
   }
 
   /**
+   * Helper method to prevent default and stop propagation for events
+   */
+  private preventAndStopEvent(e: Event): void {
+    e.preventDefault();
+    e.stopPropagation();
+  }
+
+  /**
    * Detect touch capabilities using multiple signals
    */
   private detectTouchCapabilities() {
@@ -209,7 +217,7 @@ export class LifecycleEventManager extends ManagerEventEmitter {
 
     // Handle Cmd+O / Ctrl+O to open file browser
     if ((e.metaKey || e.ctrlKey) && e.key === 'o') {
-      e.preventDefault();
+      this.preventAndStopEvent(e);
       this.callbacks.setShowFileBrowser(true);
       return;
     }
@@ -239,8 +247,7 @@ export class LifecycleEventManager extends ManagerEventEmitter {
     }
 
     // Only prevent default for keys we're actually going to handle
-    e.preventDefault();
-    e.stopPropagation();
+    this.preventAndStopEvent(e);
 
     this.callbacks.handleKeyboardInput(e);
   };


### PR DESCRIPTION
## Summary
- Implements Option/Alt + Arrow keys for word-by-word cursor navigation
- Adds Option/Alt + Backspace/Delete for word deletion functionality
- Extracts repetitive event handling code into a reusable helper method

## Implementation Details

### Word Navigation
- **Option/Alt + Left Arrow**: Move cursor one word left (sends ESC+b to terminal)
- **Option/Alt + Right Arrow**: Move cursor one word right (sends ESC+f to terminal)

### Word Deletion
- **Option/Alt + Backspace**: Delete word backward (sends Ctrl+W to terminal)
- **Option/Alt + Delete**: Delete word forward (sends ESC+d to terminal)

### Code Quality Improvements
- Extracted `preventAndStopEvent()` helper method to reduce code duplication
- Added comprehensive unit tests for all keyboard shortcuts
- Ensures cross-platform consistency (works with both Alt and Cmd keys on macOS)

## Test Plan
- [x] Unit tests added for InputManager keyboard shortcuts
- [x] Unit tests added for LifecycleEventManager helper method
- [x] All code quality checks passing (formatting, linting, TypeScript)
- [ ] Manual testing on macOS with Option key
- [ ] Manual testing on Windows/Linux with Alt key
- [ ] Verify word navigation works in bash/zsh/fish shells

## Context
This PR addresses the cleanup suggestions from #285, implementing the requested keyboard shortcuts and improving code maintainability.

Closes #285