### PR TITLE
Fix WebRTC threading crash by dispatching callbacks to main thread

### DIFF
--- a/mac/VibeTunnel/Core/Services/WebRTCManager.swift
+++ b/mac/VibeTunnel/Core/Services/WebRTCManager.swift
@@ -1276,11 +1276,17 @@ final class WebRTCManager: NSObject {
                     // WebRTC calls completion handlers on its signaling thread.
                     // We must dispatch to main thread since WebRTCManager is @MainActor
                     if let error {
-                        continuation.resume(throwing: error)
+                        Task { @MainActor in
+                            continuation.resume(throwing: error)
+                        }
                     } else if let offer {
-                        continuation.resume(returning: offer)
+                        Task { @MainActor in
+                            continuation.resume(returning: offer)
+                        }
                     } else {
-                        continuation.resume(throwing: WebRTCError.failedToCreatePeerConnection)
+                        Task { @MainActor in
+                            continuation.resume(throwing: WebRTCError.failedToCreatePeerConnection)
+                        }
                     }
                 }
             }
@@ -1296,9 +1302,13 @@ final class WebRTCManager: NSObject {
                     // WebRTC calls completion handlers on its signaling thread.
                     // We must dispatch to main thread since WebRTCManager is @MainActor
                     if let error {
-                        continuation.resume(throwing: error)
+                        Task { @MainActor in
+                            continuation.resume(throwing: error)
+                        }
                     } else {
-                        continuation.resume()
+                        Task { @MainActor in
+                            continuation.resume()
+                        }
                     }
                 }
             }
@@ -1327,9 +1337,13 @@ final class WebRTCManager: NSObject {
                     // WebRTC calls completion handlers on its signaling thread.
                     // We must dispatch to main thread since WebRTCManager is @MainActor
                     if let error {
-                        continuation.resume(throwing: error)
+                        Task { @MainActor in
+                            continuation.resume(throwing: error)
+                        }
                     } else {
-                        continuation.resume()
+                        Task { @MainActor in
+                            continuation.resume()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Fixed WebRTC callbacks that were violating @MainActor constraints by running on WebRTC's signaling thread
- Added proper Task { @MainActor in ... } dispatch blocks to ensure continuation.resume() calls execute on main thread
- Addresses potential threading crashes in screen sharing functionality

## Problem
The WebRTCManager is marked `@MainActor` but WebRTC completion handlers for `offer()`, `setLocalDescription()`, and `setRemoteDescription()` are called on WebRTC's internal signaling thread. Despite comments indicating the necessity to dispatch these callbacks to the main thread, the required `Task { @MainActor in ... }` blocks were missing.

This caused `continuation.resume()` calls to execute on the wrong thread, violating the @MainActor constraint and potentially causing crashes.

## Solution
Wrapped each `continuation.resume()` call in a `Task { @MainActor in ... }` block to ensure they execute on the main thread as required. This maintains thread safety and prevents crashes.

## Test plan
- [x] Code compiles without errors
- [x] Swift concurrency warnings resolved
- [ ] Test screen sharing functionality works correctly
- [ ] Verify no threading crashes occur during WebRTC operations