### PR TITLE
Fix welcome folder lag by implementing background scanning

### DIFF
--- a/mac/VibeTunnel/Presentation/Views/WelcomeView.swift
+++ b/mac/VibeTunnel/Presentation/Views/WelcomeView.swift
@@ -65,7 +65,7 @@ struct WelcomeView: View {
                         .frame(width: pageWidth)
 
                     // Page 5: Project Folder
-                    ProjectFolderPageView()
+                    ProjectFolderPageView(currentPage: $currentPage)
                         .frame(width: pageWidth)
 
                     // Page 6: Protect Your Dashboard


### PR DESCRIPTION
## Summary
- Resolves UI freezing when scanning home directory for Git repositories
- Implements background thread scanning with proper cancellation
- Only starts scanning when the project folder page is actually visible

## Changes
1. **Background Scanning**: Moved the Git repository scanning to a background thread using Swift concurrency to prevent UI blocking
2. **Visibility-Based Scanning**: Only start scanning when ProjectFolderPageView becomes visible (page 4 of welcome flow), not when the entire WelcomeView loads
3. **Task Cancellation**: Added proper task cancellation handling to stop scanning when user navigates away from the page
4. **Performance Optimization**: Added cancellation checks during directory traversal to ensure responsive UI

## Test Plan
- [x] Built and tested the macOS app locally
- [x] Verified that the welcome dialog no longer freezes when navigating to the project folder page
- [x] Confirmed scanning starts only when reaching page 4 (project folder selection)
- [x] Verified scanning is cancelled when navigating away from the page
- [x] Tested with large home directories to ensure smooth performance

Fixes #379