### PR TITLE
Remove explicit code sign identity for Debug

### DIFF
--- a/mac/VibeTunnel-Mac.xcodeproj/project.pbxproj
+++ b/mac/VibeTunnel-Mac.xcodeproj/project.pbxproj
@@ -443,7 +443,6 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = VibeTunnel/VibeTunnel.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = "$(inherited)";


### PR DESCRIPTION
You can run mac app locally without specifying code sign identity by default, with this change, no need to create `Local.xcconfig` if you don't need to build for release

![run_locally](https://github.com/user-attachments/assets/afe69707-ba94-491f-8142-186143c7109e)
![debug_default](https://github.com/user-attachments/assets/1f42d730-10dd-4309-a024-3dcb8c9ad2ea)
