### PR TITLE
Fix Network access mode bind address race condition

### DIFF
--- a/mac/VibeTunnel/Core/Services/BunServer.swift
+++ b/mac/VibeTunnel/Core/Services/BunServer.swift
@@ -228,6 +228,7 @@ final class BunServer {
 
         logger.info("Executing command: /bin/zsh -l -c \"\(vibetunnelCommand)\"")
         logger.info("Binary location: \(resourcesPath)")
+        logger.info("Server configuration: port=\(port), bindAddress=\(bindAddress)")
 
         // Set up a minimal environment for the SEA binary
         // SEA binaries can be sensitive to certain environment variables
@@ -432,6 +433,7 @@ final class BunServer {
 
         logger.info("Executing command: /bin/zsh -l -c \"\(pnpmCommand)\"")
         logger.info("Working directory: \(expandedPath)")
+        logger.info("Dev server configuration: port=\(port), bindAddress=\(bindAddress)")
 
         // Set up environment for dev server
         var environment = ProcessInfo.processInfo.environment

--- a/mac/VibeTunnel/Presentation/Views/Settings/DashboardSettingsView.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/DashboardSettingsView.swift
@@ -159,8 +159,12 @@ struct DashboardSettingsView: View {
 
     private func restartServerWithNewBindAddress() {
         Task {
-            // Update the bind address in ServerManager and restart
-            serverManager.bindAddress = accessMode.bindAddress
+            // Restart server to pick up the new bind address from UserDefaults
+            // (accessModeString is already persisted via @AppStorage)
+            logger
+                .info(
+                    "Restarting server due to access mode change: \(accessMode.displayName) -> \(accessMode.bindAddress)"
+                )
             await serverManager.restart()
             logger.info("Server restarted with bind address \(accessMode.bindAddress)")
 


### PR DESCRIPTION
## Summary
Fixes GitHub issue #326 where VibeTunnel's "Network" access mode was still binding to localhost instead of 0.0.0.0, preventing access over Tailscale and other networks.

## Root Cause
Race condition in UserDefaults handling when changing access modes through the UI:
- UI updates `accessModeString` via `@AppStorage` (automatically writes to UserDefaults)
- `restartServerWithNewBindAddress()` had redundant `serverManager.bindAddress = accessMode.bindAddress`
- Two concurrent UserDefaults writes to the same key could cause the server to restart with stale configuration

## Changes Made

### DashboardSettingsView.swift
- **Remove redundant UserDefaults write**: Eliminated `serverManager.bindAddress = accessMode.bindAddress` since `@AppStorage` already persists the change
- **Enhanced logging**: Added detailed logging to track access mode changes: `"Restarting server due to access mode change: Network -> 0.0.0.0"`

### BunServer.swift  
- **Debug logging**: Added server configuration logging for both production and development servers
- **Visibility**: Logs now show `"Server configuration: port=4020, bindAddress=0.0.0.0"` making binding issues easier to diagnose

## Test Plan
- [x] Test Network mode change through VibeTunnel Settings UI
- [x] Verify `lsof -iTCP:4020 -sTCP:LISTEN` shows correct binding:
  - Network mode: `TCP *:trap (LISTEN)` (0.0.0.0:4020) ✅  
  - Localhost mode: `TCP localhost:trap (LISTEN)` (127.0.0.1:4020) ✅
- [x] Check server logs show correct bind address with `./scripts/vtlog.sh -s "bind\|configuration"`
- [x] Verify automatic server restart happens when changing access modes
- [x] Test that Tailscale and external network access works in Network mode

## Verification Steps
Users can test the fix by:
1. Open VibeTunnel Settings → Dashboard → Access Mode
2. Switch between "Localhost only" and "Network" 
3. Run `lsof -iTCP:4020 -sTCP:LISTEN` to verify correct binding
4. Check logs with `./scripts/vtlog.sh -s "configuration"` to see bind address

🤖 Generated with [Claude Code](https://claude.ai/code)