### PR TITLE
Replace Microsoft node-pty with vendored fork to fix crashes

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -75,7 +75,7 @@
     "mime-types": "^3.0.1",
     "monaco-editor": "^0.52.2",
     "multer": "^2.0.1",
-    "node-pty": "github:microsoft/node-pty#v1.1.0-beta34",
+    "node-pty": "file:./vendored-pty",
     "postject": "^1.0.0-alpha.6",
     "signal-exit": "^4.1.0",
     "web-push": "^3.6.7",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^2.0.1
         version: 2.0.1
       node-pty:
-        specifier: github:microsoft/node-pty#v1.1.0-beta34
-        version: https://codeload.github.com/microsoft/node-pty/tar.gz/d738123f1faf7287513b0df8b9e327be54702e94
+        specifier: file:./vendored-pty
+        version: '@vibetunnel/vendored-pty@file:vendored-pty'
       postject:
         specifier: ^1.0.0-alpha.6
         version: 1.0.0-alpha.6
@@ -969,6 +969,9 @@ packages:
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
+  '@vibetunnel/vendored-pty@file:vendored-pty':
+    resolution: {directory: vendored-pty, type: directory}
 
   '@vitest/coverage-v8@3.2.4':
     resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
@@ -2307,10 +2310,6 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
-  node-pty@https://codeload.github.com/microsoft/node-pty/tar.gz/d738123f1faf7287513b0df8b9e327be54702e94:
-    resolution: {tarball: https://codeload.github.com/microsoft/node-pty/tar.gz/d738123f1faf7287513b0df8b9e327be54702e94}
-    version: 1.0.0
 
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
@@ -3935,6 +3934,10 @@ snapshots:
       '@types/node': 24.0.4
     optional: true
 
+  '@vibetunnel/vendored-pty@file:vendored-pty':
+    dependencies:
+      node-addon-api: 7.1.1
+
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -5394,10 +5397,6 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
-
-  node-pty@https://codeload.github.com/microsoft/node-pty/tar.gz/d738123f1faf7287513b0df8b9e327be54702e94:
-    dependencies:
-      node-addon-api: 7.1.1
 
   node-releases@2.0.19: {}
 

--- a/web/vendored-pty/.gitignore
+++ b/web/vendored-pty/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+build/
+lib/
+*.log
+.DS_Store

--- a/web/vendored-pty/README.md
+++ b/web/vendored-pty/README.md
@@ -1,0 +1,47 @@
+# Vendored PTY
+
+This is a vendored fork of [node-pty](https://github.com/microsoft/node-pty) v1.1.0-beta34 with the threading and shared pipe architecture removed.
+
+## Why?
+
+The original node-pty uses a shared pipe/socket architecture through `ConoutSocketWorker` that causes issues when used heavily:
+- All PTY instances write to the same shared pipe
+- This can overwhelm other Electron processes (like VS Code) that are also listening on the pipe
+- Heavy usage from VibeTunnel causes crashes in other applications
+
+## What's Changed?
+
+1. **Removed ConoutSocketWorker** - No more worker threads for socket management
+2. **Removed shared pipe architecture** - Each PTY instance uses direct file descriptors
+3. **Simplified Windows implementation** - Direct socket connections without intermediary workers
+4. **Kept core functionality** - The essential PTY spawn/resize/kill operations remain unchanged
+
+## Building
+
+```bash
+npm install
+npm run build
+```
+
+The native modules will be compiled during installation.
+
+## Usage
+
+The API remains compatible with node-pty:
+
+```javascript
+const pty = require('node-pty');
+const ptyProcess = pty.spawn('bash', [], {
+  name: 'xterm-color',
+  cols: 80,
+  rows: 30,
+  cwd: process.env.HOME,
+  env: process.env
+});
+
+ptyProcess.on('data', function(data) {
+  console.log(data);
+});
+
+ptyProcess.write('ls\r');
+```

--- a/web/vendored-pty/binding.gyp
+++ b/web/vendored-pty/binding.gyp
@@ -1,0 +1,63 @@
+{
+  'targets': [{
+    'target_name': 'pty',
+    'include_dirs': [
+      'src/',
+      '<!@(node -p "require(\'node-addon-api\').include")'
+    ],
+    'defines': [ 'NAPI_CPP_EXCEPTIONS' ],
+    'cflags!': [ '-fno-exceptions' ],
+    'cflags_cc!': [ '-fno-exceptions' ],
+    'xcode_settings': {
+      'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
+      'CLANG_CXX_LIBRARY': 'libc++',
+      'MACOSX_DEPLOYMENT_TARGET': '10.7',
+    },
+    'msvs_settings': {
+      'VCCLCompilerTool': { 'ExceptionHandling': 1 },
+    },
+    'conditions': [
+      ['OS=="win"', {
+        'sources': [
+          'src/win/conpty.cc',
+          'src/win/path_util.cc'
+        ],
+        'libraries': [
+          '-lkernel32.lib',
+          '-luser32.lib',
+          '-lshell32.lib',
+          '-ladvapi32.lib'
+        ],
+        'defines': [
+          '_WIN32_WINNT=0x0600',
+          'NTDDI_VERSION=0x06000000'
+        ]
+      }],
+      ['OS!="win"', {
+        'sources': [
+          'src/unix/pty.cc'
+        ],
+        'libraries': [
+          '-lutil'
+        ],
+        'conditions': [
+          ['OS=="mac"', {
+            'xcode_settings': {
+              'MACOSX_DEPLOYMENT_TARGET': '10.12'
+            }
+          }]
+        ]
+      }]
+    ]
+  }, {
+    'target_name': 'spawn-helper',
+    'type': 'executable',
+    'conditions': [
+      ['OS!="win"', {
+        'sources': [
+          'src/unix/spawn-helper.cc'
+        ],
+      }]
+    ]
+  }]
+}

--- a/web/vendored-pty/package.json
+++ b/web/vendored-pty/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@vibetunnel/vendored-pty",
+  "version": "1.0.0",
+  "description": "Minimal PTY implementation without threading - vendored from node-pty",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "scripts": {
+    "build": "tsc && node-gyp rebuild",
+    "clean": "rimraf lib build",
+    "install": "node-gyp rebuild"
+  },
+  "dependencies": {
+    "node-addon-api": "^7.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.3",
+    "node-gyp": "^11.0.0",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.8.3"
+  },
+  "gypfile": true,
+  "license": "MIT"
+}

--- a/web/vendored-pty/pnpm-lock.yaml
+++ b/web/vendored-pty/pnpm-lock.yaml
@@ -1,0 +1,786 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      node-addon-api:
+        specifier: ^7.1.0
+        version: 7.1.1
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.3
+        version: 24.0.13
+      node-gyp:
+        specifier: ^11.0.0
+        version: 11.2.0
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+
+packages:
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
+  '@npmcli/agent@3.0.0':
+    resolution: {integrity: sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@npmcli/fs@4.0.0':
+    resolution: {integrity: sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
+
+  '@types/node@24.0.13':
+    resolution: {integrity: sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==}
+
+  abbrev@3.0.1:
+    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.1.0:
+    resolution: {integrity: sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
+
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
+  brace-expansion@2.0.2:
+    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  cacache@19.0.1:
+    resolution: {integrity: sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encoding@0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
+
+  exponential-backoff@3.1.2:
+    resolution: {integrity: sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==}
+
+  fdir@6.4.6:
+    resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
+  fs-minipass@3.0.3:
+    resolution: {integrity: sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
+  ip-address@9.0.5:
+    resolution: {integrity: sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==}
+    engines: {node: '>= 12'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@3.1.1:
+    resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
+    engines: {node: '>=16'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  jsbn@1.1.0:
+    resolution: {integrity: sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  make-fetch-happen@14.0.3:
+    resolution: {integrity: sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  minimatch@9.0.5:
+    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass-collect@2.0.1:
+    resolution: {integrity: sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass-fetch@4.0.1:
+    resolution: {integrity: sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  minipass-flush@1.0.5:
+    resolution: {integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@1.0.3:
+    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.0.2:
+    resolution: {integrity: sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==}
+    engines: {node: '>= 18'}
+
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-gyp@11.2.0:
+    resolution: {integrity: sha512-T0S1zqskVUSxcsSTkAsLc7xCycrRYmtDHadDinzocrThjyQCn5kMlEBSj6H4qDbgsIOSLmmlRIeb0lZXj+UArA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  nopt@8.1.0:
+    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  p-map@7.0.3:
+    resolution: {integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==}
+    engines: {node: '>=18'}
+
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
+
+  picomatch@4.0.2:
+    resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
+    engines: {node: '>=12'}
+
+  proc-log@5.0.0:
+    resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
+    hasBin: true
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.5:
+    resolution: {integrity: sha512-iF+tNDQla22geJdTyJB1wM/qrX9DMRwWrciEPwWLPRWAUEM8sQiyxgckLxWT1f7+9VabJS0jTGGr4QgBuvi6Ww==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  ssri@12.0.0:
+    resolution: {integrity: sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
+
+  tar@7.4.3:
+    resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.14:
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+    engines: {node: '>=12.0.0'}
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.8.0:
+    resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
+
+  unique-filename@4.0.0:
+    resolution: {integrity: sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  unique-slug@5.0.0:
+    resolution: {integrity: sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  which@5.0.0:
+    resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
+snapshots:
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.2
+
+  '@npmcli/agent@3.0.0':
+    dependencies:
+      agent-base: 7.1.4
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 10.4.3
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@npmcli/fs@4.0.0':
+    dependencies:
+      semver: 7.7.2
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@types/node@24.0.13':
+    dependencies:
+      undici-types: 7.8.0
+
+  abbrev@3.0.1: {}
+
+  agent-base@7.1.4: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.1.0: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.1: {}
+
+  balanced-match@1.0.2: {}
+
+  brace-expansion@2.0.2:
+    dependencies:
+      balanced-match: 1.0.2
+
+  cacache@19.0.1:
+    dependencies:
+      '@npmcli/fs': 4.0.0
+      fs-minipass: 3.0.3
+      glob: 10.4.5
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+      minipass-collect: 2.0.1
+      minipass-flush: 1.0.5
+      minipass-pipeline: 1.2.4
+      p-map: 7.0.3
+      ssri: 12.0.0
+      tar: 7.4.3
+      unique-filename: 4.0.0
+
+  chownr@3.0.0: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
+
+  encoding@0.1.13:
+    dependencies:
+      iconv-lite: 0.6.3
+    optional: true
+
+  env-paths@2.2.1: {}
+
+  err-code@2.0.3: {}
+
+  exponential-backoff@3.1.2: {}
+
+  fdir@6.4.6(picomatch@4.0.2):
+    optionalDependencies:
+      picomatch: 4.0.2
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  fs-minipass@3.0.3:
+    dependencies:
+      minipass: 7.1.2
+
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
+  graceful-fs@4.2.11: {}
+
+  http-cache-semantics@4.2.0: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+    optional: true
+
+  imurmurhash@0.1.4: {}
+
+  ip-address@9.0.5:
+    dependencies:
+      jsbn: 1.1.0
+      sprintf-js: 1.1.3
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  isexe@2.0.0: {}
+
+  isexe@3.1.1: {}
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  jsbn@1.1.0: {}
+
+  lru-cache@10.4.3: {}
+
+  make-fetch-happen@14.0.3:
+    dependencies:
+      '@npmcli/agent': 3.0.0
+      cacache: 19.0.1
+      http-cache-semantics: 4.2.0
+      minipass: 7.1.2
+      minipass-fetch: 4.0.1
+      minipass-flush: 1.0.5
+      minipass-pipeline: 1.2.4
+      negotiator: 1.0.0
+      proc-log: 5.0.0
+      promise-retry: 2.0.1
+      ssri: 12.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  minimatch@9.0.5:
+    dependencies:
+      brace-expansion: 2.0.2
+
+  minipass-collect@2.0.1:
+    dependencies:
+      minipass: 7.1.2
+
+  minipass-fetch@4.0.1:
+    dependencies:
+      minipass: 7.1.2
+      minipass-sized: 1.0.3
+      minizlib: 3.0.2
+    optionalDependencies:
+      encoding: 0.1.13
+
+  minipass-flush@1.0.5:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-sized@1.0.3:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@7.1.2: {}
+
+  minizlib@3.0.2:
+    dependencies:
+      minipass: 7.1.2
+
+  mkdirp@3.0.1: {}
+
+  ms@2.1.3: {}
+
+  negotiator@1.0.0: {}
+
+  node-addon-api@7.1.1: {}
+
+  node-gyp@11.2.0:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.2
+      graceful-fs: 4.2.11
+      make-fetch-happen: 14.0.3
+      nopt: 8.1.0
+      proc-log: 5.0.0
+      semver: 7.7.2
+      tar: 7.4.3
+      tinyglobby: 0.2.14
+      which: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  nopt@8.1.0:
+    dependencies:
+      abbrev: 3.0.1
+
+  p-map@7.0.3: {}
+
+  package-json-from-dist@1.0.1: {}
+
+  path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
+
+  picomatch@4.0.2: {}
+
+  proc-log@5.0.0: {}
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
+
+  retry@0.12.0: {}
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.4.5
+
+  safer-buffer@2.1.2:
+    optional: true
+
+  semver@7.7.2: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.1
+      socks: 2.8.5
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.5:
+    dependencies:
+      ip-address: 9.0.5
+      smart-buffer: 4.2.0
+
+  sprintf-js@1.1.3: {}
+
+  ssri@12.0.0:
+    dependencies:
+      minipass: 7.1.2
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.1.0
+
+  tar@7.4.3:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.2
+      minizlib: 3.0.2
+      mkdirp: 3.0.1
+      yallist: 5.0.0
+
+  tinyglobby@0.2.14:
+    dependencies:
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
+
+  typescript@5.8.3: {}
+
+  undici-types@7.8.0: {}
+
+  unique-filename@4.0.0:
+    dependencies:
+      unique-slug: 5.0.0
+
+  unique-slug@5.0.0:
+    dependencies:
+      imurmurhash: 0.1.4
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  which@5.0.0:
+    dependencies:
+      isexe: 3.1.1
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
+
+  yallist@4.0.0: {}
+
+  yallist@5.0.0: {}

--- a/web/vendored-pty/src/eventEmitter2.ts
+++ b/web/vendored-pty/src/eventEmitter2.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2019, Microsoft Corporation (MIT License).
+ */
+
+import { IDisposable } from './types';
+
+interface IListener<T> {
+  (e: T): void;
+}
+
+export interface IEvent<T> {
+  (listener: (e: T) => any): IDisposable;
+}
+
+export class EventEmitter2<T> {
+  private _listeners: IListener<T>[] = [];
+  private _event?: IEvent<T>;
+
+  public get event(): IEvent<T> {
+    if (!this._event) {
+      this._event = (listener: (e: T) => any) => {
+        this._listeners.push(listener);
+        const disposable = {
+          dispose: () => {
+            for (let i = 0; i < this._listeners.length; i++) {
+              if (this._listeners[i] === listener) {
+                this._listeners.splice(i, 1);
+                return;
+              }
+            }
+          }
+        };
+        return disposable;
+      };
+    }
+    return this._event;
+  }
+
+  public fire(data: T): void {
+    const queue: IListener<T>[] = [];
+    for (let i = 0; i < this._listeners.length; i++) {
+      queue.push(this._listeners[i]);
+    }
+    for (let i = 0; i < queue.length; i++) {
+      queue[i].call(undefined, data);
+    }
+  }
+}

--- a/web/vendored-pty/src/index.ts
+++ b/web/vendored-pty/src/index.ts
@@ -1,0 +1,32 @@
+/**
+ * Minimal PTY implementation without threading
+ * Vendored from node-pty, simplified to remove shared pipe architecture
+ */
+
+import { ITerminal, IPtyForkOptions, IWindowsPtyForkOptions } from './interfaces';
+import { ArgvOrCommandLine } from './types';
+
+let terminalCtor: any;
+if (process.platform === 'win32') {
+  terminalCtor = require('./windowsTerminal').WindowsTerminal;
+} else {
+  terminalCtor = require('./unixTerminal').UnixTerminal;
+}
+
+/**
+ * Forks a process as a pseudoterminal.
+ */
+export function spawn(file?: string, args?: ArgvOrCommandLine, opt?: IPtyForkOptions | IWindowsPtyForkOptions): ITerminal {
+  return new terminalCtor(file, args, opt);
+}
+
+// Deprecated aliases
+export const fork = spawn;
+export const createTerminal = spawn;
+
+// Re-export types
+export * from './interfaces';
+export * from './types';
+
+// Alias for compatibility
+export type IPty = ITerminal;

--- a/web/vendored-pty/src/interfaces.ts
+++ b/web/vendored-pty/src/interfaces.ts
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2016, Daniel Imms (MIT License).
+ * Copyright (c) 2018, Microsoft Corporation (MIT License).
+ */
+
+export interface IProcessEnv {
+  [key: string]: string | undefined;
+}
+
+import type { IExitEvent } from './types';
+import type { IEvent } from './eventEmitter2';
+
+export interface ITerminal {
+  /**
+   * Gets the name of the process.
+   */
+  process: string;
+
+  /**
+   * Gets the process ID.
+   */
+  pid: number;
+
+  /**
+   * The data event.
+   */
+  readonly onData: IEvent<string>;
+
+  /**
+   * The exit event.
+   */
+  readonly onExit: IEvent<IExitEvent>;
+
+  /**
+   * Writes data to the socket.
+   * @param data The data to write.
+   */
+  write(data: string): void;
+
+  /**
+   * Resize the pty.
+   * @param cols The number of columns.
+   * @param rows The number of rows.
+   */
+  resize(cols: number, rows: number): void;
+
+  /**
+   * Clears the pty's internal representation of its buffer. This is a no-op
+   * unless on Windows/ConPTY.
+   */
+  clear(): void;
+
+  /**
+   * Close, kill and destroy the socket.
+   */
+  destroy(): void;
+
+  /**
+   * Kill the pty.
+   * @param signal The signal to send, by default this is SIGHUP. This is not
+   * supported on Windows.
+   */
+  kill(signal?: string): void;
+
+  /**
+   * Set the pty socket encoding.
+   */
+  setEncoding(encoding: string | null): void;
+
+  /**
+   * Resume the pty socket.
+   */
+  resume(): void;
+
+  /**
+   * Pause the pty socket.
+   */
+  pause(): void;
+
+  /**
+   * Alias for ITerminal.on(eventName, listener).
+   */
+  addListener(eventName: string, listener: (...args: any[]) => any): void;
+
+  /**
+   * Adds the listener function to the end of the listeners array for the event
+   * named eventName.
+   * @param eventName The event name.
+   * @param listener The callback function
+   */
+  on(eventName: string, listener: (...args: any[]) => any): void;
+
+  /**
+   * Returns a copy of the array of listeners for the event named eventName.
+   */
+  listeners(eventName: string): Function[];
+
+  /**
+   * Removes the specified listener from the listener array for the event named
+   * eventName.
+   */
+  removeListener(eventName: string, listener: (...args: any[]) => any): void;
+
+  /**
+   * Removes all listeners, or those of the specified eventName.
+   */
+  removeAllListeners(eventName: string): void;
+
+  /**
+   * Adds a one time listener function for the event named eventName. The next
+   * time eventName is triggered, this listener is removed and then invoked.
+   */
+  once(eventName: string, listener: (...args: any[]) => any): void;
+}
+
+interface IBasePtyForkOptions {
+  name?: string;
+  cols?: number;
+  rows?: number;
+  cwd?: string;
+  env?: IProcessEnv;
+  encoding?: string | null;
+  handleFlowControl?: boolean;
+  flowControlPause?: string;
+  flowControlResume?: string;
+}
+
+export interface IPtyForkOptions extends IBasePtyForkOptions {
+  uid?: number;
+  gid?: number;
+}
+
+export interface IWindowsPtyForkOptions extends IBasePtyForkOptions {
+  useConpty?: boolean;
+  useConptyDll?: boolean;
+  conptyInheritCursor?: boolean;
+}
+
+export interface IPtyOpenOptions {
+  cols?: number;
+  rows?: number;
+  encoding?: string | null;
+}

--- a/web/vendored-pty/src/native.d.ts
+++ b/web/vendored-pty/src/native.d.ts
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2018, Microsoft Corporation (MIT License).
+ */
+
+interface IConptyNative {
+  startProcess(file: string, cols: number, rows: number, debug: boolean, pipeName: string, conptyInheritCursor: boolean, useConptyDll: boolean): IConptyProcess;
+  connect(ptyId: number, commandLine: string, cwd: string, env: string[], useConptyDll: boolean, onExitCallback: (exitCode: number) => void): { pid: number };
+  resize(ptyId: number, cols: number, rows: number, useConptyDll: boolean): void;
+  clear(ptyId: number, useConptyDll: boolean): void;
+  kill(ptyId: number, useConptyDll: boolean): void;
+}
+
+interface IWinptyNative {
+  startProcess(file: string, commandLine: string, env: string[], cwd: string, cols: number, rows: number, debug: boolean): IWinptyProcess;
+  resize(pid: number, cols: number, rows: number): void;
+  kill(pid: number, innerPid: number): void;
+  getProcessList(pid: number): number[];
+  getExitCode(innerPid: number): number;
+}
+
+interface IUnixNative {
+  fork(file: string, args: string[], parsedEnv: string[], cwd: string, cols: number, rows: number, uid: number, gid: number, useUtf8: boolean, helperPath: string, onExitCallback: (code: number, signal: number) => void): IUnixProcess;
+  open(cols: number, rows: number): IUnixOpenProcess;
+  process(fd: number, pty?: string): string;
+  resize(fd: number, cols: number, rows: number): void;
+}
+
+interface IConptyProcess {
+  pty: number;
+  fd: number;
+  conin: string;
+  conout: string;
+}
+
+interface IWinptyProcess {
+  pty: number;
+  fd: number;
+  conin: string;
+  conout: string;
+  pid: number;
+  innerPid: number;
+}
+
+interface IUnixProcess {
+  fd: number;
+  pid: number;
+  pty: string;
+}
+
+interface IUnixOpenProcess {
+  master: number;
+  slave: number;
+  pty: string;
+}

--- a/web/vendored-pty/src/terminal.ts
+++ b/web/vendored-pty/src/terminal.ts
@@ -1,0 +1,211 @@
+/**
+ * Copyright (c) 2012-2015, Christopher Jeffrey (MIT License)
+ * Copyright (c) 2016, Daniel Imms (MIT License).
+ * Copyright (c) 2018, Microsoft Corporation (MIT License).
+ */
+
+import { Socket } from 'net';
+import { EventEmitter } from 'events';
+import { ITerminal, IPtyForkOptions, IProcessEnv } from './interfaces';
+import { EventEmitter2, IEvent } from './eventEmitter2';
+import { IExitEvent } from './types';
+
+export const DEFAULT_COLS: number = 80;
+export const DEFAULT_ROWS: number = 24;
+
+/**
+ * Default messages to indicate PAUSE/RESUME for automatic flow control.
+ * To avoid conflicts with rebound XON/XOFF control codes (such as on-my-zsh),
+ * the sequences can be customized in `IPtyForkOptions`.
+ */
+const FLOW_CONTROL_PAUSE =  '\x13';   // defaults to XOFF
+const FLOW_CONTROL_RESUME = '\x11';   // defaults to XON
+
+export abstract class Terminal implements ITerminal {
+  protected _socket!: Socket; // HACK: This is unsafe
+  protected _pid: number = 0;
+  protected _fd: number = 0;
+  protected _pty: any;
+
+  protected _file!: string; // HACK: This is unsafe
+  protected _name!: string; // HACK: This is unsafe
+  protected _cols: number = 0;
+  protected _rows: number = 0;
+
+  protected _readable: boolean = false;
+  protected _writable: boolean = false;
+
+  protected _internalee: EventEmitter;
+  private _flowControlPause: string;
+  private _flowControlResume: string;
+  public handleFlowControl: boolean;
+
+  private _onData = new EventEmitter2<string>();
+  public get onData(): IEvent<string> { return this._onData.event; }
+  private _onExit = new EventEmitter2<IExitEvent>();
+  public get onExit(): IEvent<IExitEvent> { return this._onExit.event; }
+
+  public get pid(): number { return this._pid; }
+  public get cols(): number { return this._cols; }
+  public get rows(): number { return this._rows; }
+
+  constructor(opt?: IPtyForkOptions) {
+    // for 'close'
+    this._internalee = new EventEmitter();
+
+    // setup flow control handling
+    this.handleFlowControl = !!(opt?.handleFlowControl);
+    this._flowControlPause = opt?.flowControlPause || FLOW_CONTROL_PAUSE;
+    this._flowControlResume = opt?.flowControlResume || FLOW_CONTROL_RESUME;
+
+    if (!opt) {
+      return;
+    }
+
+    // Do basic type checks here in case node-pty is being used within JavaScript. If the wrong
+    // types go through to the C++ side it can lead to hard to diagnose exceptions.
+    this._checkType('name', opt.name ? opt.name : undefined, 'string');
+    this._checkType('cols', opt.cols ? opt.cols : undefined, 'number');
+    this._checkType('rows', opt.rows ? opt.rows : undefined, 'number');
+    this._checkType('cwd', opt.cwd ? opt.cwd : undefined, 'string');
+    this._checkType('env', opt.env ? opt.env : undefined, 'object');
+    this._checkType('uid', opt.uid ? opt.uid : undefined, 'number');
+    this._checkType('gid', opt.gid ? opt.gid : undefined, 'number');
+    this._checkType('encoding', opt.encoding ? opt.encoding : undefined, 'string');
+  }
+
+  protected abstract _write(data: string): void;
+
+  public write(data: string): void {
+    if (this.handleFlowControl) {
+      // PAUSE/RESUME messages are not forwarded to the pty
+      if (data === this._flowControlPause) {
+        this.pause();
+        return;
+      }
+      if (data === this._flowControlResume) {
+        this.resume();
+        return;
+      }
+    }
+    // everything else goes to the real pty
+    this._write(data);
+  }
+
+  protected _forwardEvents(): void {
+    this.on('data', e => this._onData.fire(e));
+    this.on('exit', (exitCode, signal) => this._onExit.fire({ exitCode, signal }));
+  }
+
+  protected _checkType<T>(name: string, value: T | undefined, type: string, allowArray: boolean = false): void {
+    if (value === undefined) {
+      return;
+    }
+    if (allowArray) {
+      if (Array.isArray(value)) {
+        value.forEach((v, i) => {
+          if (typeof v !== type) {
+            throw new Error(`${name}[${i}] must be a ${type} (not a ${typeof v[i]})`);
+          }
+        });
+        return;
+      }
+    }
+    if (typeof value !== type) {
+      throw new Error(`${name} must be a ${type} (not a ${typeof value})`);
+    }
+  }
+
+  /** See net.Socket.end */
+  public end(data: string): void {
+    this._socket.end(data);
+  }
+
+  /** See stream.Readable.pipe */
+  public pipe(dest: any, options: any): any {
+    return this._socket.pipe(dest, options);
+  }
+
+  /** See net.Socket.pause */
+  public pause(): Socket {
+    return this._socket.pause();
+  }
+
+  /** See net.Socket.resume */
+  public resume(): Socket {
+    return this._socket.resume();
+  }
+
+  /** See net.Socket.setEncoding */
+  public setEncoding(encoding: string | null): void {
+    if ((this._socket as any)._decoder) {
+      delete (this._socket as any)._decoder;
+    }
+    if (encoding) {
+      this._socket.setEncoding(encoding as BufferEncoding);
+    }
+  }
+
+  public addListener(eventName: string, listener: (...args: any[]) => any): void { this.on(eventName, listener); }
+  public on(eventName: string, listener: (...args: any[]) => any): void {
+    if (eventName === 'close') {
+      this._internalee.on('close', listener);
+      return;
+    }
+    this._socket.on(eventName, listener);
+  }
+
+  public emit(eventName: string, ...args: any[]): any {
+    if (eventName === 'close') {
+      return this._internalee.emit.apply(this._internalee, arguments as any);
+    }
+    return this._socket.emit.apply(this._socket, arguments as any);
+  }
+
+  public listeners(eventName: string): Function[] {
+    return this._socket.listeners(eventName);
+  }
+
+  public removeListener(eventName: string, listener: (...args: any[]) => any): void {
+    this._socket.removeListener(eventName, listener);
+  }
+
+  public removeAllListeners(eventName: string): void {
+    this._socket.removeAllListeners(eventName);
+  }
+
+  public once(eventName: string, listener: (...args: any[]) => any): void {
+    this._socket.once(eventName, listener);
+  }
+
+  public abstract resize(cols: number, rows: number): void;
+  public abstract clear(): void;
+  public abstract destroy(): void;
+  public abstract kill(signal?: string): void;
+
+  public abstract get process(): string;
+  public abstract get master(): Socket| undefined;
+  public abstract get slave(): Socket | undefined;
+
+  protected _close(): void {
+    this._socket.readable = false;
+    this.write = () => {};
+    this.end = () => {};
+    this._writable = false;
+    this._readable = false;
+  }
+
+  protected _parseEnv(env: IProcessEnv): string[] {
+    const keys = Object.keys(env || {});
+    const pairs = [];
+
+    for (let i = 0; i < keys.length; i++) {
+      if (keys[i] === undefined) {
+        continue;
+      }
+      pairs.push(keys[i] + '=' + env[keys[i]]);
+    }
+
+    return pairs;
+  }
+}

--- a/web/vendored-pty/src/types.ts
+++ b/web/vendored-pty/src/types.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2017, Daniel Imms (MIT License).
+ * Copyright (c) 2018, Microsoft Corporation (MIT License).
+ */
+
+export type ArgvOrCommandLine = string[] | string;
+
+export interface IExitEvent {
+  exitCode: number;
+  signal: number | undefined;
+}
+
+export interface IDisposable {
+  dispose(): void;
+}

--- a/web/vendored-pty/src/unix/pty.cc
+++ b/web/vendored-pty/src/unix/pty.cc
@@ -1,0 +1,796 @@
+/**
+ * Copyright (c) 2012-2015, Christopher Jeffrey (MIT License)
+ * Copyright (c) 2017, Daniel Imms (MIT License)
+ *
+ * pty.cc:
+ *   This file is responsible for starting processes
+ *   with pseudo-terminal file descriptors.
+ *
+ * See:
+ *   man pty
+ *   man tty_ioctl
+ *   man termios
+ *   man forkpty
+ */
+
+/**
+ * Includes
+ */
+
+#define NODE_ADDON_API_DISABLE_DEPRECATED
+#include <napi.h>
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <thread>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <fcntl.h>
+#include <signal.h>
+
+/* forkpty */
+/* http://www.gnu.org/software/gnulib/manual/html_node/forkpty.html */
+#if defined(__linux__)
+#include <pty.h>
+#elif defined(__APPLE__)
+#include <util.h>
+#elif defined(__FreeBSD__)
+#include <libutil.h>
+#include <termios.h>
+#endif
+
+/* Some platforms name VWERASE and VDISCARD differently */
+#if !defined(VWERASE) && defined(VWERSE)
+#define VWERASE	VWERSE
+#endif
+#if !defined(VDISCARD) && defined(VDISCRD)
+#define VDISCARD	VDISCRD
+#endif
+
+/* for pty_getproc */
+#if defined(__linux__)
+#include <stdio.h>
+#include <stdint.h>
+#elif defined(__APPLE__)
+#include <libproc.h>
+#include <os/availability.h>
+#include <paths.h>
+#include <spawn.h>
+#include <sys/event.h>
+#include <sys/sysctl.h>
+#include <termios.h>
+#endif
+
+/* NSIG - macro for highest signal + 1, should be defined */
+#ifndef NSIG
+#define NSIG 32
+#endif
+
+/* macOS 10.14 back does not define this constant */
+#ifndef POSIX_SPAWN_SETSID
+  #define POSIX_SPAWN_SETSID 1024
+#endif
+
+/* environ for execvpe */
+/* node/src/node_child_process.cc */
+#if !defined(__APPLE__)
+extern char **environ;
+#endif
+
+#if defined(__APPLE__)
+extern "C" {
+// Changes the current thread's directory to a path or directory file
+// descriptor. libpthread only exposes a syscall wrapper starting in
+// macOS 10.12, but the system call dates back to macOS 10.5. On older OSes,
+// the syscall is issued directly.
+int pthread_chdir_np(const char* dir) API_AVAILABLE(macosx(10.12));
+int pthread_fchdir_np(int fd) API_AVAILABLE(macosx(10.12));
+}
+
+#define HANDLE_EINTR(x) ({ \
+  int eintr_wrapper_counter = 0; \
+  decltype(x) eintr_wrapper_result; \
+  do { \
+    eintr_wrapper_result = (x); \
+  } while (eintr_wrapper_result == -1 && errno == EINTR && \
+           eintr_wrapper_counter++ < 100); \
+  eintr_wrapper_result; \
+})
+#endif
+
+struct ExitEvent {
+  int exit_code = 0, signal_code = 0;
+};
+
+void SetupExitCallback(Napi::Env env, Napi::Function cb, pid_t pid) {
+  std::thread *th = new std::thread;
+  // Don't use Napi::AsyncWorker which is limited by UV_THREADPOOL_SIZE.
+  auto tsfn = Napi::ThreadSafeFunction::New(
+      env,
+      cb,                           // JavaScript function called asynchronously
+      "SetupExitCallback_resource", // Name
+      0,                            // Unlimited queue
+      1,                            // Only one thread will use this initially
+      [th](Napi::Env) {   // Finalizer used to clean threads up
+        th->join();
+        delete th;
+      });
+  *th = std::thread([tsfn = std::move(tsfn), pid] {
+    auto callback = [](Napi::Env env, Napi::Function cb, ExitEvent *exit_event) {
+      cb.Call({Napi::Number::New(env, exit_event->exit_code),
+               Napi::Number::New(env, exit_event->signal_code)});
+      delete exit_event;
+    };
+
+    int ret;
+    int stat_loc;
+#if defined(__APPLE__)
+    // Based on
+    // https://source.chromium.org/chromium/chromium/src/+/main:base/process/kill_mac.cc;l=35-69?
+    int kq = HANDLE_EINTR(kqueue());
+    struct kevent change = {0};
+    EV_SET(&change, pid, EVFILT_PROC, EV_ADD, NOTE_EXIT, 0, NULL);
+    ret = HANDLE_EINTR(kevent(kq, &change, 1, NULL, 0, NULL));
+    if (ret == -1) {
+      if (errno == ESRCH) {
+        // At this point, one of the following has occurred:
+        // 1. The process has died but has not yet been reaped.
+        // 2. The process has died and has already been reaped.
+        // 3. The process is in the process of dying. It's no longer
+        //    kqueueable, but it may not be waitable yet either. Mark calls
+        //    this case the "zombie death race".
+        ret = HANDLE_EINTR(waitpid(pid, &stat_loc, WNOHANG));
+        if (ret == 0) {
+          ret = kill(pid, SIGKILL);
+          if (ret != -1) {
+            HANDLE_EINTR(waitpid(pid, &stat_loc, 0));
+          }
+        }
+      }
+    } else {
+      struct kevent event = {0};
+      ret = HANDLE_EINTR(kevent(kq, NULL, 0, &event, 1, NULL));
+      if (ret == 1) {
+        if ((event.fflags & NOTE_EXIT) &&
+            (event.ident == static_cast<uintptr_t>(pid))) {
+          // The process is dead or dying. This won't block for long, if at
+          // all.
+          HANDLE_EINTR(waitpid(pid, &stat_loc, 0));
+        }
+      }
+    }
+#else
+    while (true) {
+      errno = 0;
+      if ((ret = waitpid(pid, &stat_loc, 0)) != pid) {
+        if (ret == -1 && errno == EINTR) {
+          continue;
+        }
+        if (ret == -1 && errno == ECHILD) {
+          // XXX node v0.8.x seems to have this problem.
+          // waitpid is already handled elsewhere.
+          ;
+        } else {
+          assert(false);
+        }
+      }
+      break;
+    }
+#endif
+    ExitEvent *exit_event = new ExitEvent;
+    if (WIFEXITED(stat_loc)) {
+      exit_event->exit_code = WEXITSTATUS(stat_loc); // errno?
+    }
+    if (WIFSIGNALED(stat_loc)) {
+      exit_event->signal_code = WTERMSIG(stat_loc);
+    }
+    auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
+    switch (status) {
+      case napi_closing:
+        break;
+
+      case napi_queue_full:
+        Napi::Error::Fatal("SetupExitCallback", "Queue was full");
+
+      case napi_ok:
+        if (tsfn.Release() != napi_ok) {
+          Napi::Error::Fatal("SetupExitCallback", "ThreadSafeFunction.Release() failed");
+        }
+        break;
+
+      default:
+        Napi::Error::Fatal("SetupExitCallback", "ThreadSafeFunction.BlockingCall() failed");
+    }
+  });
+}
+
+/**
+ * Methods
+ */
+
+Napi::Value PtyFork(const Napi::CallbackInfo& info);
+Napi::Value PtyOpen(const Napi::CallbackInfo& info);
+Napi::Value PtyResize(const Napi::CallbackInfo& info);
+Napi::Value PtyGetProc(const Napi::CallbackInfo& info);
+
+/**
+ * Functions
+ */
+
+static int
+pty_nonblock(int);
+
+#if defined(__APPLE__)
+static char *
+pty_getproc(int);
+#else
+static char *
+pty_getproc(int, char *);
+#endif
+
+#if defined(__APPLE__) || defined(__OpenBSD__)
+static void
+pty_posix_spawn(char** argv, char** env,
+                const struct termios *termp,
+                const struct winsize *winp,
+                int* master,
+                pid_t* pid,
+                int* err);
+#endif
+
+struct DelBuf {
+  int len;
+  DelBuf(int len) : len(len) {}
+  void operator()(char **p) {
+    if (p == nullptr)
+      return;
+    for (int i = 0; i < len; i++)
+      free(p[i]);
+    delete[] p;
+  }
+};
+
+Napi::Value PtyFork(const Napi::CallbackInfo& info) {
+  Napi::Env napiEnv(info.Env());
+  Napi::HandleScope scope(napiEnv);
+
+  if (info.Length() != 11 ||
+      !info[0].IsString() ||
+      !info[1].IsArray() ||
+      !info[2].IsArray() ||
+      !info[3].IsString() ||
+      !info[4].IsNumber() ||
+      !info[5].IsNumber() ||
+      !info[6].IsNumber() ||
+      !info[7].IsNumber() ||
+      !info[8].IsBoolean() ||
+      !info[9].IsString() ||
+      !info[10].IsFunction()) {
+    throw Napi::Error::New(napiEnv, "Usage: pty.fork(file, args, env, cwd, cols, rows, uid, gid, utf8, helperPath, onexit)");
+  }
+
+  // file
+  std::string file = info[0].As<Napi::String>();
+
+  // args
+  Napi::Array argv_ = info[1].As<Napi::Array>();
+
+  // env
+  Napi::Array env_ = info[2].As<Napi::Array>();
+  int envc = env_.Length();
+  std::unique_ptr<char *, DelBuf> env_unique_ptr(new char *[envc + 1], DelBuf(envc + 1));
+  char **env = env_unique_ptr.get();
+  env[envc] = NULL;
+  for (int i = 0; i < envc; i++) {
+    std::string pair = env_.Get(i).As<Napi::String>();
+    env[i] = strdup(pair.c_str());
+  }
+
+  // cwd
+  std::string cwd_ = info[3].As<Napi::String>();
+
+  // size
+  struct winsize winp;
+  winp.ws_col = info[4].As<Napi::Number>().Int32Value();
+  winp.ws_row = info[5].As<Napi::Number>().Int32Value();
+  winp.ws_xpixel = 0;
+  winp.ws_ypixel = 0;
+
+#if !defined(__APPLE__)
+  // uid / gid
+  int uid = info[6].As<Napi::Number>().Int32Value();
+  int gid = info[7].As<Napi::Number>().Int32Value();
+#endif
+
+  // termios
+  struct termios t = termios();
+  struct termios *term = &t;
+  term->c_iflag = ICRNL | IXON | IXANY | IMAXBEL | BRKINT;
+  if (info[8].As<Napi::Boolean>().Value()) {
+#if defined(IUTF8)
+    term->c_iflag |= IUTF8;
+#endif
+  }
+  term->c_oflag = OPOST | ONLCR;
+  term->c_cflag = CREAD | CS8 | HUPCL;
+  term->c_lflag = ICANON | ISIG | IEXTEN | ECHO | ECHOE | ECHOK | ECHOKE | ECHOCTL;
+
+  term->c_cc[VEOF] = 4;
+  term->c_cc[VEOL] = -1;
+  term->c_cc[VEOL2] = -1;
+  term->c_cc[VERASE] = 0x7f;
+  term->c_cc[VWERASE] = 23;
+  term->c_cc[VKILL] = 21;
+  term->c_cc[VREPRINT] = 18;
+  term->c_cc[VINTR] = 3;
+  term->c_cc[VQUIT] = 0x1c;
+  term->c_cc[VSUSP] = 26;
+  term->c_cc[VSTART] = 17;
+  term->c_cc[VSTOP] = 19;
+  term->c_cc[VLNEXT] = 22;
+  term->c_cc[VDISCARD] = 15;
+  term->c_cc[VMIN] = 1;
+  term->c_cc[VTIME] = 0;
+
+  #if (__APPLE__)
+  term->c_cc[VDSUSP] = 25;
+  term->c_cc[VSTATUS] = 20;
+  #endif
+
+  cfsetispeed(term, B38400);
+  cfsetospeed(term, B38400);
+
+  // helperPath
+  std::string helper_path = info[9].As<Napi::String>();
+
+  pid_t pid;
+  int master;
+#if defined(__APPLE__)
+  int argc = argv_.Length();
+  int argl = argc + 4;
+  std::unique_ptr<char *, DelBuf> argv_unique_ptr(new char *[argl], DelBuf(argl));
+  char **argv = argv_unique_ptr.get();
+  argv[0] = strdup(helper_path.c_str());
+  argv[1] = strdup(cwd_.c_str());
+  argv[2] = strdup(file.c_str());
+  argv[argl - 1] = NULL;
+  for (int i = 0; i < argc; i++) {
+    std::string arg = argv_.Get(i).As<Napi::String>();
+    argv[i + 3] = strdup(arg.c_str());
+  }
+
+  int err = -1;
+  pty_posix_spawn(argv, env, term, &winp, &master, &pid, &err);
+  if (err != 0) {
+    throw Napi::Error::New(napiEnv, "posix_spawnp failed.");
+  }
+  if (pty_nonblock(master) == -1) {
+    throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
+  }
+#else
+  int argc = argv_.Length();
+  int argl = argc + 2;
+  std::unique_ptr<char *, DelBuf> argv_unique_ptr(new char *[argl], DelBuf(argl));
+  char** argv = argv_unique_ptr.get();
+  argv[0] = strdup(file.c_str());
+  argv[argl - 1] = NULL;
+  for (int i = 0; i < argc; i++) {
+    std::string arg = argv_.Get(i).As<Napi::String>();
+    argv[i + 1] = strdup(arg.c_str());
+  }
+
+  sigset_t newmask, oldmask;
+  struct sigaction sig_action;
+  // temporarily block all signals
+  // this is needed due to a race condition in openpty
+  // and to avoid running signal handlers in the child
+  // before exec* happened
+  sigfillset(&newmask);
+  pthread_sigmask(SIG_SETMASK, &newmask, &oldmask);
+
+  pid = forkpty(&master, nullptr, static_cast<termios*>(term), static_cast<winsize*>(&winp));
+
+  if (!pid) {
+    // remove all signal handler from child
+    sig_action.sa_handler = SIG_DFL;
+    sig_action.sa_flags = 0;
+    sigemptyset(&sig_action.sa_mask);
+    for (int i = 0 ; i < NSIG ; i++) {    // NSIG is a macro for all signals + 1
+      sigaction(i, &sig_action, NULL);
+    }
+  }
+
+  // reenable signals
+  pthread_sigmask(SIG_SETMASK, &oldmask, NULL);
+
+  switch (pid) {
+    case -1:
+      throw Napi::Error::New(napiEnv, "forkpty(3) failed.");
+    case 0:
+      if (strlen(cwd_.c_str())) {
+        if (chdir(cwd_.c_str()) == -1) {
+          perror("chdir(2) failed.");
+          _exit(1);
+        }
+      }
+
+      if (uid != -1 && gid != -1) {
+        if (setgid(gid) == -1) {
+          perror("setgid(2) failed.");
+          _exit(1);
+        }
+        if (setuid(uid) == -1) {
+          perror("setuid(2) failed.");
+          _exit(1);
+        }
+      }
+
+      {
+        char **old = environ;
+        environ = env;
+        execvp(argv[0], argv);
+        environ = old;
+        perror("execvp(3) failed.");
+        _exit(1);
+      }
+    default:
+      if (pty_nonblock(master) == -1) {
+        throw Napi::Error::New(napiEnv, "Could not set master fd to nonblocking.");
+      }
+  }
+#endif
+
+  Napi::Object obj = Napi::Object::New(napiEnv);  
+  obj.Set("fd", Napi::Number::New(napiEnv, master));  
+  obj.Set("pid", Napi::Number::New(napiEnv, pid));  
+  obj.Set("pty", Napi::String::New(napiEnv, ptsname(master)));  
+
+  // Set up process exit callback.
+  Napi::Function cb = info[10].As<Napi::Function>();
+  SetupExitCallback(napiEnv, cb, pid);
+  return obj;
+}
+
+Napi::Value PtyOpen(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 2 ||
+      !info[0].IsNumber() ||
+      !info[1].IsNumber()) {
+    throw Napi::Error::New(env, "Usage: pty.open(cols, rows)");
+  }
+
+  // size
+  struct winsize winp;
+  winp.ws_col = info[0].As<Napi::Number>().Int32Value();
+  winp.ws_row = info[1].As<Napi::Number>().Int32Value();
+  winp.ws_xpixel = 0;
+  winp.ws_ypixel = 0;
+
+  // pty
+  int master, slave;
+  int ret = openpty(&master, &slave, nullptr, NULL, static_cast<winsize*>(&winp));
+
+  if (ret == -1) {
+    throw Napi::Error::New(env, "openpty(3) failed.");
+  }
+
+  if (pty_nonblock(master) == -1) {
+    throw Napi::Error::New(env, "Could not set master fd to nonblocking.");
+  }
+
+  if (pty_nonblock(slave) == -1) {
+    throw Napi::Error::New(env, "Could not set slave fd to nonblocking.");
+  }
+
+  Napi::Object obj = Napi::Object::New(env);  
+  obj.Set("master", Napi::Number::New(env, master));  
+  obj.Set("slave", Napi::Number::New(env, slave));  
+  obj.Set("pty", Napi::String::New(env, ptsname(master)));  
+
+  return obj;
+}
+
+Napi::Value PtyResize(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 3 ||
+      !info[0].IsNumber() ||
+      !info[1].IsNumber() ||
+      !info[2].IsNumber()) {
+    throw Napi::Error::New(env, "Usage: pty.resize(fd, cols, rows)");
+  }
+
+  int fd = info[0].As<Napi::Number>().Int32Value();
+
+  struct winsize winp;
+  winp.ws_col = info[1].As<Napi::Number>().Int32Value();
+  winp.ws_row = info[2].As<Napi::Number>().Int32Value();
+  winp.ws_xpixel = 0;
+  winp.ws_ypixel = 0;
+
+  if (ioctl(fd, TIOCSWINSZ, &winp) == -1) {
+    switch (errno) {
+      case EBADF:
+        throw Napi::Error::New(env, "ioctl(2) failed, EBADF");
+      case EFAULT:
+        throw Napi::Error::New(env, "ioctl(2) failed, EFAULT");
+      case EINVAL:
+        throw Napi::Error::New(env, "ioctl(2) failed, EINVAL");
+      case ENOTTY:
+        throw Napi::Error::New(env, "ioctl(2) failed, ENOTTY");
+    }
+    throw Napi::Error::New(env, "ioctl(2) failed");
+  }
+
+  return env.Undefined();
+}
+
+/**
+ * Foreground Process Name
+ */
+Napi::Value PtyGetProc(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+#if defined(__APPLE__)
+  if (info.Length() != 1 ||
+      !info[0].IsNumber()) {
+    throw Napi::Error::New(env, "Usage: pty.process(pid)");
+  }
+
+  int fd = info[0].As<Napi::Number>().Int32Value();
+  char *name = pty_getproc(fd);
+#else
+  if (info.Length() != 2 ||
+      !info[0].IsNumber() ||
+      !info[1].IsString()) {
+    throw Napi::Error::New(env, "Usage: pty.process(fd, tty)");
+  }
+
+  int fd = info[0].As<Napi::Number>().Int32Value();
+
+  std::string tty_ = info[1].As<Napi::String>();
+  char *tty = strdup(tty_.c_str());
+  char *name = pty_getproc(fd, tty);
+  free(tty);
+#endif
+
+  if (name == NULL) {
+    return env.Undefined();
+  }
+
+  Napi::String name_ = Napi::String::New(env, name);
+  free(name);
+  return name_;
+}
+
+/**
+ * Nonblocking FD
+ */
+
+static int
+pty_nonblock(int fd) {
+  int flags = fcntl(fd, F_GETFL, 0);
+  if (flags == -1) return -1;
+  return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+}
+
+/**
+ * pty_getproc
+ * Taken from tmux.
+ */
+
+// Taken from: tmux (http://tmux.sourceforge.net/)
+// Copyright (c) 2009 Nicholas Marriott <nicm@users.sourceforge.net>
+// Copyright (c) 2009 Joshua Elsasser <josh@elsasser.org>
+// Copyright (c) 2009 Todd Carson <toc@daybefore.net>
+//
+// Permission to use, copy, modify, and distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF MIND, USE, DATA OR PROFITS, WHETHER
+// IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+// OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+#if defined(__linux__)
+
+static char *
+pty_getproc(int fd, char *tty) {
+  FILE *f;
+  char *path, *buf;
+  size_t len;
+  int ch;
+  pid_t pgrp;
+  int r;
+
+  if ((pgrp = tcgetpgrp(fd)) == -1) {
+    return NULL;
+  }
+
+  r = asprintf(&path, "/proc/%lld/cmdline", (long long)pgrp);
+  if (r == -1 || path == NULL) return NULL;
+
+  if ((f = fopen(path, "r")) == NULL) {
+    free(path);
+    return NULL;
+  }
+
+  free(path);
+
+  len = 0;
+  buf = NULL;
+  while ((ch = fgetc(f)) != EOF) {
+    if (ch == '\0') break;
+    buf = (char *)realloc(buf, len + 2);
+    if (buf == NULL) return NULL;
+    buf[len++] = ch;
+  }
+
+  if (buf != NULL) {
+    buf[len] = '\0';
+  }
+
+  fclose(f);
+  return buf;
+}
+
+#elif defined(__APPLE__)
+
+static char *
+pty_getproc(int fd) {
+  int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PID, 0 };
+  size_t size;
+  struct kinfo_proc kp;
+
+  if ((mib[3] = tcgetpgrp(fd)) == -1) {
+    return NULL;
+  }
+
+  size = sizeof kp;
+  if (sysctl(mib, 4, &kp, &size, NULL, 0) == -1) {
+    return NULL;
+  }
+
+  if (size != (sizeof kp) || *kp.kp_proc.p_comm == '\0') {
+    return NULL;
+  }
+
+  return strdup(kp.kp_proc.p_comm);
+}
+
+#else
+
+static char *
+pty_getproc(int fd, char *tty) {
+  return NULL;
+}
+
+#endif
+
+#if defined(__APPLE__)
+static void
+pty_posix_spawn(char** argv, char** env,
+                const struct termios *termp,
+                const struct winsize *winp,
+                int* master,
+                pid_t* pid,
+                int* err) {
+  int low_fds[3];
+  size_t count = 0;
+
+  for (; count < 3; count++) {
+    low_fds[count] = posix_openpt(O_RDWR);
+    if (low_fds[count] >= STDERR_FILENO)
+      break;
+  }
+
+  int flags = POSIX_SPAWN_CLOEXEC_DEFAULT |
+              POSIX_SPAWN_SETSIGDEF |
+              POSIX_SPAWN_SETSIGMASK |
+              POSIX_SPAWN_SETSID;
+  *master = posix_openpt(O_RDWR);
+  if (*master == -1) {
+    return;
+  }
+
+  int res = grantpt(*master) || unlockpt(*master);
+  if (res == -1) {
+    return;
+  }
+
+  // Use TIOCPTYGNAME instead of ptsname() to avoid threading problems.
+  int slave;
+  char slave_pty_name[128];
+  res = ioctl(*master, TIOCPTYGNAME, slave_pty_name);
+  if (res == -1) {
+    return;
+  }
+
+  slave = open(slave_pty_name, O_RDWR | O_NOCTTY);
+  if (slave == -1) {
+    return;
+  }
+
+  if (termp) {
+    res = tcsetattr(slave, TCSANOW, termp);
+    if (res == -1) {
+      return;
+    };
+  }
+
+  if (winp) {
+    res = ioctl(slave, TIOCSWINSZ, winp);
+    if (res == -1) {
+      return;
+    }
+  }
+
+  posix_spawn_file_actions_t acts;
+  posix_spawn_file_actions_init(&acts);
+  posix_spawn_file_actions_adddup2(&acts, slave, STDIN_FILENO);
+  posix_spawn_file_actions_adddup2(&acts, slave, STDOUT_FILENO);
+  posix_spawn_file_actions_adddup2(&acts, slave, STDERR_FILENO);
+  posix_spawn_file_actions_addclose(&acts, slave);
+  posix_spawn_file_actions_addclose(&acts, *master);
+
+  posix_spawnattr_t attrs;
+  posix_spawnattr_init(&attrs);
+  *err = posix_spawnattr_setflags(&attrs, flags);
+  if (*err != 0) {
+    goto done;
+  }
+
+  sigset_t signal_set;
+  /* Reset all signal the child to their default behavior */
+  sigfillset(&signal_set);
+  *err = posix_spawnattr_setsigdefault(&attrs, &signal_set);
+  if (*err != 0) {
+    goto done;
+  }
+
+  /* Reset the signal mask for all signals */
+  sigemptyset(&signal_set);
+  *err = posix_spawnattr_setsigmask(&attrs, &signal_set);
+  if (*err != 0) {
+    goto done;
+  }
+
+  do
+    *err = posix_spawn(pid, argv[0], &acts, &attrs, argv, env);
+  while (*err == EINTR);
+done:
+  posix_spawn_file_actions_destroy(&acts);
+  posix_spawnattr_destroy(&attrs);
+
+  for (; count > 0; count--) {
+    close(low_fds[count]);
+  }
+}
+#endif
+
+/**
+ * Init
+ */
+
+Napi::Object init(Napi::Env env, Napi::Object exports) {
+  exports.Set("fork",    Napi::Function::New(env, PtyFork));
+  exports.Set("open",    Napi::Function::New(env, PtyOpen));
+  exports.Set("resize",  Napi::Function::New(env, PtyResize));
+  exports.Set("process", Napi::Function::New(env, PtyGetProc));
+  return exports;
+}
+
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, init)

--- a/web/vendored-pty/src/unix/spawn-helper.cc
+++ b/web/vendored-pty/src/unix/spawn-helper.cc
@@ -1,0 +1,23 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+int main (int argc, char** argv) {
+  char *slave_path = ttyname(STDIN_FILENO);
+  // open implicit attaches a process to a terminal device if:
+  // - process has no controlling terminal yet
+  // - O_NOCTTY is not set
+  close(open(slave_path, O_RDWR));
+
+  char *cwd = argv[1];
+  char *file = argv[2];
+  argv = &argv[2];
+
+  if (strlen(cwd) && chdir(cwd) == -1) {
+    _exit(1);
+  }
+
+  execvp(file, argv);
+  return 1;
+}

--- a/web/vendored-pty/src/unixTerminal.ts
+++ b/web/vendored-pty/src/unixTerminal.ts
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) 2012-2015, Christopher Jeffrey (MIT License)
+ * Copyright (c) 2016, Daniel Imms (MIT License).
+ * Copyright (c) 2018, Microsoft Corporation (MIT License).
+ */
+import * as net from 'net';
+import * as path from 'path';
+import * as tty from 'tty';
+import { Terminal, DEFAULT_COLS, DEFAULT_ROWS } from './terminal';
+import { IProcessEnv, IPtyForkOptions, IPtyOpenOptions } from './interfaces';
+import { ArgvOrCommandLine } from './types';
+import { assign } from './utils';
+
+let pty: IUnixNative;
+let helperPath: string;
+try {
+  pty = require('../build/Release/pty.node');
+  helperPath = '../build/Release/spawn-helper';
+} catch (outerError) {
+  try {
+    pty = require('../build/Debug/pty.node');
+    helperPath = '../build/Debug/spawn-helper';
+  } catch (innerError) {
+    console.error('innerError', innerError);
+    // Re-throw the exception from the Release require if the Debug require fails as well
+    throw outerError;
+  }
+}
+
+helperPath = path.resolve(__dirname, helperPath);
+helperPath = helperPath.replace('app.asar', 'app.asar.unpacked');
+helperPath = helperPath.replace('node_modules.asar', 'node_modules.asar.unpacked');
+
+const DEFAULT_FILE = 'sh';
+const DEFAULT_NAME = 'xterm';
+const DESTROY_SOCKET_TIMEOUT_MS = 200;
+
+export class UnixTerminal extends Terminal {
+  protected _fd: number;
+  protected _pty: string;
+
+  protected _file: string;
+  protected _name: string;
+
+  protected _readable: boolean;
+  protected _writable: boolean;
+
+  private _boundClose: boolean = false;
+  private _emittedClose: boolean = false;
+  private _master: net.Socket | undefined;
+  private _slave: net.Socket | undefined;
+
+  public get master(): net.Socket | undefined { return this._master; }
+  public get slave(): net.Socket | undefined { return this._slave; }
+
+  constructor(file?: string, args?: ArgvOrCommandLine, opt?: IPtyForkOptions) {
+    super(opt);
+
+    if (typeof args === 'string') {
+      throw new Error('args as a string is not supported on unix.');
+    }
+
+    // Initialize arguments
+    args = args || [];
+    file = file || DEFAULT_FILE;
+    opt = opt || {};
+    opt.env = opt.env || process.env;
+
+    this._cols = opt.cols || DEFAULT_COLS;
+    this._rows = opt.rows || DEFAULT_ROWS;
+    const uid = opt.uid ?? -1;
+    const gid = opt.gid ?? -1;
+    const env: IProcessEnv = assign({}, opt.env);
+
+    if (opt.env === process.env) {
+      this._sanitizeEnv(env);
+    }
+
+    const cwd = opt.cwd || process.cwd();
+    env.PWD = cwd;
+    const name = opt.name || env.TERM || DEFAULT_NAME;
+    env.TERM = name;
+    const parsedEnv = this._parseEnv(env);
+
+    const encoding = (opt.encoding === undefined ? 'utf8' : opt.encoding);
+
+    const onexit = (code: number, signal: number): void => {
+      // XXX Sometimes a data event is emitted after exit. Wait til socket is
+      // destroyed.
+      if (!this._emittedClose) {
+        if (this._boundClose) {
+          return;
+        }
+        this._boundClose = true;
+        // From macOS High Sierra 10.13.2 sometimes the socket never gets
+        // closed. A timeout is applied here to avoid the terminal never being
+        // destroyed when this occurs.
+        let timeout: NodeJS.Timeout | null = setTimeout(() => {
+          timeout = null;
+          // Destroying the socket now will cause the close event to fire
+          this._socket.destroy();
+        }, DESTROY_SOCKET_TIMEOUT_MS);
+        this.once('close', () => {
+          if (timeout !== null) {
+            clearTimeout(timeout);
+          }
+          this.emit('exit', code, signal);
+        });
+        return;
+      }
+      this.emit('exit', code, signal);
+    };
+
+    // fork
+    const term = pty.fork(file, args, parsedEnv, cwd, this._cols, this._rows, uid, gid, (encoding === 'utf8'), helperPath, onexit);
+
+    this._socket = new tty.ReadStream(term.fd);
+    if (encoding !== null) {
+      this._socket.setEncoding(encoding as BufferEncoding);
+    }
+
+    // setup
+    this._socket.on('error', (err: any) => {
+      // NOTE: fs.ReadStream gets EAGAIN twice at first:
+      if (err.code) {
+        if (~err.code.indexOf('EAGAIN')) {
+          return;
+        }
+      }
+
+      // close
+      this._close();
+      // EIO on exit from fs.ReadStream:
+      if (!this._emittedClose) {
+        this._emittedClose = true;
+        this.emit('close');
+      }
+
+      // EIO, happens when someone closes our child process: the only process in
+      // the terminal.
+      // node < 0.6.14: errno 5
+      // node >= 0.6.14: read EIO
+      if (err.code) {
+        if (~err.code.indexOf('errno 5') || ~err.code.indexOf('EIO')) {
+          return;
+        }
+      }
+
+      // throw anything else
+      if (this.listeners('error').length < 2) {
+        throw err;
+      }
+    });
+
+    this._pid = term.pid;
+    this._fd = term.fd;
+    this._pty = term.pty;
+
+    this._file = file;
+    this._name = name;
+
+    this._readable = true;
+    this._writable = true;
+
+    this._socket.on('close', () => {
+      if (this._emittedClose) {
+        return;
+      }
+      this._emittedClose = true;
+      this._close();
+      this.emit('close');
+    });
+
+    this._forwardEvents();
+  }
+
+  protected _write(data: string): void {
+    this._socket.write(data);
+  }
+
+  /* Accessors */
+  get fd(): number { return this._fd; }
+  get ptsName(): string { return this._pty; }
+
+  /**
+   * openpty
+   */
+
+  public static open(opt: IPtyOpenOptions): UnixTerminal {
+    const self: UnixTerminal = Object.create(UnixTerminal.prototype);
+    opt = opt || {};
+
+    if (arguments.length > 1) {
+      opt = {
+        cols: arguments[1],
+        rows: arguments[2]
+      };
+    }
+
+    const cols = opt.cols || DEFAULT_COLS;
+    const rows = opt.rows || DEFAULT_ROWS;
+    const encoding = (opt.encoding === undefined ? 'utf8' : opt.encoding);
+
+    // open
+    const term: IUnixOpenProcess = pty.open(cols, rows);
+
+    self._master = new tty.ReadStream(term.master);
+    if (encoding !== null) {
+      self._master.setEncoding(encoding as BufferEncoding);
+    }
+    self._master.resume();
+
+    self._slave = new tty.ReadStream(term.slave);
+    if (encoding !== null) {
+      self._slave.setEncoding(encoding as BufferEncoding);
+    }
+    self._slave.resume();
+
+    self._socket = self._master;
+    self._pid = -1;
+    self._fd = term.master;
+    self._pty = term.pty;
+
+    self._file = process.argv[0] || 'node';
+    self._name = process.env.TERM || '';
+
+    self._readable = true;
+    self._writable = true;
+
+    self._socket.on('error', err => {
+      self._close();
+      if (self.listeners('error').length < 2) {
+        throw err;
+      }
+    });
+
+    self._socket.on('close', () => {
+      self._close();
+    });
+
+    return self;
+  }
+
+  public destroy(): void {
+    this._close();
+
+    // Need to close the read stream so node stops reading a dead file
+    // descriptor. Then we can safely SIGHUP the shell.
+    this._socket.once('close', () => {
+      this.kill('SIGHUP');
+    });
+
+    this._socket.destroy();
+  }
+
+  public kill(signal?: string): void {
+    try {
+      process.kill(this.pid, signal || 'SIGHUP');
+    } catch (e) { /* swallow */ }
+  }
+
+  /**
+   * Gets the name of the process.
+   */
+  public get process(): string {
+    if (process.platform === 'darwin') {
+      const title = pty.process(this._fd);
+      return (title !== 'kernel_task' ) ? title : this._file;
+    }
+
+    return pty.process(this._fd, this._pty) || this._file;
+  }
+
+  /**
+   * TTY
+   */
+
+  public resize(cols: number, rows: number): void {
+    if (cols <= 0 || rows <= 0 || isNaN(cols) || isNaN(rows) || cols === Infinity || rows === Infinity) {
+      throw new Error('resizing must be done using positive cols and rows');
+    }
+    pty.resize(this._fd, cols, rows);
+    this._cols = cols;
+    this._rows = rows;
+  }
+
+  public clear(): void {
+
+  }
+
+  private _sanitizeEnv(env: IProcessEnv): void {
+    // Make sure we didn't start our server from inside tmux.
+    delete env['TMUX'];
+    delete env['TMUX_PANE'];
+
+    // Make sure we didn't start our server from inside screen.
+    // http://web.mit.edu/gnu/doc/html/screen_20.html
+    delete env['STY'];
+    delete env['WINDOW'];
+
+    // Delete some variables that might confuse our terminal.
+    delete env['WINDOWID'];
+    delete env['TERMCAP'];
+    delete env['COLUMNS'];
+    delete env['LINES'];
+  }
+}

--- a/web/vendored-pty/src/utils.ts
+++ b/web/vendored-pty/src/utils.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) 2017, Daniel Imms (MIT License).
+ * Copyright (c) 2018, Microsoft Corporation (MIT License).
+ */
+
+export function assign(target: any, ...sources: any[]): any {
+  sources.forEach(source => Object.keys(source).forEach(key => target[key] = source[key]));
+  return target;
+}

--- a/web/vendored-pty/src/win/conpty.cc
+++ b/web/vendored-pty/src/win/conpty.cc
@@ -1,0 +1,583 @@
+/**
+ * Copyright (c) 2013-2015, Christopher Jeffrey, Peter Sunde (MIT License)
+ * Copyright (c) 2016, Daniel Imms (MIT License).
+ * Copyright (c) 2018, Microsoft Corporation (MIT License).
+ *
+ * pty.cc:
+ *   This file is responsible for starting processes
+ *   with pseudo-terminal file descriptors.
+ */
+
+#define _WIN32_WINNT 0x600
+
+#define NODE_ADDON_API_DISABLE_DEPRECATED
+#include <node_api.h>
+#include <assert.h>
+#include <Shlwapi.h> // PathCombine, PathIsRelative
+#include <sstream>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+#include <Windows.h>
+#include <strsafe.h>
+#include "path_util.h"
+#include "conpty.h"
+
+// Taken from the RS5 Windows SDK, but redefined here in case we're targeting <= 17134
+#ifndef PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE
+#define PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE \
+  ProcThreadAttributeValue(22, FALSE, TRUE, FALSE)
+
+typedef VOID* HPCON;
+typedef HRESULT (__stdcall *PFNCREATEPSEUDOCONSOLE)(COORD c, HANDLE hIn, HANDLE hOut, DWORD dwFlags, HPCON* phpcon);
+typedef HRESULT (__stdcall *PFNRESIZEPSEUDOCONSOLE)(HPCON hpc, COORD newSize);
+typedef HRESULT (__stdcall *PFNCLEARPSEUDOCONSOLE)(HPCON hpc);
+typedef void (__stdcall *PFNCLOSEPSEUDOCONSOLE)(HPCON hpc);
+typedef void (__stdcall *PFNRELEASEPSEUDOCONSOLE)(HPCON hpc);
+
+#endif
+
+struct pty_baton {
+  int id;
+  HANDLE hIn;
+  HANDLE hOut;
+  HPCON hpc;
+
+  HANDLE hShell;
+
+  pty_baton(int _id, HANDLE _hIn, HANDLE _hOut, HPCON _hpc) : id(_id), hIn(_hIn), hOut(_hOut), hpc(_hpc) {};
+};
+
+static std::vector<std::unique_ptr<pty_baton>> ptyHandles;
+static volatile LONG ptyCounter;
+
+static pty_baton* get_pty_baton(int id) {
+  auto it = std::find_if(ptyHandles.begin(), ptyHandles.end(), [id](const auto& ptyHandle) {
+    return ptyHandle->id == id;
+  });
+  if (it != ptyHandles.end()) {
+    return it->get();
+  }
+  return nullptr;
+}
+
+static bool remove_pty_baton(int id) {
+  auto it = std::remove_if(ptyHandles.begin(), ptyHandles.end(), [id](const auto& ptyHandle) {
+    return ptyHandle->id == id;
+  });
+  if (it != ptyHandles.end()) {
+    ptyHandles.erase(it);
+    return true;
+  }
+  return false;
+}
+
+struct ExitEvent {
+  int exit_code = 0;
+};
+
+void SetupExitCallback(Napi::Env env, Napi::Function cb, pty_baton* baton) {
+  std::thread *th = new std::thread;
+  // Don't use Napi::AsyncWorker which is limited by UV_THREADPOOL_SIZE.
+  auto tsfn = Napi::ThreadSafeFunction::New(
+      env,
+      cb,                           // JavaScript function called asynchronously
+      "SetupExitCallback_resource", // Name
+      0,                            // Unlimited queue
+      1,                            // Only one thread will use this initially
+      [th](Napi::Env) {   // Finalizer used to clean threads up
+        th->join();
+        delete th;
+      });
+  *th = std::thread([tsfn = std::move(tsfn), baton] {
+    auto callback = [](Napi::Env env, Napi::Function cb, ExitEvent *exit_event) {
+      cb.Call({Napi::Number::New(env, exit_event->exit_code)});
+      delete exit_event;
+    };
+
+    ExitEvent *exit_event = new ExitEvent;
+    // Wait for process to complete.
+    WaitForSingleObject(baton->hShell, INFINITE);
+    // Get process exit code.
+    GetExitCodeProcess(baton->hShell, (LPDWORD)(&exit_event->exit_code));
+    // Clean up handles
+    CloseHandle(baton->hShell);
+    assert(remove_pty_baton(baton->id));
+
+    auto status = tsfn.BlockingCall(exit_event, callback); // In main thread
+    switch (status) {
+      case napi_closing:
+        break;
+
+      case napi_queue_full:
+        Napi::Error::Fatal("SetupExitCallback", "Queue was full");
+
+      case napi_ok:
+        if (tsfn.Release() != napi_ok) {
+          Napi::Error::Fatal("SetupExitCallback", "ThreadSafeFunction.Release() failed");
+        }
+        break;
+
+      default:
+        Napi::Error::Fatal("SetupExitCallback", "ThreadSafeFunction.BlockingCall() failed");
+    }
+  });
+}
+
+Napi::Error errorWithCode(const Napi::CallbackInfo& info, const char* text) {
+  std::stringstream errorText;
+  errorText << text;
+  errorText << ", error code: " << GetLastError();
+  return Napi::Error::New(info.Env(), errorText.str());
+}
+
+// Returns a new server named pipe.  It has not yet been connected.
+bool createDataServerPipe(bool write,
+                          std::wstring kind,
+                          HANDLE* hServer,
+                          std::wstring &name,
+                          const std::wstring &pipeName)
+{
+  *hServer = INVALID_HANDLE_VALUE;
+
+  name = L"\\\\.\\pipe\\" + pipeName + L"-" + kind;
+
+  const DWORD winOpenMode =  PIPE_ACCESS_INBOUND | PIPE_ACCESS_OUTBOUND | FILE_FLAG_FIRST_PIPE_INSTANCE/*  | FILE_FLAG_OVERLAPPED */;
+
+  SECURITY_ATTRIBUTES sa = {};
+  sa.nLength = sizeof(sa);
+
+  *hServer = CreateNamedPipeW(
+      name.c_str(),
+      /*dwOpenMode=*/winOpenMode,
+      /*dwPipeMode=*/PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT,
+      /*nMaxInstances=*/1,
+      /*nOutBufferSize=*/128 * 1024,
+      /*nInBufferSize=*/128 * 1024,
+      /*nDefaultTimeOut=*/30000,
+      &sa);
+
+  return *hServer != INVALID_HANDLE_VALUE;
+}
+
+HANDLE LoadConptyDll(const Napi::CallbackInfo& info,
+                     const bool useConptyDll)
+{
+  if (!useConptyDll) {
+    return LoadLibraryExW(L"kernel32.dll", 0, 0);
+  }
+  wchar_t currentDir[MAX_PATH];
+  HMODULE hModule = GetModuleHandleA("conpty.node");
+  if (hModule == NULL) {
+    throw errorWithCode(info, "Failed to get conpty.node module handle");
+  }
+  DWORD result = GetModuleFileNameW(hModule, currentDir, MAX_PATH);
+  if (result == 0) {
+    throw errorWithCode(info, "Failed to get conpty.node module file name");
+  }
+  PathRemoveFileSpecW(currentDir);
+  wchar_t conptyDllPath[MAX_PATH];
+  PathCombineW(conptyDllPath, currentDir, L"conpty\\conpty.dll");
+  if (!path_util::file_exists(conptyDllPath)) {
+    std::wstring errorMessage = L"Cannot find conpty.dll at " + std::wstring(conptyDllPath);
+    std::string errorMessageStr = path_util::wstring_to_string(errorMessage);
+    throw errorWithCode(info, errorMessageStr.c_str());
+  }
+
+  return LoadLibraryW(conptyDllPath);
+}
+
+HRESULT CreateNamedPipesAndPseudoConsole(const Napi::CallbackInfo& info,
+                                         COORD size,
+                                         DWORD dwFlags,
+                                         HANDLE *phInput,
+                                         HANDLE *phOutput,
+                                         HPCON* phPC,
+                                         std::wstring& inName,
+                                         std::wstring& outName,
+                                         const std::wstring& pipeName,
+                                         const bool useConptyDll)
+{
+  HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
+  DWORD error = GetLastError();
+  bool fLoadedDll = hLibrary != nullptr;
+  if (fLoadedDll)
+  {
+    PFNCREATEPSEUDOCONSOLE const pfnCreate = (PFNCREATEPSEUDOCONSOLE)GetProcAddress(
+        (HMODULE)hLibrary,
+        useConptyDll ? "ConptyCreatePseudoConsole" : "CreatePseudoConsole");
+    if (pfnCreate)
+    {
+      if (phPC == NULL || phInput == NULL || phOutput == NULL)
+      {
+        return E_INVALIDARG;
+      }
+
+      bool success = createDataServerPipe(true, L"in", phInput, inName, pipeName);
+      if (!success)
+      {
+        return HRESULT_FROM_WIN32(GetLastError());
+      }
+      success = createDataServerPipe(false, L"out", phOutput, outName, pipeName);
+      if (!success)
+      {
+        return HRESULT_FROM_WIN32(GetLastError());
+      }
+      return pfnCreate(size, *phInput, *phOutput, dwFlags, phPC);
+    }
+    else
+    {
+      // Failed to find CreatePseudoConsole in kernel32. This is likely because
+      //    the user is not running a build of Windows that supports that API.
+      //    We should fall back to winpty in this case.
+      return HRESULT_FROM_WIN32(GetLastError());
+    }
+  } else {
+    throw errorWithCode(info, "Failed to load conpty.dll");
+  }
+
+  // Failed to find  kernel32. This is realy unlikely - honestly no idea how
+  //    this is even possible to hit. But if it does happen, fall back to winpty.
+  return HRESULT_FROM_WIN32(GetLastError());
+}
+
+static Napi::Value PtyStartProcess(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  Napi::Object marshal;
+  std::wstring inName, outName;
+  BOOL fSuccess = FALSE;
+  std::unique_ptr<wchar_t[]> mutableCommandline;
+  PROCESS_INFORMATION _piClient{};
+
+  if (info.Length() != 7 ||
+      !info[0].IsString() ||
+      !info[1].IsNumber() ||
+      !info[2].IsNumber() ||
+      !info[3].IsBoolean() ||
+      !info[4].IsString() ||
+      !info[5].IsBoolean() ||
+      !info[6].IsBoolean()) {
+    throw Napi::Error::New(env, "Usage: pty.startProcess(file, cols, rows, debug, pipeName, inheritCursor, useConptyDll)");
+  }
+
+  const std::wstring filename(path_util::to_wstring(info[0].As<Napi::String>()));
+  const SHORT cols = static_cast<SHORT>(info[1].As<Napi::Number>().Uint32Value());
+  const SHORT rows = static_cast<SHORT>(info[2].As<Napi::Number>().Uint32Value());
+  const bool debug = info[3].As<Napi::Boolean>().Value();
+  const std::wstring pipeName(path_util::to_wstring(info[4].As<Napi::String>()));
+  const bool inheritCursor = info[5].As<Napi::Boolean>().Value();
+  const bool useConptyDll = info[6].As<Napi::Boolean>().Value();
+
+  // use environment 'Path' variable to determine location of
+  // the relative path that we have recieved (e.g cmd.exe)
+  std::wstring shellpath;
+  if (::PathIsRelativeW(filename.c_str())) {
+    shellpath = path_util::get_shell_path(filename.c_str());
+  } else {
+    shellpath = filename;
+  }
+
+  if (shellpath.empty() || !path_util::file_exists(shellpath)) {
+    std::string why;
+    why += "File not found: ";
+    why += path_util::wstring_to_string(shellpath);
+    throw Napi::Error::New(env, why);
+  }
+
+  HANDLE hIn, hOut;
+  HPCON hpc;
+  HRESULT hr = CreateNamedPipesAndPseudoConsole(info, {cols, rows}, inheritCursor ? 1/*PSEUDOCONSOLE_INHERIT_CURSOR*/ : 0, &hIn, &hOut, &hpc, inName, outName, pipeName, useConptyDll);
+
+  // Restore default handling of ctrl+c
+  SetConsoleCtrlHandler(NULL, FALSE);
+
+  // Set return values
+  marshal = Napi::Object::New(env);
+
+  if (SUCCEEDED(hr)) {
+    // We were able to instantiate a conpty
+    const int ptyId = InterlockedIncrement(&ptyCounter);
+    marshal.Set("pty", Napi::Number::New(env, ptyId));
+    ptyHandles.emplace_back(
+        std::make_unique<pty_baton>(ptyId, hIn, hOut, hpc));
+  } else {
+    throw Napi::Error::New(env, "Cannot launch conpty");
+  }
+
+  std::string inNameStr = path_util::wstring_to_string(inName);
+  if (inNameStr.empty()) {
+    throw Napi::Error::New(env, "Failed to initialize conpty conin");
+  }
+  std::string outNameStr = path_util::wstring_to_string(outName);
+  if (outNameStr.empty()) {
+    throw Napi::Error::New(env, "Failed to initialize conpty conout");
+  }
+
+  marshal.Set("fd", Napi::Number::New(env, -1));
+  marshal.Set("conin", Napi::String::New(env, inNameStr));
+  marshal.Set("conout", Napi::String::New(env, outNameStr));
+  return marshal;
+}
+
+static Napi::Value PtyConnect(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  // If we're working with conpty's we need to call ConnectNamedPipe here AFTER
+  //    the Socket has attempted to connect to the other end, then actually
+  //    spawn the process here.
+
+  std::stringstream errorText;
+  BOOL fSuccess = FALSE;
+
+  if (info.Length() != 6 ||
+      !info[0].IsNumber() ||
+      !info[1].IsString() ||
+      !info[2].IsString() ||
+      !info[3].IsArray() ||
+      !info[4].IsBoolean() ||
+      !info[5].IsFunction()) {
+    throw Napi::Error::New(env, "Usage: pty.connect(id, cmdline, cwd, env, useConptyDll, exitCallback)");
+  }
+
+  const int id = info[0].As<Napi::Number>().Int32Value();
+  const std::wstring cmdline(path_util::to_wstring(info[1].As<Napi::String>()));
+  const std::wstring cwd(path_util::to_wstring(info[2].As<Napi::String>()));
+  const Napi::Array envValues = info[3].As<Napi::Array>();
+  const bool useConptyDll = info[4].As<Napi::Boolean>().Value();
+  Napi::Function exitCallback = info[5].As<Napi::Function>();
+
+  // Fetch pty handle from ID and start process
+  pty_baton* handle = get_pty_baton(id);
+  if (!handle) {
+    throw Napi::Error::New(env, "Invalid pty handle");
+  }
+
+  // Prepare command line
+  std::unique_ptr<wchar_t[]> mutableCommandline = std::make_unique<wchar_t[]>(cmdline.length() + 1);
+  HRESULT hr = StringCchCopyW(mutableCommandline.get(), cmdline.length() + 1, cmdline.c_str());
+
+  // Prepare cwd
+  std::unique_ptr<wchar_t[]> mutableCwd = std::make_unique<wchar_t[]>(cwd.length() + 1);
+  hr = StringCchCopyW(mutableCwd.get(), cwd.length() + 1, cwd.c_str());
+
+  // Prepare environment
+  std::wstring envStr;
+  if (!envValues.IsEmpty()) {
+    std::wstring envBlock;
+    for(uint32_t i = 0; i < envValues.Length(); i++) {
+      envBlock += path_util::to_wstring(envValues.Get(i).As<Napi::String>());
+      envBlock += L'\0';
+    }
+    envBlock += L'\0';
+    envStr = std::move(envBlock);
+  }
+  std::vector<wchar_t> envV(envStr.cbegin(), envStr.cend());
+  LPWSTR envArg = envV.empty() ? nullptr : envV.data();
+
+  ConnectNamedPipe(handle->hIn, nullptr);
+  ConnectNamedPipe(handle->hOut, nullptr);
+
+  // Attach the pseudoconsole to the client application we're creating
+  STARTUPINFOEXW siEx{0};
+  siEx.StartupInfo.cb = sizeof(STARTUPINFOEXW);
+  siEx.StartupInfo.dwFlags |= STARTF_USESTDHANDLES;
+  siEx.StartupInfo.hStdError = nullptr;
+  siEx.StartupInfo.hStdInput = nullptr;
+  siEx.StartupInfo.hStdOutput = nullptr;
+
+  SIZE_T size = 0;
+  InitializeProcThreadAttributeList(NULL, 1, 0, &size);
+  BYTE *attrList = new BYTE[size];
+  siEx.lpAttributeList = reinterpret_cast<PPROC_THREAD_ATTRIBUTE_LIST>(attrList);
+
+  fSuccess = InitializeProcThreadAttributeList(siEx.lpAttributeList, 1, 0, &size);
+  if (!fSuccess) {
+    throw errorWithCode(info, "InitializeProcThreadAttributeList failed");
+  }
+  fSuccess = UpdateProcThreadAttribute(siEx.lpAttributeList,
+                                       0,
+                                       PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+                                       handle->hpc,
+                                       sizeof(HPCON),
+                                       NULL,
+                                       NULL);
+  if (!fSuccess) {
+    throw errorWithCode(info, "UpdateProcThreadAttribute failed");
+  }
+
+  PROCESS_INFORMATION piClient{};
+  fSuccess = !!CreateProcessW(
+      nullptr,
+      mutableCommandline.get(),
+      nullptr,                      // lpProcessAttributes
+      nullptr,                      // lpThreadAttributes
+      false,                        // bInheritHandles VERY IMPORTANT that this is false
+      EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT, // dwCreationFlags
+      envArg,                       // lpEnvironment
+      mutableCwd.get(),             // lpCurrentDirectory
+      &siEx.StartupInfo,            // lpStartupInfo
+      &piClient                     // lpProcessInformation
+  );
+  if (!fSuccess) {
+    throw errorWithCode(info, "Cannot create process");
+  }
+
+  HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
+  bool fLoadedDll = hLibrary != nullptr;
+  if (useConptyDll && fLoadedDll)
+  {
+    PFNRELEASEPSEUDOCONSOLE const pfnReleasePseudoConsole = (PFNRELEASEPSEUDOCONSOLE)GetProcAddress(
+      (HMODULE)hLibrary, "ConptyReleasePseudoConsole");
+    if (pfnReleasePseudoConsole)
+    {
+      pfnReleasePseudoConsole(handle->hpc);
+    }
+  }
+
+  // Update handle
+  handle->hShell = piClient.hProcess;
+
+  // Close the thread handle to avoid resource leak
+  CloseHandle(piClient.hThread);
+  // Close the input read and output write handle of the pseudoconsole
+  CloseHandle(handle->hIn);
+  CloseHandle(handle->hOut);
+
+  SetupExitCallback(env, exitCallback, handle);
+
+  // Return
+  auto marshal = Napi::Object::New(env);
+  marshal.Set("pid", Napi::Number::New(env, piClient.dwProcessId));
+  return marshal;
+}
+
+static Napi::Value PtyResize(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 4 ||
+      !info[0].IsNumber() ||
+      !info[1].IsNumber() ||
+      !info[2].IsNumber() ||
+      !info[3].IsBoolean()) {
+    throw Napi::Error::New(env, "Usage: pty.resize(id, cols, rows, useConptyDll)");
+  }
+
+  int id = info[0].As<Napi::Number>().Int32Value();
+  SHORT cols = static_cast<SHORT>(info[1].As<Napi::Number>().Uint32Value());
+  SHORT rows = static_cast<SHORT>(info[2].As<Napi::Number>().Uint32Value());
+  const bool useConptyDll = info[3].As<Napi::Boolean>().Value();
+
+  const pty_baton* handle = get_pty_baton(id);
+
+  if (handle != nullptr) {
+    HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
+    bool fLoadedDll = hLibrary != nullptr;
+    if (fLoadedDll)
+    {
+      PFNRESIZEPSEUDOCONSOLE const pfnResizePseudoConsole = (PFNRESIZEPSEUDOCONSOLE)GetProcAddress(
+        (HMODULE)hLibrary,
+        useConptyDll ? "ConptyResizePseudoConsole" : "ResizePseudoConsole");
+      if (pfnResizePseudoConsole)
+      {
+        COORD size = {cols, rows};
+        pfnResizePseudoConsole(handle->hpc, size);
+      }
+    }
+  }
+
+  return env.Undefined();
+}
+
+static Napi::Value PtyClear(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 2 ||
+      !info[0].IsNumber() ||
+      !info[1].IsBoolean()) {
+    throw Napi::Error::New(env, "Usage: pty.clear(id, useConptyDll)");
+  }
+
+  int id = info[0].As<Napi::Number>().Int32Value();
+  const bool useConptyDll = info[1].As<Napi::Boolean>().Value();
+
+  // This API is only supported for conpty.dll as it was introduced in a later version of Windows.
+  // We could hook it up to point at >= a version of Windows only, but the future is conpty.dll
+  // anyway.
+  if (!useConptyDll) {
+    return env.Undefined();
+  }
+
+  const pty_baton* handle = get_pty_baton(id);
+
+  if (handle != nullptr) {
+    HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
+    bool fLoadedDll = hLibrary != nullptr;
+    if (fLoadedDll)
+    {
+      PFNCLEARPSEUDOCONSOLE const pfnClearPseudoConsole = (PFNCLEARPSEUDOCONSOLE)GetProcAddress((HMODULE)hLibrary, "ConptyClearPseudoConsole");
+      if (pfnClearPseudoConsole)
+      {
+        pfnClearPseudoConsole(handle->hpc);
+      }
+    }
+  }
+
+  return env.Undefined();
+}
+
+static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 2 ||
+      !info[0].IsNumber() ||
+      !info[1].IsBoolean()) {
+    throw Napi::Error::New(env, "Usage: pty.kill(id, useConptyDll)");
+  }
+
+  int id = info[0].As<Napi::Number>().Int32Value();
+  const bool useConptyDll = info[1].As<Napi::Boolean>().Value();
+
+  const pty_baton* handle = get_pty_baton(id);
+
+  if (handle != nullptr) {
+    HANDLE hLibrary = LoadConptyDll(info, useConptyDll);
+    bool fLoadedDll = hLibrary != nullptr;
+    if (fLoadedDll)
+    {
+      PFNCLOSEPSEUDOCONSOLE const pfnClosePseudoConsole = (PFNCLOSEPSEUDOCONSOLE)GetProcAddress(
+        (HMODULE)hLibrary,
+        useConptyDll ? "ConptyClosePseudoConsole" : "ClosePseudoConsole");
+      if (pfnClosePseudoConsole)
+      {
+        pfnClosePseudoConsole(handle->hpc);
+      }
+    }
+    if (useConptyDll) {
+      TerminateProcess(handle->hShell, 1);
+    }
+  }
+
+  return env.Undefined();
+}
+
+/**
+* Init
+*/
+
+Napi::Object init(Napi::Env env, Napi::Object exports) {
+  exports.Set("startProcess", Napi::Function::New(env, PtyStartProcess));
+  exports.Set("connect", Napi::Function::New(env, PtyConnect));
+  exports.Set("resize", Napi::Function::New(env, PtyResize));
+  exports.Set("clear", Napi::Function::New(env, PtyClear));
+  exports.Set("kill", Napi::Function::New(env, PtyKill));
+  return exports;
+};
+
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, init);

--- a/web/vendored-pty/src/win/conpty.h
+++ b/web/vendored-pty/src/win/conpty.h
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// This header prototypes the Pseudoconsole symbols from conpty.lib with their original names.
+// This is required because we cannot import __imp_CreatePseudoConsole from a static library
+// as it doesn't produce an import lib.
+// We can't use an /ALTERNATENAME trick because it seems that that name is only resolved when the
+// linker cannot otherwise find the symbol.
+
+#pragma once
+
+#include <consoleapi.h>
+
+#ifndef CONPTY_IMPEXP
+#define CONPTY_IMPEXP __declspec(dllimport)
+#endif
+
+#ifndef CONPTY_EXPORT
+#ifdef __cplusplus
+#define CONPTY_EXPORT extern "C" CONPTY_IMPEXP
+#else
+#define CONPTY_EXPORT extern CONPTY_IMPEXP
+#endif
+#endif
+
+#define PSEUDOCONSOLE_RESIZE_QUIRK (2u)
+#define PSEUDOCONSOLE_PASSTHROUGH_MODE (8u)
+
+CONPTY_EXPORT HRESULT WINAPI ConptyCreatePseudoConsole(COORD size, HANDLE hInput, HANDLE hOutput, DWORD dwFlags, HPCON* phPC);
+CONPTY_EXPORT HRESULT WINAPI ConptyCreatePseudoConsoleAsUser(HANDLE hToken, COORD size, HANDLE hInput, HANDLE hOutput, DWORD dwFlags, HPCON* phPC);
+
+CONPTY_EXPORT HRESULT WINAPI ConptyResizePseudoConsole(HPCON hPC, COORD size);
+CONPTY_EXPORT HRESULT WINAPI ConptyClearPseudoConsole(HPCON hPC);
+CONPTY_EXPORT HRESULT WINAPI ConptyShowHidePseudoConsole(HPCON hPC, bool show);
+CONPTY_EXPORT HRESULT WINAPI ConptyReparentPseudoConsole(HPCON hPC, HWND newParent);
+CONPTY_EXPORT HRESULT WINAPI ConptyReleasePseudoConsole(HPCON hPC);
+
+CONPTY_EXPORT VOID WINAPI ConptyClosePseudoConsole(HPCON hPC);
+CONPTY_EXPORT VOID WINAPI ConptyClosePseudoConsoleTimeout(HPCON hPC, DWORD dwMilliseconds);
+
+CONPTY_EXPORT HRESULT WINAPI ConptyPackPseudoConsole(HANDLE hServerProcess, HANDLE hRef, HANDLE hSignal, HPCON* phPC);

--- a/web/vendored-pty/src/win/conpty_console_list.cc
+++ b/web/vendored-pty/src/win/conpty_console_list.cc
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2019, Microsoft Corporation (MIT License).
+ */
+
+#define NODE_ADDON_API_DISABLE_DEPRECATED
+#include <napi.h>
+#include <windows.h>
+
+static Napi::Value ApiConsoleProcessList(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  if (info.Length() != 1 ||
+      !info[0].IsNumber()) {
+    throw Napi::Error::New(env, "Usage: getConsoleProcessList(shellPid)");
+  }
+
+  const DWORD pid = info[0].As<Napi::Number>().Uint32Value();
+
+  if (!FreeConsole()) {
+    throw Napi::Error::New(env, "FreeConsole failed");
+  }
+  if (!AttachConsole(pid)) {
+    throw Napi::Error::New(env, "AttachConsole failed");
+  }
+  auto processList = std::vector<DWORD>(64);
+  auto processCount = GetConsoleProcessList(&processList[0], static_cast<DWORD>(processList.size()));
+  if (processList.size() < processCount) {
+      processList.resize(processCount);
+      processCount = GetConsoleProcessList(&processList[0], static_cast<DWORD>(processList.size()));
+  }
+  FreeConsole();
+
+  Napi::Array result = Napi::Array::New(env);
+  for (DWORD i = 0; i < processCount; i++) {
+    result.Set(i, Napi::Number::New(env, processList[i]));
+  }
+  return result;
+}
+
+Napi::Object init(Napi::Env env, Napi::Object exports) {
+  exports.Set("getConsoleProcessList", Napi::Function::New(env, ApiConsoleProcessList));
+  return exports;
+};
+
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, init);

--- a/web/vendored-pty/src/win/path_util.cc
+++ b/web/vendored-pty/src/win/path_util.cc
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2013-2015, Christopher Jeffrey, Peter Sunde (MIT License)
+ * Copyright (c) 2016, Daniel Imms (MIT License).
+ * Copyright (c) 2018, Microsoft Corporation (MIT License).
+ */
+
+#include <stdexcept>
+#include <Shlwapi.h> // PathCombine
+#include <Windows.h>
+#include "path_util.h"
+
+namespace path_util {
+
+std::wstring to_wstring(const Napi::String& str) {
+  const std::u16string & u16 = str.Utf16Value();
+  return std::wstring(u16.begin(), u16.end());
+}
+
+std::string wstring_to_string(const std::wstring &wide_string) {
+  if (wide_string.empty()) {
+    return "";
+  }
+  const auto size_needed = WideCharToMultiByte(CP_UTF8, 0, &wide_string.at(0), (int)wide_string.size(), nullptr, 0, nullptr, nullptr);
+  if (size_needed <= 0) {
+    return "";
+  }
+  std::string result(size_needed, 0);
+  WideCharToMultiByte(CP_UTF8, 0, &wide_string.at(0), (int)wide_string.size(), &result.at(0), size_needed, nullptr, nullptr);
+  return result;
+}
+
+const char* from_wstring(const wchar_t* wstr) {
+  int bufferSize = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, NULL, 0, NULL, NULL);
+  if (bufferSize <= 0) {
+    return "";
+  }
+  char *output = new char[bufferSize];
+  int status = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, output, bufferSize, NULL, NULL);
+  if (status == 0) {
+    return "";
+  }
+  return output;
+}
+
+bool file_exists(std::wstring filename) {
+  DWORD attr = ::GetFileAttributesW(filename.c_str());
+  if (attr == INVALID_FILE_ATTRIBUTES || (attr & FILE_ATTRIBUTE_DIRECTORY)) {
+    return false;
+  }
+  return true;
+}
+
+// cmd.exe -> C:\Windows\system32\cmd.exe
+std::wstring get_shell_path(std::wstring filename) {
+  std::wstring shellpath;
+
+  if (file_exists(filename)) {
+    return shellpath;
+  }
+
+  wchar_t* buffer_ = new wchar_t[MAX_ENV];
+  int read = ::GetEnvironmentVariableW(L"Path", buffer_, MAX_ENV);
+  if (read) {
+    std::wstring delimiter = L";";
+    size_t pos = 0;
+    std::vector<std::wstring> paths;
+    std::wstring buffer(buffer_);
+    while ((pos = buffer.find(delimiter)) != std::wstring::npos) {
+      paths.push_back(buffer.substr(0, pos));
+      buffer.erase(0, pos + delimiter.length());
+    }
+
+    const wchar_t *filename_ = filename.c_str();
+
+    for (size_t i = 0; i < paths.size(); ++i) {
+      std::wstring path = paths[i];
+      wchar_t searchPath[MAX_PATH];
+      ::PathCombineW(searchPath, const_cast<wchar_t*>(path.c_str()), filename_);
+
+      if (searchPath == NULL) {
+        continue;
+      }
+
+      if (file_exists(searchPath)) {
+        shellpath = searchPath;
+        break;
+      }
+    }
+  }
+
+  delete[] buffer_;
+  return shellpath;
+}
+
+}  // namespace path_util

--- a/web/vendored-pty/src/win/path_util.h
+++ b/web/vendored-pty/src/win/path_util.h
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2013-2015, Christopher Jeffrey, Peter Sunde (MIT License)
+ * Copyright (c) 2016, Daniel Imms (MIT License).
+ * Copyright (c) 2018, Microsoft Corporation (MIT License).
+ */
+
+#ifndef NODE_PTY_PATH_UTIL_H_
+#define NODE_PTY_PATH_UTIL_H_
+
+#define NODE_ADDON_API_DISABLE_DEPRECATED
+#include <napi.h>
+#include <string>
+
+#define MAX_ENV 65536
+
+namespace path_util {
+
+std::wstring to_wstring(const Napi::String& str);
+std::string wstring_to_string(const std::wstring &wide_string);
+const char* from_wstring(const wchar_t* wstr);
+bool file_exists(std::wstring filename);
+std::wstring get_shell_path(std::wstring filename);
+
+}  // namespace path_util
+
+#endif  // NODE_PTY_PATH_UTIL_H_

--- a/web/vendored-pty/src/win/winpty.cc
+++ b/web/vendored-pty/src/win/winpty.cc
@@ -1,0 +1,333 @@
+/**
+ * Copyright (c) 2013-2015, Christopher Jeffrey, Peter Sunde (MIT License)
+ * Copyright (c) 2016, Daniel Imms (MIT License).
+ * Copyright (c) 2018, Microsoft Corporation (MIT License).
+ *
+ * pty.cc:
+ *   This file is responsible for starting processes
+ *   with pseudo-terminal file descriptors.
+ */
+
+#define NODE_ADDON_API_DISABLE_DEPRECATED
+#include <napi.h>
+#include <iostream>
+#include <assert.h>
+#include <map>
+#include <Shlwapi.h> // PathCombine, PathIsRelative
+#include <sstream>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <vector>
+#include <winpty.h>
+
+#include "path_util.h"
+
+/**
+* Misc
+*/
+#define WINPTY_DBG_VARIABLE TEXT("WINPTYDBG")
+
+/**
+* winpty
+*/
+static std::vector<winpty_t *> ptyHandles;
+static volatile LONG ptyCounter;
+
+/**
+* Helpers
+*/
+
+/** Keeps track of the handles created by PtyStartProcess */
+static std::map<DWORD, HANDLE> createdHandles;
+
+static winpty_t *get_pipe_handle(DWORD pid) {
+  for (size_t i = 0; i < ptyHandles.size(); ++i) {
+    winpty_t *ptyHandle = ptyHandles[i];
+    HANDLE current = winpty_agent_process(ptyHandle);
+    if (GetProcessId(current) == pid) {
+      return ptyHandle;
+    }
+  }
+  return nullptr;
+}
+
+static bool remove_pipe_handle(DWORD pid) {
+  for (size_t i = 0; i < ptyHandles.size(); ++i) {
+    winpty_t *ptyHandle = ptyHandles[i];
+    HANDLE current = winpty_agent_process(ptyHandle);
+    if (GetProcessId(current) == pid) {
+      winpty_free(ptyHandle);
+      ptyHandles.erase(ptyHandles.begin() + i);
+      ptyHandle = nullptr;
+      return true;
+    }
+  }
+  return false;
+}
+
+Napi::Error error_with_winpty_msg(const char *generalMsg, winpty_error_ptr_t error_ptr, Napi::Env env) {
+  std::string why;
+  why += generalMsg;
+  why += ": ";
+  why += path_util::wstring_to_string(winpty_error_msg(error_ptr));
+  winpty_error_free(error_ptr);
+  return Napi::Error::New(env, why);
+}
+
+static Napi::Value PtyGetExitCode(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 1 ||
+      !info[0].IsNumber()) {
+    throw Napi::Error::New(env, "Usage: pty.getExitCode(pid)");
+  }
+
+  DWORD pid = info[0].As<Napi::Number>().Uint32Value();
+  HANDLE handle = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, pid);
+  if (handle == NULL) {
+    return Napi::Number::New(env, -1);
+  }
+
+  DWORD exitCode = 0;
+  BOOL success = GetExitCodeProcess(handle, &exitCode);
+  if (success == FALSE) {
+    exitCode = -1;
+  }
+
+  CloseHandle(handle);
+  return Napi::Number::New(env, exitCode);
+}
+
+static Napi::Value PtyGetProcessList(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 1 ||
+      !info[0].IsNumber()) {
+    throw Napi::Error::New(env, "Usage: pty.getProcessList(pid)");
+  }
+
+  DWORD pid = info[0].As<Napi::Number>().Uint32Value();
+  winpty_t *pc = get_pipe_handle(pid);
+  if (pc == nullptr) {
+    return Napi::Number::New(env, 0);
+  }
+  int processList[64];
+  const int processCount = 64;
+  int actualCount = winpty_get_console_process_list(pc, processList, processCount, nullptr);
+  if (actualCount <= 0) {
+    return Napi::Number::New(env, 0);
+  }
+  Napi::Array result = Napi::Array::New(env, actualCount);
+  for (int i = 0; i < actualCount; i++) {
+    result.Set(i, Napi::Number::New(env, processList[i]));
+  }
+  return result;
+}
+
+static Napi::Value PtyStartProcess(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 7 ||
+      !info[0].IsString() ||
+      !info[1].IsString() ||
+      !info[2].IsArray() ||
+      !info[3].IsString() ||
+      !info[4].IsNumber() ||
+      !info[5].IsNumber() ||
+      !info[6].IsBoolean()) {
+    throw Napi::Error::New(env, "Usage: pty.startProcess(file, cmdline, env, cwd, cols, rows, debug)");
+  }
+
+  std::wstring filename(path_util::to_wstring(info[0].As<Napi::String>()));
+  std::wstring cmdline(path_util::to_wstring(info[1].As<Napi::String>()));
+  std::wstring cwd(path_util::to_wstring(info[3].As<Napi::String>()));
+
+  // create environment block
+  std::wstring envStr;
+  const Napi::Array envValues = info[2].As<Napi::Array>();
+  if (!envValues.IsEmpty()) {
+    std::wstring envBlock;
+    for(uint32_t i = 0; i < envValues.Length(); i++) {
+      envBlock += path_util::to_wstring(envValues.Get(i).As<Napi::String>());
+      envBlock += L'\0';
+    }
+    envStr = std::move(envBlock);
+  }
+
+  // use environment 'Path' variable to determine location of
+  // the relative path that we have recieved (e.g cmd.exe)
+  std::wstring shellpath;
+  if (::PathIsRelativeW(filename.c_str())) {
+    shellpath = path_util::get_shell_path(filename);
+  } else {
+    shellpath = filename;
+  }
+
+  if (shellpath.empty() || !path_util::file_exists(shellpath)) {
+    std::string why;
+    why += "File not found: ";
+    why += path_util::wstring_to_string(shellpath);
+    throw Napi::Error::New(env, why);
+  }
+
+  int cols = info[4].As<Napi::Number>().Int32Value();
+  int rows = info[5].As<Napi::Number>().Int32Value();
+  bool debug = info[6].As<Napi::Boolean>().Value();
+
+  // Enable/disable debugging
+  SetEnvironmentVariable(WINPTY_DBG_VARIABLE, debug ? "1" : NULL); // NULL = deletes variable
+
+  // Create winpty config
+  winpty_error_ptr_t error_ptr = nullptr;
+  winpty_config_t* winpty_config = winpty_config_new(0, &error_ptr);
+  if (winpty_config == nullptr) {
+    throw error_with_winpty_msg("Error creating WinPTY config", error_ptr, env);
+  }
+  winpty_error_free(error_ptr);
+
+  // Set pty size on config
+  winpty_config_set_initial_size(winpty_config, cols, rows);
+
+  // Start the pty agent
+  winpty_t *pc = winpty_open(winpty_config, &error_ptr);
+  winpty_config_free(winpty_config);
+  if (pc == nullptr) {
+    throw error_with_winpty_msg("Error launching WinPTY agent", error_ptr, env);
+  }
+  winpty_error_free(error_ptr);
+
+  // Create winpty spawn config
+  winpty_spawn_config_t* config = winpty_spawn_config_new(WINPTY_SPAWN_FLAG_AUTO_SHUTDOWN, shellpath.c_str(), cmdline.c_str(), cwd.c_str(), envStr.c_str(), &error_ptr);
+  if (config == nullptr) {
+    winpty_free(pc);
+    throw error_with_winpty_msg("Error creating WinPTY spawn config", error_ptr, env);
+  }
+  winpty_error_free(error_ptr);
+
+  // Spawn the new process
+  HANDLE handle = nullptr;
+  BOOL spawnSuccess = winpty_spawn(pc, config, &handle, nullptr, nullptr, &error_ptr);
+  winpty_spawn_config_free(config);
+  if (!spawnSuccess) {
+    if (handle) {
+      CloseHandle(handle);
+    }
+    winpty_free(pc);
+    throw error_with_winpty_msg("Unable to start terminal process", error_ptr, env);
+  }
+  winpty_error_free(error_ptr);
+
+  LPCWSTR coninPipeName = winpty_conin_name(pc);
+  std::string coninPipeNameStr(path_util::from_wstring(coninPipeName));
+  if (coninPipeNameStr.empty()) {
+    CloseHandle(handle);
+    winpty_free(pc);
+    throw Napi::Error::New(env, "Failed to initialize winpty conin");
+  }
+
+  LPCWSTR conoutPipeName = winpty_conout_name(pc);
+  std::string conoutPipeNameStr(path_util::from_wstring(conoutPipeName));
+  if (conoutPipeNameStr.empty()) {
+    CloseHandle(handle);
+    winpty_free(pc);
+    throw Napi::Error::New(env, "Failed to initialize winpty conout");
+  }
+
+  DWORD innerPid = GetProcessId(handle);
+  if (createdHandles[innerPid]) {
+    CloseHandle(handle);
+    winpty_free(pc);
+    std::stringstream why;
+    why << "There is already a process with innerPid " << innerPid;
+    throw Napi::Error::New(env, why.str());
+  }
+  createdHandles[innerPid] = handle;
+
+  // Save pty struct for later use
+  ptyHandles.push_back(pc);
+
+  DWORD pid = GetProcessId(winpty_agent_process(pc));
+  Napi::Object marshal = Napi::Object::New(env);
+  marshal.Set("innerPid", Napi::Number::New(env, (int)innerPid));
+  marshal.Set("pid", Napi::Number::New(env, (int)pid));
+  marshal.Set("pty", Napi::Number::New(env, InterlockedIncrement(&ptyCounter)));
+  marshal.Set("fd", Napi::Number::New(env, -1));
+  marshal.Set("conin", Napi::String::New(env, coninPipeNameStr));
+  marshal.Set("conout", Napi::String::New(env, conoutPipeNameStr));
+
+  return marshal;
+}
+
+static Napi::Value PtyResize(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 3 ||
+      !info[0].IsNumber() ||
+      !info[1].IsNumber() ||
+      !info[2].IsNumber()) {
+    throw Napi::Error::New(env, "Usage: pty.resize(pid, cols, rows)");
+  }
+
+  DWORD pid = info[0].As<Napi::Number>().Uint32Value();
+  int cols = info[1].As<Napi::Number>().Int32Value();
+  int rows = info[2].As<Napi::Number>().Int32Value();
+
+  winpty_t *pc = get_pipe_handle(pid);
+
+  if (pc == nullptr) {
+    throw Napi::Error::New(env, "The pty doesn't appear to exist");
+  }
+  BOOL success = winpty_set_size(pc, cols, rows, nullptr);
+  if (!success) {
+    throw Napi::Error::New(env, "The pty could not be resized");
+  }
+
+  return env.Undefined();
+}
+
+static Napi::Value PtyKill(const Napi::CallbackInfo& info) {
+  Napi::Env env(info.Env());
+  Napi::HandleScope scope(env);
+
+  if (info.Length() != 2 ||
+      !info[0].IsNumber() ||
+      !info[1].IsNumber()) {
+    throw Napi::Error::New(env, "Usage: pty.kill(pid, innerPid)");
+  }
+
+  DWORD pid = info[0].As<Napi::Number>().Uint32Value();
+  DWORD innerPid = info[1].As<Napi::Number>().Uint32Value();
+
+  winpty_t *pc = get_pipe_handle(pid);
+  if (pc == nullptr) {
+    throw Napi::Error::New(env, "Pty seems to have been killed already");
+  }
+
+  assert(remove_pipe_handle(pid));
+
+  HANDLE innerPidHandle = createdHandles[innerPid];
+  createdHandles.erase(innerPid);
+  CloseHandle(innerPidHandle);
+
+  return env.Undefined();
+}
+
+/**
+* Init
+*/
+
+Napi::Object init(Napi::Env env, Napi::Object exports) {
+  exports.Set("startProcess", Napi::Function::New(env, PtyStartProcess));
+  exports.Set("resize", Napi::Function::New(env, PtyResize));
+  exports.Set("kill", Napi::Function::New(env, PtyKill));
+  exports.Set("getExitCode", Napi::Function::New(env, PtyGetExitCode));
+  exports.Set("getProcessList", Napi::Function::New(env, PtyGetProcessList));
+  return exports;
+};
+
+NODE_API_MODULE(NODE_GYP_MODULE_NAME, init);

--- a/web/vendored-pty/src/windowsTerminal.ts
+++ b/web/vendored-pty/src/windowsTerminal.ts
@@ -1,0 +1,214 @@
+/**
+ * Simplified Windows terminal implementation without threading
+ * Removed ConoutSocketWorker and shared pipe architecture
+ */
+
+import * as fs from 'fs';
+import { Socket } from 'net';
+import { Terminal, DEFAULT_COLS, DEFAULT_ROWS } from './terminal';
+import { IPtyOpenOptions, IWindowsPtyForkOptions } from './interfaces';
+import { ArgvOrCommandLine } from './types';
+import { assign } from './utils';
+
+const DEFAULT_FILE = 'cmd.exe';
+const DEFAULT_NAME = 'Windows Shell';
+
+// Native module interfaces
+interface IConptyProcess {
+  pty: number;
+  fd: number;
+  conin: string;
+  conout: string;
+}
+
+interface IConptyNative {
+  startProcess(file: string, cols: number, rows: number, debug: boolean, pipeName: string, inheritCursor: boolean, useConptyDll: boolean): IConptyProcess;
+  connect(pty: number, commandLine: string, cwd: string, env: string[], useConptyDll: boolean, onExit: (exitCode: number) => void): { pid: number };
+  resize(pty: number, cols: number, rows: number, useConptyDll: boolean): void;
+  clear(pty: number, useConptyDll: boolean): void;
+  kill(pty: number, useConptyDll: boolean): void;
+}
+
+let conptyNative: IConptyNative;
+
+export class WindowsTerminal extends Terminal {
+  private _isReady: boolean = false;
+  protected _pid: number = 0;
+  private _innerPid: number = 0;
+  private _ptyNative: IConptyNative;
+  protected _pty: number;
+  private _inSocket!: Socket;
+  private _outSocket!: Socket;
+  private _exitCode: number | undefined;
+  private _useConptyDll: boolean = false;
+
+  public get master(): Socket | undefined { return this._outSocket; }
+  public get slave(): Socket | undefined { return this._inSocket; }
+
+  constructor(file?: string, args?: ArgvOrCommandLine, opt?: IWindowsPtyForkOptions) {
+    super(opt);
+
+    // Load native module
+    if (!conptyNative) {
+      try {
+        conptyNative = require('../build/Release/conpty.node');
+      } catch (outerError) {
+        try {
+          conptyNative = require('../build/Debug/conpty.node');
+        } catch (innerError) {
+          throw outerError;
+        }
+      }
+    }
+    this._ptyNative = conptyNative;
+
+    // Initialize arguments
+    args = args || [];
+    file = file || DEFAULT_FILE;
+    opt = opt || {};
+    opt.env = opt.env || process.env;
+
+    const env = assign({}, opt.env);
+    this._cols = opt.cols || DEFAULT_COLS;
+    this._rows = opt.rows || DEFAULT_ROWS;
+    const cwd = opt.cwd || process.cwd();
+    const parsedEnv = this._parseEnv(env);
+
+    // Compose command line
+    const commandLine = this._argsToCommandLine(file, args);
+
+    // Start ConPTY process
+    const pipeName = this._generatePipeName();
+    const term = this._ptyNative.startProcess(file, this._cols, this._rows, false, pipeName, false, this._useConptyDll);
+    
+    this._pty = term.pty;
+    this._fd = term.fd;
+
+    // Create direct socket connections without worker threads
+    this._setupDirectSockets(term);
+
+    // Connect the process
+    const connect = this._ptyNative.connect(this._pty, commandLine, cwd, parsedEnv, this._useConptyDll, (exitCode) => {
+      this._exitCode = exitCode;
+      this.emit('exit', exitCode);
+      this._close();
+    });
+    this._innerPid = connect.pid;
+    this._pid = connect.pid;
+
+    this._file = file;
+    this._name = opt.name || env.TERM || DEFAULT_NAME;
+    this._readable = true;
+    this._writable = true;
+
+    this._forwardEvents();
+  }
+
+  private _setupDirectSockets(term: IConptyProcess): void {
+    // Setup output socket - read directly from conout
+    const outFd = fs.openSync(term.conout, 'r');
+    this._outSocket = new Socket({ fd: outFd, readable: true, writable: false });
+    this._outSocket.setEncoding('utf8');
+    this._socket = this._outSocket;
+
+    // Setup input socket - write directly to conin
+    const inFd = fs.openSync(term.conin, 'w');
+    this._inSocket = new Socket({ fd: inFd, readable: false, writable: true });
+    this._inSocket.setEncoding('utf8');
+
+    // Forward events directly
+    this._outSocket.on('data', (data) => {
+      if (!this._isReady) {
+        this._isReady = true;
+      }
+      this.emit('data', data);
+    });
+
+    this._outSocket.on('error', (err) => {
+      if ((err as any).code && ((err as any).code.includes('EPIPE') || (err as any).code.includes('EIO'))) {
+        // Expected errors when process exits
+        return;
+      }
+      this.emit('error', err);
+    });
+
+    this._outSocket.on('close', () => {
+      if (this._exitCode === undefined) {
+        this.emit('exit', 0);
+      }
+      this._close();
+    });
+  }
+
+  protected _write(data: string): void {
+    if (this._inSocket && this._inSocket.writable) {
+      this._inSocket.write(data);
+    }
+  }
+
+  public resize(cols: number, rows: number): void {
+    if (cols <= 0 || rows <= 0 || isNaN(cols) || isNaN(rows) || cols === Infinity || rows === Infinity) {
+      throw new Error('resizing must be done using positive cols and rows');
+    }
+    if (this._exitCode !== undefined) {
+      throw new Error('Cannot resize a pty that has already exited');
+    }
+    this._cols = cols;
+    this._rows = rows;
+    this._ptyNative.resize(this._pty, cols, rows, this._useConptyDll);
+  }
+
+  public clear(): void {
+    this._ptyNative.clear(this._pty, this._useConptyDll);
+  }
+
+  public kill(signal?: string): void {
+    this._close();
+    try {
+      process.kill(this._pid);
+    } catch (e) {
+      // Ignore if process cannot be found
+    }
+    this._ptyNative.kill(this._pty, this._useConptyDll);
+  }
+
+  protected _close(): void {
+    if (this._inSocket) {
+      this._inSocket.destroy();
+    }
+    if (this._outSocket) {
+      this._outSocket.destroy();
+    }
+  }
+
+  private _generatePipeName(): string {
+    return `\\\\.\\pipe\\conpty-${Date.now()}-${Math.random()}`;
+  }
+
+  private _argsToCommandLine(file: string, args: ArgvOrCommandLine): string {
+    if (typeof args === 'string') {
+      return `${file} ${args}`;
+    }
+    const argv = [file];
+    if (args) {
+      argv.push(...args);
+    }
+    return argv.map(arg => {
+      if (arg.includes(' ') || arg.includes('\t')) {
+        return `"${arg.replace(/"/g, '\\"')}"`;
+      }
+      return arg;
+    }).join(' ');
+  }
+
+  public static open(options?: IPtyOpenOptions): void {
+    throw new Error('open() not supported on windows, use spawn() instead.');
+  }
+
+  public get process(): string { return this._name; }
+  public get pid(): number { return this._pid; }
+
+  public destroy(): void {
+    this.kill();
+  }
+}

--- a/web/vendored-pty/tsconfig.json
+++ b/web/vendored-pty/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "declaration": true,
+    "outDir": "./lib",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary
- Replaced Microsoft's node-pty with a vendored fork that removes the problematic shared pipe architecture
- This fixes crashes in VS Code and other Electron applications when VibeTunnel writes large amounts of data
- Maintains full API compatibility - no code changes required

## Problem
Microsoft's node-pty uses a `ConoutSocketWorker` that creates a shared pipe where all PTY instances write. When VibeTunnel writes large amounts of terminal data, it overwhelms this shared infrastructure, causing other Electron processes (like VS Code) to crash.

As discovered in the debugging session, the issue is:
> "When the worker/pipe is shared and every PTY wraps it, all messages are received by everyone. The Electron worker sitting on the pipe gets all messages from VibeTunnel, which writes many, many messages, causing the crash."

## Solution
Created a minimal fork of node-pty that:
- ✅ Removes `ConoutSocketWorker` and all worker thread infrastructure
- ✅ Eliminates shared pipes between processes  
- ✅ Uses direct file descriptors for I/O instead of socket-based communication
- ✅ Each PTY instance has isolated I/O streams
- ✅ Maintains full API compatibility with the original node-pty

## Technical Changes
1. **Removed problematic components**:
   - `ConoutSocketWorker` - the shared pipe worker
   - `ConoutConnection` - the threading infrastructure
   - `WindowsPtyAgent` - the intermediary layer

2. **Simplified Windows implementation**:
   - Direct socket connections to conin/conout pipes
   - No intermediate workers or shared state
   - Each PTY instance is fully isolated

3. **Updated package.json**:
   - Changed from `node-pty: "github:microsoft/node-pty#v1.1.0-beta34"`
   - To `node-pty: "file:./vendored-pty"`

4. **Added compatibility types**:
   - Added `IPty` type alias for backward compatibility
   - Added `onData`/`onExit` to `ITerminal` interface

## Testing
- ✅ TypeScript compilation passes
- ✅ Basic PTY functionality verified with test script
- ✅ All existing VibeTunnel code works without modifications
- ✅ Code quality checks pass

## Impact
This change should completely resolve the crashes reported when VibeTunnel is used alongside VS Code or other Electron applications. Each application now has its own isolated PTY communication channel.

## Future Considerations
The debugging transcript mentioned potentially moving to a Rust implementation for better performance (2MB binary vs 70MB Node process per terminal), but this vendored fork solves the immediate crash issue while maintaining full compatibility.