### PR TITLE
Set Dracula as default theme for new users

### DIFF
--- a/ios/VibeTunnel/Models/TerminalTheme.swift
+++ b/ios/VibeTunnel/Models/TerminalTheme.swift
@@ -193,7 +193,7 @@ extension TerminalTheme {
             guard let themeId = UserDefaults.standard.string(forKey: selectedThemeKey),
                   let theme = allThemes.first(where: { $0.id == themeId })
             else {
-                return .vibeTunnel
+                return .dracula
             }
             return theme
         }

--- a/web/src/client/utils/terminal-preferences.ts
+++ b/web/src/client/utils/terminal-preferences.ts
@@ -30,7 +30,7 @@ const DEFAULT_PREFERENCES: TerminalPreferences = {
   maxCols: 0, // No limit by default - take as much as possible
   fontSize: detectMobile() ? 12 : 14, // 12px on mobile, 14px on desktop
   fitHorizontally: false,
-  theme: 'auto',
+  theme: 'dracula',
 };
 
 const STORAGE_KEY_TERMINAL_PREFS = 'vibetunnel_terminal_preferences';


### PR DESCRIPTION
## Summary
- Changes the default terminal theme from 'auto' to 'dracula' for new users who haven't set a theme preference yet
- Updates both web frontend and iOS/macOS companion app defaults
- Provides a consistent dark theme experience out of the box

## Changes Made
- **Web**: Updated `terminal-preferences.ts:33` to set Dracula as default instead of 'auto'
- **iOS/macOS**: Updated `TerminalTheme.swift:196` to return `.dracula` instead of `.vibeTunnel` as fallback

## Test Plan
- [x] Code quality checks pass (`pnpm run check`)
- [x] Verified Dracula theme is available in both platforms
- [ ] Test with fresh user profile (clear localStorage/UserDefaults)
- [ ] Verify existing users with saved preferences are unaffected
- [ ] Test theme switching still works correctly

## Notes
- Existing users who have already customized their theme preferences will see no change
- Only affects new users or users who reset their preferences
- Dracula provides a popular, well-designed dark theme that works well with terminal applications

🤖 Generated with [Claude Code](https://claude.ai/code)