### PR TITLE
Fix WebRTC threading crash in screen capture

### DIFF
--- a/mac/VibeTunnel/Core/Services/WebRTCManager.swift
+++ b/mac/VibeTunnel/Core/Services/WebRTCManager.swift
@@ -1236,12 +1236,15 @@ final class WebRTCManager: NSObject {
                 Error
             >) in
                 peerConnection.offer(for: constraints) { offer, error in
-                    if let error {
-                        continuation.resume(throwing: error)
-                    } else if let offer {
-                        continuation.resume(returning: offer)
-                    } else {
-                        continuation.resume(throwing: WebRTCError.failedToCreatePeerConnection)
+                    // WebRTC calls this on its signaling thread, dispatch to main
+                    Task { @MainActor in
+                        if let error {
+                            continuation.resume(throwing: error)
+                        } else if let offer {
+                            continuation.resume(returning: offer)
+                        } else {
+                            continuation.resume(throwing: WebRTCError.failedToCreatePeerConnection)
+                        }
                     }
                 }
             }
@@ -1254,10 +1257,13 @@ final class WebRTCManager: NSObject {
             // Set local description
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 peerConnection.setLocalDescription(modifiedOffer) { error in
-                    if let error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume()
+                    // WebRTC calls this on its signaling thread, dispatch to main
+                    Task { @MainActor in
+                        if let error {
+                            continuation.resume(throwing: error)
+                        } else {
+                            continuation.resume()
+                        }
                     }
                 }
             }
@@ -1283,10 +1289,13 @@ final class WebRTCManager: NSObject {
         do {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 peerConnection.setRemoteDescription(description) { error in
-                    if let error {
-                        continuation.resume(throwing: error)
-                    } else {
-                        continuation.resume()
+                    // WebRTC calls this on its signaling thread, dispatch to main
+                    Task { @MainActor in
+                        if let error {
+                            continuation.resume(throwing: error)
+                        } else {
+                            continuation.resume()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Fixed `dispatch_assert_queue_fail` crash when starting screen capture
- Ensured all WebRTC callbacks execute on the main thread
- Resolved issue #265 where screen sharing would crash with malloc error

## Problem
The crash occurred because WebRTC completion handlers (for `offer()`, `setLocalDescription()`, and `setRemoteDescription()`) were being executed on WebRTC's internal signaling thread, but our `WebRTCManager` class is marked as `@MainActor` and expects to run on the main thread.

## Solution
Added proper `Task { @MainActor in ... }` dispatch blocks around all WebRTC callback continuations to ensure they execute on the main thread.

## Test plan
- [x] Build the Mac app
- [ ] Start screen capture and verify it doesn't crash
- [ ] Test that screen sharing works properly end-to-end
- [ ] Verify no threading warnings in console

Fixes #265