### PR TITLE
Remove activity indicator to prevent title jumping

### DIFF
--- a/web/src/server/utils/activity-detector.ts
+++ b/web/src/server/utils/activity-detector.ts
@@ -180,11 +180,11 @@ function parseClaudeStatus(data: string): ActivityStatus | null {
     // Format tokens - the input already has 'k' suffix in the regex pattern
     // So "6.0" means 6.0k tokens, not 6.0 tokens
     const formattedTokens = `${tokens}k`;
-    // Include indicator + action and stats
-    displayText = `${indicator} ${action} (${duration}s, ${direction}${formattedTokens})`;
+    // Include action and stats (without indicator to avoid title jumping)
+    displayText = `${action} (${duration}s, ${direction}${formattedTokens})`;
   } else {
-    // Simple format without token info
-    displayText = `${indicator} ${action} (${duration}s)`;
+    // Simple format without token info (without indicator to avoid title jumping)
+    displayText = `${action} (${duration}s)`;
   }
 
   return {


### PR DESCRIPTION
## Summary
- Removes the activity indicator (spinner/checkmark) from the terminal title display
- Keeps only the action text and statistics (duration, tokens)
- Prevents visual jumping in the terminal title when the indicator changes states

## Changes
Modified `web/src/server/utils/activity-detector.ts`:
- Removed `${indicator}` from both display text formats (with and without token info)
- Updated comments to explain why indicators are excluded

## Test plan
- [x] Verify terminal titles show activity without indicators
- [x] Confirm no visual jumping when activity state changes
- [x] Check that action and stats still display correctly