### PR TITLE
Fix file browser constant refresh issue

### DIFF
--- a/web/src/client/components/file-browser.ts
+++ b/web/src/client/components/file-browser.ts
@@ -131,7 +131,7 @@ export class FileBrowser extends LitElement {
   async updated(changedProperties: Map<string, unknown>) {
     super.updated(changedProperties);
 
-    // Only load directory when the component becomes visible or when session changes while visible
+    // Only load directory when the component becomes visible or when session's workingDir actually changes
     if (changedProperties.has('visible')) {
       if (this.visible) {
         // Component just became visible
@@ -139,9 +139,17 @@ export class FileBrowser extends LitElement {
         await this.loadDirectory(this.currentPath);
       }
     } else if (changedProperties.has('session') && this.visible) {
-      // Session changed while component is visible
-      this.currentPath = this.session?.workingDir || '.';
-      await this.loadDirectory(this.currentPath);
+      // Check if the workingDir actually changed
+      const oldSession = changedProperties.get('session') as Session | null;
+      const oldWorkingDir = oldSession?.workingDir;
+      const newWorkingDir = this.session?.workingDir;
+
+      if (oldWorkingDir !== newWorkingDir) {
+        // Working directory actually changed, reload
+        this.currentPath = newWorkingDir || '.';
+        await this.loadDirectory(this.currentPath);
+      }
+      // If only the session object reference changed but workingDir is the same, don't reload
     }
 
     // Monaco editor will handle its own updates through properties


### PR DESCRIPTION
## Summary
- Fixed file browser refreshing every second, making it unusable
- Now only reloads when working directory actually changes
- Resolves #320

## Problem
The file browser was reloading every second because it was detecting changes to the `session` object reference. In the parent `session-view` component, the session object gets updated with spread syntax (creating a new object reference) whenever any property changes, triggering unnecessary reloads.

## Solution
Modified the `updated` lifecycle method in `file-browser.ts` to:
1. Check if the `workingDir` property actually changed, not just the session object reference
2. Only reload the directory when the working directory truly changes
3. Ignore updates where only the session object reference changed but the working directory remains the same

## Test plan
- [x] Open a session and navigate to the file browser
- [x] Verify the file browser no longer refreshes every second
- [x] Change directories in the terminal and verify the file browser updates appropriately
- [x] All linting and type checking passes