### PR TITLE
Add terminal stats log overlay

### DIFF
--- a/web/src/client/components/session-view/connection-manager.ts
+++ b/web/src/client/components/session-view/connection-manager.ts
@@ -26,11 +26,16 @@ export class ConnectionManager {
   private terminal: Terminal | null = null;
   private session: Session | null = null;
   private isConnected = false;
+  private logCallback?: (msg: string) => void;
 
   constructor(
     private onSessionExit: (sessionId: string) => void,
     private onSessionUpdate: (session: Session) => void
   ) {}
+
+  setLogCallback(callback: ((msg: string) => void) | undefined): void {
+    this.logCallback = callback;
+  }
 
   setTerminal(terminal: Terminal | null): void {
     this.terminal = terminal;
@@ -164,6 +169,7 @@ export class ConnectionManager {
       if (!response.ok) throw new Error(`Failed to fetch snapshot: ${response.status}`);
 
       const castContent = await response.text();
+      this.logCallback?.(`snapshot size: ${castContent.length} bytes`);
 
       // Clear terminal and load snapshot
       this.terminal.clear();

--- a/web/src/client/components/session-view/manager-factory.ts
+++ b/web/src/client/components/session-view/manager-factory.ts
@@ -91,6 +91,8 @@ function wireDependencies(managers: ManagerInstances, sessionView: SessionView):
   terminalLifecycleManager.setInputManager(inputManager);
   terminalLifecycleManager.setConnected(true);
   terminalLifecycleManager.setDomElement(sessionView);
+  connectionManager.setLogCallback((msg) => sessionView['logStat']?.call(sessionView, msg));
+  terminalLifecycleManager.setLogCallback((msg) => sessionView['logStat']?.call(sessionView, msg));
 
   // Set up lifecycle event manager
   lifecycleEventManager.setSessionViewElement(sessionView);

--- a/web/src/client/components/session-view/session-header.ts
+++ b/web/src/client/components/session-view/session-header.ts
@@ -46,6 +46,8 @@ export class SessionHeader extends LitElement {
   @property({ type: Function }) onFontSizeChange?: (size: number) => void;
   @property({ type: Function }) onScreenshare?: () => void;
   @property({ type: Function }) onOpenSettings?: () => void;
+  @property({ type: Function }) onToggleStatsLog?: () => void;
+  @property({ type: Boolean }) statsLogVisible = false;
   @property({ type: String }) currentTheme = 'system';
   @state() private isHovered = false;
 
@@ -262,6 +264,15 @@ export class SessionHeader extends LitElement {
               title="${this.widthTooltip}"
             >
               ${this.widthLabel}
+            </button>
+            <button
+              class="bg-elevated border border-base rounded-lg p-2 font-mono text-muted transition-all duration-200 hover:text-primary hover:bg-hover hover:border-primary hover:shadow-sm flex-shrink-0"
+              @click=${() => this.onToggleStatsLog?.()}
+              title=${this.statsLogVisible ? 'Hide Stats Log' : 'Show Stats Log'}
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M3 3h10v2H3V3zm0 4h10v2H3V7zm0 4h10v2H3v-2z" />
+              </svg>
             </button>
           </div>
           

--- a/web/src/client/components/terminal-stats-log.ts
+++ b/web/src/client/components/terminal-stats-log.ts
@@ -1,0 +1,95 @@
+import { html, LitElement } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+
+@customElement('terminal-stats-log')
+export class TerminalStatsLog extends LitElement {
+  createRenderRoot() {
+    return this;
+  }
+
+  @property({ type: Boolean }) visible = false;
+  @state() private entries: Array<{ time: string; message: string }> = [];
+  @state() private isScrolledToBottom = true;
+
+  addEntry(message: string) {
+    const now = new Date();
+    const time =
+      now.toLocaleTimeString('en-US', {
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }) +
+      '.' +
+      now.getMilliseconds().toString().padStart(3, '0');
+    this.entries = [...this.entries, { time, message }];
+    if (this.entries.length > 50) {
+      this.entries = this.entries.slice(-50);
+    }
+
+    this.updateComplete.then(() => {
+      const el = this.querySelector('.terminal-stats-log');
+      if (el && this.isScrolledToBottom) {
+        el.scrollTop = el.scrollHeight;
+      }
+    });
+  }
+
+  private handleScroll(e: Event) {
+    const el = e.target as HTMLDivElement;
+    const threshold = 10;
+    this.isScrolledToBottom = el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
+  }
+
+  render() {
+    if (!this.visible) return null;
+    return html`
+      <style>
+        .terminal-stats-log {
+          position: absolute;
+          bottom: calc(3rem + env(safe-area-inset-bottom));
+          left: max(1rem, env(safe-area-inset-left));
+          right: max(1rem, env(safe-area-inset-right));
+          max-height: 150px;
+          overflow-y: auto;
+          background: rgb(var(--color-bg-elevated) / 0.95);
+          backdrop-filter: blur(10px);
+          border: 1px solid rgb(var(--color-border) / 0.3);
+          border-radius: 0.5rem;
+          padding: 0.5rem;
+          font-family: var(--font-mono);
+          font-size: 0.75rem;
+          line-height: 1.5;
+          color: rgb(var(--color-text-muted));
+          z-index: 40;
+        }
+        .terminal-stats-log-entry {
+          margin-bottom: 0.25rem;
+          display: flex;
+          gap: 0.5rem;
+        }
+        .terminal-stats-log-time {
+          color: rgb(var(--color-text-dim));
+          flex-shrink: 0;
+        }
+        .terminal-stats-log-message {
+          flex: 1;
+        }
+      </style>
+      <div class="terminal-stats-log" @scroll=${this.handleScroll}>
+        ${this.entries.map(
+          (entry) => html`<div class="terminal-stats-log-entry">
+            <span class="terminal-stats-log-time">${entry.time}</span>
+            <span class="terminal-stats-log-message">${entry.message}</span>
+          </div>`
+        )}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'terminal-stats-log': TerminalStatsLog;
+  }
+}


### PR DESCRIPTION
## Summary
- add `terminal-stats-log` overlay component
- hook session view to toggle and log terminal statistics
- report resize and snapshot fetch size events

## Testing
- `pnpm lint`
- `pnpm test` *(fails: el?.addEntry is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68722cf90210832398e191a0ef363a50