### PR TITLE
Handle iOS pointer capture

### DIFF
--- a/web/src/client/components/terminal.ts
+++ b/web/src/client/components/terminal.ts
@@ -15,7 +15,7 @@ import { html, LitElement, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { processKeyboardShortcuts } from '../utils/keyboard-shortcut-highlighter.js';
 import { createLogger } from '../utils/logger.js';
-import { detectMobile } from '../utils/mobile-utils.js';
+import { detectMobile, isIOS } from '../utils/mobile-utils.js';
 import { UrlHighlighter } from '../utils/url-highlighter';
 
 const logger = createLogger('terminal');
@@ -810,12 +810,18 @@ export class Terminal extends LitElement {
       touchHistory = [{ y: e.clientY, x: e.clientX, time: performance.now() }];
 
       // Capture the pointer so we continue to receive events even if DOM rebuilds
-      this.container?.setPointerCapture(e.pointerId);
+      // iOS Safari has issues with pointer capture causing lost taps when the
+      // terminal is updating, so skip capture on iOS devices
+      if (!isIOS()) {
+        this.container?.setPointerCapture(e.pointerId);
+      }
     };
 
     const handlePointerMove = (e: PointerEvent) => {
-      // Only handle touch pointers that we have captured
-      if (e.pointerType !== 'touch' || !this.container?.hasPointerCapture(e.pointerId)) return;
+      // Only handle touch pointers; on non-iOS we require pointer capture to avoid
+      // losing events when the DOM updates
+      if (e.pointerType !== 'touch') return;
+      if (!isIOS() && !this.container?.hasPointerCapture(e.pointerId)) return;
 
       const currentY = e.clientY;
       const currentX = e.clientX;
@@ -874,8 +880,10 @@ export class Terminal extends LitElement {
         }
       }
 
-      // Release pointer capture
-      this.container?.releasePointerCapture(e.pointerId);
+      // Release pointer capture on non-iOS devices. On iOS we skip capture entirely
+      if (!isIOS()) {
+        this.container?.releasePointerCapture(e.pointerId);
+      }
     };
 
     const handlePointerCancel = (e: PointerEvent) => {
@@ -883,7 +891,9 @@ export class Terminal extends LitElement {
       if (e.pointerType !== 'touch') return;
 
       // Release pointer capture
-      this.container?.releasePointerCapture(e.pointerId);
+      if (!isIOS()) {
+        this.container?.releasePointerCapture(e.pointerId);
+      }
     };
 
     // Attach pointer events to the container (touch only)


### PR DESCRIPTION
## Summary
- avoid pointer capture for iOS Safari to prevent lost taps when terminal updates

## Testing
- `./scripts/test-all-coverage.sh` *(fails: xcrun command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68722f3324e883238f69d658c007effe