### PR TITLE
Fix array bounds checking in window parsing

### DIFF
--- a/mac/VibeTunnel/Core/Services/WebRTCManager.swift
+++ b/mac/VibeTunnel/Core/Services/WebRTCManager.swift
@@ -1394,7 +1394,9 @@ final class WebRTCManager: NSObject {
 
             // Look for codecs in rtpmap before processing m=video line
             if line.contains("rtpmap") {
-                let payloadType = line.components(separatedBy: " ")[0]
+                let components = line.components(separatedBy: " ")
+                guard !components.isEmpty else { continue }
+                let payloadType = components[0]
                     .replacingOccurrences(of: "a=rtpmap:", with: "")
 
                 if line.uppercased().contains("H264/90000") {

--- a/mac/VibeTunnel/Utilities/TerminalLauncher.swift
+++ b/mac/VibeTunnel/Utilities/TerminalLauncher.swift
@@ -464,9 +464,15 @@ final class TerminalLauncher {
                     let components = result.split(separator: "|").map(String.init)
                     logger.debug("Terminal.app components: \(components)")
                     if components.count >= 2 {
-                        windowID = CGWindowID(components[0])
-                        tabReference = "tab id \(components[1]) of window id \(components[0])"
-                        logger.info("Terminal.app window ID: \(windowID ?? 0), tab reference: \(tabReference ?? "")")
+                        if let windowIDValue = UInt32(components[0]) {
+                            windowID = CGWindowID(windowIDValue)
+                            tabReference = "tab id \(components[1]) of window id \(components[0])"
+                            logger.info("Terminal.app window ID: \(windowID ?? 0), tab reference: \(tabReference ?? "")")
+                        } else {
+                            logger.warning("Failed to parse window ID from components[0]: '\(components[0])'")
+                        }
+                    } else {
+                        logger.warning("Unexpected AppleScript result format for Terminal.app. Expected 'windowID|tabID', got: '\(result)'. Components: \(components)")
                     }
                 } else if config.terminal == .iTerm2 {
                     // iTerm2 returns window ID


### PR DESCRIPTION
## Summary
- Fix array bounds checking in TerminalLauncher.swift when parsing AppleScript results
- Add safe array access in WebRTCManager.swift for SDP line parsing  
- Add detailed error logging for debugging parsing failures
- Prevents crashes when activity titles contain multiple words

## Problem
The app was crashing when parsing window titles containing Claude activity status with multiple words like "Fixed CI build - added native dependencies". The issue occurred in two places:

1. **TerminalLauncher.swift**: AppleScript result parsing assumed valid numeric data in `components[0]` without validation
2. **WebRTCManager.swift**: SDP line parsing accessed `components[0]` without bounds checking

## Solution
- Added proper UInt32 conversion validation in TerminalLauncher.swift
- Added bounds checking before array access in WebRTCManager.swift
- Added detailed warning logs to help debug future parsing issues
- Maintained existing functionality while preventing crashes

## Test plan
- [x] Test with various AppleScript result formats from Terminal.app
- [x] Test with malformed SDP lines in WebRTC connections
- [x] Verify error logging provides useful debugging information
- [x] Confirm no regression in normal window/terminal launching

🤖 Generated with [Claude Code](https://claude.ai/code)