### PR TITLE
Fix SSH key generation errors on non-localhost HTTP connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,8 +317,8 @@ Modern browsers block the Web Crypto API (required for SSH key operations) when 
    - Enable the flag and restart Chrome
    - ⚠️ This reduces security - use only for development
 
-4. **Firefox Alternative**
-   Firefox may be less restrictive with local network addresses - try it if Chrome doesn't work.
+4. **Note on Firefox**
+   Since Firefox 75, it also requires secure contexts for Web Crypto API. The same restrictions apply as in Chrome.
 
 #### Why This Happens
 The Web Crypto API is restricted to secure contexts (HTTPS or localhost) to prevent man-in-the-middle attacks on cryptographic operations. This is a browser security feature, not a VibeTunnel limitation.

--- a/README.md
+++ b/README.md
@@ -287,6 +287,42 @@ The macOS menu bar app supports these authentication modes:
 6. **Monitor access logs** for suspicious authentication patterns
 7. **Default to secure** - explicitly enable less secure options only when needed
 
+### SSH Key Authentication Troubleshooting
+
+If you encounter errors when generating or importing SSH keys (e.g., "Cannot read properties of undefined"), this is likely due to browser security restrictions on the Web Crypto API.
+
+#### The Issue
+Modern browsers block the Web Crypto API (required for SSH key operations) when accessing web applications over HTTP from non-localhost addresses. This affects:
+- Local network IPs (192.168.x.x, 10.x.x.x, 172.16-31.x.x)
+- Any non-localhost hostname over HTTP
+
+#### Solutions
+
+1. **Use localhost (Recommended)**
+   ```bash
+   # Access VibeTunnel via localhost
+   http://localhost:4020
+   
+   # If running on a remote server, use SSH tunneling:
+   ssh -L 4020:localhost:4020 user@your-server
+   # Then access http://localhost:4020 in your browser
+   ```
+
+2. **Enable HTTPS**
+   Set up a reverse proxy with HTTPS using nginx or Caddy (recommended for production).
+
+3. **Chrome Flag Workaround** (Development only)
+   - Navigate to `chrome://flags/#unsafely-treat-insecure-origin-as-secure`
+   - Add your server URL (e.g., `http://192.168.1.100:4020`)
+   - Enable the flag and restart Chrome
+   - ⚠️ This reduces security - use only for development
+
+4. **Firefox Alternative**
+   Firefox may be less restrictive with local network addresses - try it if Chrome doesn't work.
+
+#### Why This Happens
+The Web Crypto API is restricted to secure contexts (HTTPS or localhost) to prevent man-in-the-middle attacks on cryptographic operations. This is a browser security feature, not a VibeTunnel limitation.
+
 
 ## npm Package
 

--- a/README.md
+++ b/README.md
@@ -289,39 +289,7 @@ The macOS menu bar app supports these authentication modes:
 
 ### SSH Key Authentication Troubleshooting
 
-If you encounter errors when generating or importing SSH keys (e.g., "Cannot read properties of undefined"), this is likely due to browser security restrictions on the Web Crypto API.
-
-#### The Issue
-Modern browsers block the Web Crypto API (required for SSH key operations) when accessing web applications over HTTP from non-localhost addresses. This affects:
-- Local network IPs (192.168.x.x, 10.x.x.x, 172.16-31.x.x)
-- Any non-localhost hostname over HTTP
-
-#### Solutions
-
-1. **Use localhost (Recommended)**
-   ```bash
-   # Access VibeTunnel via localhost
-   http://localhost:4020
-   
-   # If running on a remote server, use SSH tunneling:
-   ssh -L 4020:localhost:4020 user@your-server
-   # Then access http://localhost:4020 in your browser
-   ```
-
-2. **Enable HTTPS**
-   Set up a reverse proxy with HTTPS using nginx or Caddy (recommended for production).
-
-3. **Chrome Flag Workaround** (Development only)
-   - Navigate to `chrome://flags/#unsafely-treat-insecure-origin-as-secure`
-   - Add your server URL (e.g., `http://192.168.1.100:4020`)
-   - Enable the flag and restart Chrome
-   - ⚠️ This reduces security - use only for development
-
-4. **Note on Firefox**
-   Since Firefox 75, it also requires secure contexts for Web Crypto API. The same restrictions apply as in Chrome.
-
-#### Why This Happens
-The Web Crypto API is restricted to secure contexts (HTTPS or localhost) to prevent man-in-the-middle attacks on cryptographic operations. This is a browser security feature, not a VibeTunnel limitation.
+If SSH key generation fails with crypto errors, see the [detailed troubleshooting guide](web/README.md#ssh-key-authentication-issues) for solutions.
 
 
 ## npm Package

--- a/web/README.md
+++ b/web/README.md
@@ -234,6 +234,39 @@ If you encounter issues during installation:
 - **Authentication Failed**: Verify system authentication setup
 - **Terminal Not Responsive**: Check browser console for WebSocket errors
 
+### SSH Key Authentication Issues
+
+If you encounter errors when generating or importing SSH keys (e.g., "Cannot read properties of undefined"), this is due to browser security restrictions on the Web Crypto API.
+
+#### The Issue
+Modern browsers (Chrome 60+, Firefox 75+) block the Web Crypto API when accessing web applications over HTTP from non-localhost addresses. This affects:
+- Local network IPs (192.168.x.x, 10.x.x.x, 172.16-31.x.x)
+- Any non-localhost hostname over HTTP
+
+#### Solutions
+
+1. **Use localhost (Recommended)**
+   ```bash
+   # Access VibeTunnel via localhost
+   http://localhost:4020
+   
+   # If running on a remote server, use SSH tunneling:
+   ssh -L 4020:localhost:4020 user@your-server
+   # Then access http://localhost:4020 in your browser
+   ```
+
+2. **Enable HTTPS**
+   Set up a reverse proxy with HTTPS using nginx or Caddy (recommended for production).
+
+3. **Chrome Flag Workaround** (Development only)
+   - Navigate to `chrome://flags/#unsafely-treat-insecure-origin-as-secure`
+   - Add your server URL (e.g., `http://192.168.1.100:4020`)
+   - Enable the flag and restart Chrome
+   - ⚠️ This reduces security - use only for development
+
+#### Why This Happens
+The Web Crypto API is restricted to secure contexts (HTTPS or localhost) to prevent man-in-the-middle attacks on cryptographic operations. This is a browser security feature, not a VibeTunnel limitation.
+
 ### Development Setup
 
 For source installations:

--- a/web/src/client/services/ssh-agent.ts
+++ b/web/src/client/services/ssh-agent.ts
@@ -18,10 +18,11 @@ if (!globalThis.crypto?.subtle) {
     errorMessage +=
       '3. For Chrome: Enable insecure origins at chrome://flags/#unsafely-treat-insecure-origin-as-secure\n';
     errorMessage += '   - Add your server URL (e.g., http://192.168.1.100:4020)\n';
-    errorMessage += '   - Restart Chrome after changing the flag';
+    errorMessage += '   - Restart Chrome after changing the flag\n';
+    errorMessage += '   - Note: Firefox also enforces these restrictions since v75';
   } else {
     errorMessage += 'Your browser may not support the Web Crypto API or it may be disabled.\n';
-    errorMessage += 'Please use a modern browser (Chrome 37+, Firefox 34+, Safari 11+).';
+    errorMessage += 'Please use a modern browser (Chrome 60+, Firefox 75+, Safari 11+).';
   }
 
   // Display user-friendly error in the UI

--- a/web/src/client/services/ssh-agent.ts
+++ b/web/src/client/services/ssh-agent.ts
@@ -1,59 +1,10 @@
-// Check if Web Crypto API is available
-if (!globalThis.crypto?.subtle) {
-  // Detect if we're on a local network IP
-  const hostname = window.location.hostname;
-  const isLocalNetwork = hostname.match(/^(192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)/);
-  const isNonLocalhost = hostname !== 'localhost' && hostname !== '127.0.0.1';
+// Module-level variable to track if crypto is available
+let cryptoSubtle: SubtleCrypto | undefined;
 
-  let errorMessage =
-    'SSH key operations are unavailable because the Web Crypto API is not accessible.\n\n';
-
-  if (isLocalNetwork || (isNonLocalhost && window.location.protocol === 'http:')) {
-    errorMessage +=
-      'This happens when accessing VibeTunnel over HTTP from non-localhost addresses.\n\n';
-    errorMessage += 'To fix this, use one of these methods:\n';
-    errorMessage += '1. Access via http://localhost:4020 instead\n';
-    errorMessage += '   - Use SSH tunnel: ssh -L 4020:localhost:4020 user@server\n';
-    errorMessage += '2. Enable HTTPS on the server (recommended for production)\n';
-    errorMessage +=
-      '3. For Chrome: Enable insecure origins at chrome://flags/#unsafely-treat-insecure-origin-as-secure\n';
-    errorMessage += '   - Add your server URL (e.g., http://192.168.1.100:4020)\n';
-    errorMessage += '   - Restart Chrome after changing the flag\n';
-    errorMessage += '   - Note: Firefox also enforces these restrictions since v75';
-  } else {
-    errorMessage += 'Your browser may not support the Web Crypto API or it may be disabled.\n';
-    errorMessage += 'Please use a modern browser (Chrome 60+, Firefox 75+, Safari 11+).';
-  }
-
-  // Display user-friendly error in the UI
-  const style = document.createElement('style');
-  style.textContent = `
-    .crypto-error-banner {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      background: #dc2626;
-      color: white;
-      padding: 16px;
-      z-index: 9999;
-      font-family: monospace;
-      white-space: pre-wrap;
-      box-shadow: 0 2px 10px rgba(0,0,0,0.3);
-    }
-  `;
-  document.head.appendChild(style);
-
-  const banner = document.createElement('div');
-  banner.className = 'crypto-error-banner';
-  banner.textContent = errorMessage;
-  document.body.appendChild(banner);
-
-  throw new Error(errorMessage);
+// Try to get subtle crypto if available, but don't throw at module load
+if (globalThis.crypto?.subtle) {
+  cryptoSubtle = globalThis.crypto.subtle;
 }
-
-// Use Web Crypto API available in browsers and Node.js (via globalThis)
-const { subtle } = globalThis.crypto;
 
 interface SSHKey {
   id: string;
@@ -75,10 +26,96 @@ export class BrowserSSHAgent {
   private static readonly DEFAULT_STORAGE_KEY = 'vibetunnel_ssh_keys';
   private keys: Map<string, SSHKey> = new Map();
   private storageKey: string;
+  private cryptoErrorShown = false;
 
   constructor(customStorageKey?: string) {
     this.storageKey = customStorageKey || BrowserSSHAgent.DEFAULT_STORAGE_KEY;
     this.loadKeysFromStorage();
+  }
+
+  /**
+   * Check if Web Crypto API is available and show error if not
+   */
+  private ensureCryptoAvailable(): void {
+    if (!cryptoSubtle) {
+      if (!this.cryptoErrorShown) {
+        this.showCryptoError();
+        this.cryptoErrorShown = true;
+      }
+      throw new Error('Web Crypto API is not available');
+    }
+  }
+
+  /**
+   * Show user-friendly error banner for crypto unavailability
+   */
+  private showCryptoError(): void {
+    // Check if DOM is ready
+    if (!document.body) {
+      console.error('Web Crypto API not available and DOM not ready to show error');
+      return;
+    }
+
+    // Detect if we're on a local network IP
+    const hostname = window.location.hostname;
+    const isLocalNetwork = hostname.match(/^(192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)/);
+    const isNonLocalhost = hostname !== 'localhost' && hostname !== '127.0.0.1';
+
+    let errorMessage =
+      'SSH key operations are unavailable because the Web Crypto API is not accessible.\n\n';
+
+    if (isLocalNetwork || (isNonLocalhost && window.location.protocol === 'http:')) {
+      // Differentiate between HTTP and HTTPS on local IPs
+      if (isLocalNetwork && window.location.protocol === 'https:') {
+        errorMessage +=
+          "Even though you're using HTTPS, browsers block the Web Crypto API on local network IPs.\n\n";
+      } else {
+        errorMessage +=
+          'This happens when accessing VibeTunnel over HTTP from non-localhost addresses.\n\n';
+      }
+      errorMessage += 'To fix this, use one of these methods:\n';
+      errorMessage += '1. Access via http://localhost:4020 instead\n';
+      errorMessage += '   - Use SSH tunnel: ssh -L 4020:localhost:4020 user@server\n';
+      errorMessage += '2. Enable HTTPS on the server (recommended for production)\n';
+      errorMessage +=
+        '3. For Chrome: Enable insecure origins at chrome://flags/#unsafely-treat-insecure-origin-as-secure\n';
+      errorMessage += '   - Add your server URL (e.g., http://192.168.1.100:4020)\n';
+      errorMessage += '   - Restart Chrome after changing the flag\n';
+      errorMessage += '   - Note: Firefox also enforces these restrictions since v75';
+    } else {
+      errorMessage += 'Your browser may not support the Web Crypto API or it may be disabled.\n';
+      errorMessage += 'Please use a modern browser (Chrome 60+, Firefox 75+, Safari 11+).';
+    }
+
+    // Create and append style if not already exists
+    if (!document.querySelector('#crypto-error-style')) {
+      const style = document.createElement('style');
+      style.id = 'crypto-error-style';
+      style.textContent = `
+        .crypto-error-banner {
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          background: #dc2626;
+          color: white;
+          padding: 16px;
+          z-index: 9999;
+          font-family: monospace;
+          white-space: pre-wrap;
+          box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+        }
+      `;
+      document.head.appendChild(style);
+    }
+
+    // Create and append banner if not already exists
+    if (!document.querySelector('.crypto-error-banner')) {
+      const banner = document.createElement('div');
+      banner.className = 'crypto-error-banner';
+      banner.textContent = errorMessage;
+      document.body.appendChild(banner);
+    }
   }
 
   /**
@@ -92,6 +129,13 @@ export class BrowserSSHAgent {
    * Add SSH private key to the agent
    */
   async addKey(name: string, privateKeyPEM: string): Promise<string> {
+    this.ensureCryptoAvailable();
+
+    // After ensureCryptoAvailable, we know cryptoSubtle is defined
+    if (!cryptoSubtle) {
+      throw new Error('Crypto not available');
+    }
+
     try {
       // Parse and validate the private key (detect encryption without decrypting)
       const keyData = await this.parsePrivateKey(privateKeyPEM);
@@ -144,6 +188,13 @@ export class BrowserSSHAgent {
    * Sign data with a specific SSH key
    */
   async sign(keyId: string, data: string): Promise<SignatureResult> {
+    this.ensureCryptoAvailable();
+
+    // After ensureCryptoAvailable, we know cryptoSubtle is defined
+    if (!cryptoSubtle) {
+      throw new Error('Crypto not available');
+    }
+
     const key = this.keys.get(keyId);
     if (!key) {
       throw new Error('SSH key not found');
@@ -172,7 +223,7 @@ export class BrowserSSHAgent {
       const dataBuffer = this.base64ToArrayBuffer(data);
 
       // Sign the data
-      const signature = await subtle.sign({ name: 'Ed25519' }, privateKey, dataBuffer);
+      const signature = await cryptoSubtle.sign({ name: 'Ed25519' }, privateKey, dataBuffer);
 
       // Return base64 encoded signature
       return {
@@ -191,10 +242,17 @@ export class BrowserSSHAgent {
     name: string,
     password?: string
   ): Promise<{ keyId: string; privateKeyPEM: string }> {
+    this.ensureCryptoAvailable();
+
+    // After ensureCryptoAvailable, we know cryptoSubtle is defined
+    if (!cryptoSubtle) {
+      throw new Error('Crypto not available');
+    }
+
     console.log(`🔑 SSH Agent: Starting Ed25519 key generation for "${name}"`);
 
     try {
-      const keyPair = await subtle.generateKey(
+      const keyPair = await cryptoSubtle.generateKey(
         {
           name: 'Ed25519',
         } as AlgorithmIdentifier,
@@ -204,8 +262,8 @@ export class BrowserSSHAgent {
 
       // Export keys
       const cryptoKeyPair = keyPair as CryptoKeyPair;
-      const privateKeyBuffer = await subtle.exportKey('pkcs8', cryptoKeyPair.privateKey);
-      const publicKeyBuffer = await subtle.exportKey('raw', cryptoKeyPair.publicKey);
+      const privateKeyBuffer = await cryptoSubtle.exportKey('pkcs8', cryptoKeyPair.privateKey);
+      const publicKeyBuffer = await cryptoSubtle.exportKey('raw', cryptoKeyPair.publicKey);
 
       // Convert to proper formats
       let privateKeyPEM = this.arrayBufferToPEM(privateKeyBuffer, 'PRIVATE KEY');
@@ -289,6 +347,10 @@ export class BrowserSSHAgent {
   }
 
   private async importPrivateKey(privateKeyPEM: string, _algorithm: 'Ed25519'): Promise<CryptoKey> {
+    if (!cryptoSubtle) {
+      throw new Error('Crypto not available');
+    }
+
     // Remove PEM headers and decode
     const pemContents = privateKeyPEM
       .replace('-----BEGIN PRIVATE KEY-----', '')
@@ -297,7 +359,7 @@ export class BrowserSSHAgent {
 
     const keyData = this.base64ToArrayBuffer(pemContents);
 
-    return subtle.importKey(
+    return cryptoSubtle.importKey(
       'pkcs8',
       keyData,
       {
@@ -340,8 +402,12 @@ export class BrowserSSHAgent {
   }
 
   private async generateFingerprint(publicKey: string): Promise<string> {
+    if (!cryptoSubtle) {
+      throw new Error('Crypto not available');
+    }
+
     const encoder = new TextEncoder();
-    const hash = await subtle.digest('SHA-256', encoder.encode(publicKey));
+    const hash = await cryptoSubtle.digest('SHA-256', encoder.encode(publicKey));
     return this.arrayBufferToBase64(hash).substring(0, 16);
   }
 
@@ -401,11 +467,15 @@ export class BrowserSSHAgent {
    * Encrypt private key with password using Web Crypto API
    */
   private async encryptPrivateKey(privateKeyPEM: string, password: string): Promise<string> {
+    if (!cryptoSubtle) {
+      throw new Error('Crypto not available');
+    }
+
     const encoder = new TextEncoder();
     const data = encoder.encode(privateKeyPEM);
 
     // Derive key from password using PBKDF2
-    const passwordKey = await subtle.importKey(
+    const passwordKey = await cryptoSubtle.importKey(
       'raw',
       encoder.encode(password),
       { name: 'PBKDF2' },
@@ -417,7 +487,7 @@ export class BrowserSSHAgent {
     const salt = crypto.getRandomValues(new Uint8Array(16));
 
     // Derive encryption key
-    const encryptionKey = await subtle.deriveKey(
+    const encryptionKey = await cryptoSubtle.deriveKey(
       {
         name: 'PBKDF2',
         salt,
@@ -434,7 +504,7 @@ export class BrowserSSHAgent {
     const iv = crypto.getRandomValues(new Uint8Array(12));
 
     // Encrypt the data
-    const encryptedData = await subtle.encrypt({ name: 'AES-GCM', iv }, encryptionKey, data);
+    const encryptedData = await cryptoSubtle.encrypt({ name: 'AES-GCM', iv }, encryptionKey, data);
 
     // Combine salt + iv + encrypted data and base64 encode
     const combined = new Uint8Array(salt.length + iv.length + encryptedData.byteLength);
@@ -452,6 +522,10 @@ export class BrowserSSHAgent {
     encryptedPrivateKeyPEM: string,
     password: string
   ): Promise<string> {
+    if (!cryptoSubtle) {
+      throw new Error('Crypto not available');
+    }
+
     // Extract base64 data
     const base64Data = encryptedPrivateKeyPEM
       .replace('-----BEGIN ENCRYPTED PRIVATE KEY-----', '')
@@ -469,7 +543,7 @@ export class BrowserSSHAgent {
     const encoder = new TextEncoder();
 
     // Derive key from password
-    const passwordKey = await subtle.importKey(
+    const passwordKey = await cryptoSubtle.importKey(
       'raw',
       encoder.encode(password),
       { name: 'PBKDF2' },
@@ -477,7 +551,7 @@ export class BrowserSSHAgent {
       ['deriveKey']
     );
 
-    const encryptionKey = await subtle.deriveKey(
+    const encryptionKey = await cryptoSubtle.deriveKey(
       {
         name: 'PBKDF2',
         salt,
@@ -491,7 +565,7 @@ export class BrowserSSHAgent {
     );
 
     // Decrypt the data
-    const decryptedData = await subtle.decrypt(
+    const decryptedData = await cryptoSubtle.decrypt(
       { name: 'AES-GCM', iv },
       encryptionKey,
       encryptedData

--- a/web/src/client/services/ssh-agent.ts
+++ b/web/src/client/services/ssh-agent.ts
@@ -1,3 +1,56 @@
+// Check if Web Crypto API is available
+if (!globalThis.crypto?.subtle) {
+  // Detect if we're on a local network IP
+  const hostname = window.location.hostname;
+  const isLocalNetwork = hostname.match(/^(192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)/);
+  const isNonLocalhost = hostname !== 'localhost' && hostname !== '127.0.0.1';
+
+  let errorMessage =
+    'SSH key operations are unavailable because the Web Crypto API is not accessible.\n\n';
+
+  if (isLocalNetwork || (isNonLocalhost && window.location.protocol === 'http:')) {
+    errorMessage +=
+      'This happens when accessing VibeTunnel over HTTP from non-localhost addresses.\n\n';
+    errorMessage += 'To fix this, use one of these methods:\n';
+    errorMessage += '1. Access via http://localhost:4020 instead\n';
+    errorMessage += '   - Use SSH tunnel: ssh -L 4020:localhost:4020 user@server\n';
+    errorMessage += '2. Enable HTTPS on the server (recommended for production)\n';
+    errorMessage +=
+      '3. For Chrome: Enable insecure origins at chrome://flags/#unsafely-treat-insecure-origin-as-secure\n';
+    errorMessage += '   - Add your server URL (e.g., http://192.168.1.100:4020)\n';
+    errorMessage += '   - Restart Chrome after changing the flag';
+  } else {
+    errorMessage += 'Your browser may not support the Web Crypto API or it may be disabled.\n';
+    errorMessage += 'Please use a modern browser (Chrome 37+, Firefox 34+, Safari 11+).';
+  }
+
+  // Display user-friendly error in the UI
+  const style = document.createElement('style');
+  style.textContent = `
+    .crypto-error-banner {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      background: #dc2626;
+      color: white;
+      padding: 16px;
+      z-index: 9999;
+      font-family: monospace;
+      white-space: pre-wrap;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.3);
+    }
+  `;
+  document.head.appendChild(style);
+
+  const banner = document.createElement('div');
+  banner.className = 'crypto-error-banner';
+  banner.textContent = errorMessage;
+  document.body.appendChild(banner);
+
+  throw new Error(errorMessage);
+}
+
 // Use Web Crypto API available in browsers and Node.js (via globalThis)
 const { subtle } = globalThis.crypto;
 


### PR DESCRIPTION
## Summary
- Fixes SSH key generation/import failures when accessing VibeTunnel over HTTP from non-localhost addresses
- Adds clear error messaging explaining the Web Crypto API security restrictions
- Provides actionable solutions for users encountering this issue

## Problem
Users accessing VibeTunnel from local network IPs (192.168.x.x, 10.x.x.x) over HTTP encounter "Cannot read properties of undefined (reading 'generateKey')" errors because browsers block the Web Crypto API on insecure origins.

## Solution
1. Added comprehensive error detection in `ssh-agent.ts` that:
   - Checks if Web Crypto API is available
   - Detects local network IPs vs localhost
   - Shows a user-friendly error banner with specific solutions
   
2. Added SSH troubleshooting section to README explaining:
   - Why the issue occurs (browser security)
   - Multiple solutions (localhost access, SSH tunneling, HTTPS, Chrome flags)
   - Clear instructions for each workaround

## Test Plan
- [ ] Access VibeTunnel from a local network IP over HTTP
- [ ] Verify the error banner appears with clear instructions
- [ ] Test accessing via localhost works correctly
- [ ] Verify SSH key generation works when accessed properly

Fixes #382