### PR TITLE
fix: prevent repeated screen recording permission dialogs

### DIFF
--- a/mac/VibeTunnel/Core/Services/Screencap/DisplayCoordinator.swift
+++ b/mac/VibeTunnel/Core/Services/Screencap/DisplayCoordinator.swift
@@ -507,14 +507,17 @@ public final class DisplayCoordinator: NSObject {
 
     /// Check if screen recording permission is granted
     private func isScreenRecordingAllowed() async -> Bool {
-        do {
-            // Try to get shareable content - this will fail if no permission
-            _ = try await SCShareableContent.current
-            logger.info("✅ Screen recording permission is granted")
-            return true
-        } catch {
-            logger.warning("❌ Screen recording permission check failed: \(error)")
-            return false
+        // Use SystemPermissionManager which has better caching and non-triggering checks
+        let hasPermission = await MainActor.run {
+            SystemPermissionManager.shared.hasPermission(.screenRecording)
         }
+
+        if hasPermission {
+            logger.info("✅ Screen recording permission is granted")
+        } else {
+            logger.warning("❌ Screen recording permission not granted")
+        }
+
+        return hasPermission
     }
 }


### PR DESCRIPTION
- Replace SCShareableContent.current with CGPreflightScreenCaptureAccess for non-triggering permission checks
- Add 5-second cache for permission state to reduce frequent checks
- Add permission guards to WebRTC endpoints (/displays, /processes)
- Only trigger permission dialog on explicit user action (button click)
- Return proper error responses when permission is denied instead of triggering dialog

This fixes the issue where VibeTunnel would repeatedly show the screen recording permission dialog even after permissions were granted in System Settings.

🤖 Generated with [Claude Code](https://claude.ai/code)