### PR TITLE
fix: add user ID for no-auth mode and improve TypeScript imports

### DIFF
--- a/web/src/client/services/push-notification-service.ts
+++ b/web/src/client/services/push-notification-service.ts
@@ -1,9 +1,9 @@
-import { PushNotificationPreferences, PushSubscription } from '../../shared/types.js';
-import { createLogger } from '../utils/logger.js';
-import { authClient } from './auth-client.js';
+import type { PushNotificationPreferences, PushSubscription } from '../../shared/types';
+import { createLogger } from '../utils/logger';
+import { authClient } from './auth-client';
 
 // Re-export types for components
-export { PushSubscription, PushNotificationPreferences };
+export type { PushSubscription, PushNotificationPreferences };
 export type NotificationPreferences = PushNotificationPreferences;
 
 const logger = createLogger('push-notification-service');
@@ -71,7 +71,7 @@ export class PushNotificationService {
         scope: '/',
       });
 
-      logger.log('service worker registered');
+      logger.log('service worker registered successfully');
 
       // Wait for service worker to be ready
       await navigator.serviceWorker.ready;

--- a/web/src/server/middleware/auth.ts
+++ b/web/src/server/middleware/auth.ts
@@ -58,9 +58,10 @@ export function createAuthMiddleware(config: AuthConfig) {
       return next();
     }
 
-    // If no auth is disabled, allow all requests
+    // If no auth is required, allow all requests
     if (config.noAuth) {
       req.authMethod = 'no-auth';
+      req.userId = 'no-auth-user'; // Set a default user ID for no-auth mode
       return next();
     }
 


### PR DESCRIPTION
## Summary

Extract small improvements from PR #318 for auth middleware and push notification service.

## Changes

### Auth Middleware (`web/src/server/middleware/auth.ts`)
- Add default user ID (`no-auth-user`) when running in no-auth mode
- Ensures consistent behavior and prevents potential undefined user ID issues
- Comment clarification: "no auth is disabled" → "no auth is required"

### Push Notification Service (`web/src/client/services/push-notification-service.ts`)
- Convert to TypeScript type-only imports for better tree shaking
- Remove `.js` extensions from import paths for consistency
- Minor logging improvement: "service worker registered" → "service worker registered successfully"

## Benefits

- **Better type safety**: Type-only imports ensure types are properly erased during compilation
- **Consistent auth behavior**: No-auth mode now properly sets a user ID
- **Cleaner imports**: Follows TypeScript best practices

## Testing

- [x] Auth middleware works correctly in no-auth mode
- [x] Push notification service compiles without errors
- [x] Type imports are properly handled by the build system

🤖 Generated with [Claude Code](https://claude.ai/code)