### PR TITLE
ci: simplify Mac workflow by removing Node.js dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
   mac:
     name: Mac CI
-    needs: [changes, node]
+    needs: [changes]
     if: |
       always() && 
       !contains(needs.*.result, 'failure') && 
@@ -62,7 +62,7 @@ jobs:
     
   ios:
     name: iOS CI
-    needs: [changes, node]
+    needs: [changes]
     if: |
       always() && 
       !contains(needs.*.result, 'failure') && 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -141,25 +141,14 @@ jobs:
           fi
         done
     
-    - name: Download web build artifacts
-      uses: actions/download-artifact@v4
-      continue-on-error: true
-      with:
-        name: web-build-${{ github.sha }}
-        path: web/
-    
-    - name: Build web artifacts if missing
+    - name: Build web artifacts
       run: |
-        if [ ! -d "web/dist" ] || [ ! -d "web/public/bundle" ]; then
-          echo "Web build artifacts not found, building locally..."
-          cd web
-          # Skip custom Node.js build in CI to avoid timeout
-          export CI=true
-          pnpm run build
-          echo "Web artifacts built successfully"
-        else
-          echo "Web build artifacts found, skipping local build"
-        fi
+        echo "Building web artifacts locally..."
+        cd web
+        # Skip custom Node.js build in CI to avoid timeout
+        export CI=true
+        pnpm run build
+        echo "Web artifacts built successfully"
     
     - name: Resolve Dependencies (once)
       run: |


### PR DESCRIPTION
## Summary

Extract CI workflow improvements from PR #318 to simplify the build process and remove cross-job dependencies.

## Changes

This PR extracts the CI workflow improvements from #318, specifically:

- **Remove Node.js dependency**: Mac and iOS jobs no longer depend on the Node.js CI job
- **Direct web builds**: Mac workflow always builds web artifacts locally instead of downloading from artifacts
- **Simplified workflow**: Removes conditional logic and potential artifact download failures

## Benefits

1. **Faster CI**: Mac/iOS builds can start immediately without waiting for Node.js CI
2. **More reliable**: No artifact download failures or missing artifact issues
3. **Simpler logic**: Removes complex conditional checks for artifact availability

## Testing

- [x] CI workflows pass with the new configuration
- [x] Mac builds successfully compile web artifacts
- [x] No regression in build outputs

🤖 Generated with [Claude Code](https://claude.ai/code)