### PR TITLE
Add uninstall option for vt command in settings

### DIFF
--- a/mac/VibeTunnel/Presentation/Views/Settings/CLIInstallationSection.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/CLIInstallationSection.swift
@@ -40,37 +40,67 @@ struct CLIInstallationSection: View {
                         HStack {
                             ProgressView()
                                 .scaleEffect(0.7)
-                            Text("Installing...")
+                            Text(cliInstaller.isUninstalling ? "Uninstalling..." : "Installing...")
                                 .font(.caption)
                         }
                     } else {
                         if cliInstaller.isInstalled {
                             // Updated status
                             if cliInstaller.isOutdated {
-                                Button("Update 'vt' Command") {
-                                    Task {
-                                        await cliInstaller.install()
+                                HStack(spacing: 8) {
+                                    Button("Update 'vt' Command") {
+                                        Task {
+                                            await cliInstaller.install()
+                                        }
                                     }
-                                }
-                                .buttonStyle(.bordered)
-                                .disabled(cliInstaller.isInstalling)
-                            } else {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundColor(.green)
-                                Text("VT installed")
-                                    .foregroundColor(.secondary)
-
-                                // Show reinstall button in debug mode
-                                if debugMode {
+                                    .buttonStyle(.bordered)
+                                    .disabled(cliInstaller.isInstalling)
+                                    
                                     Button(action: {
-                                        cliInstaller.installCLITool()
+                                        Task {
+                                            await cliInstaller.uninstall()
+                                        }
                                     }, label: {
-                                        Image(systemName: "arrow.clockwise.circle")
+                                        Image(systemName: "trash")
                                             .font(.system(size: 14))
                                     })
                                     .buttonStyle(.plain)
-                                    .foregroundColor(.accentColor)
-                                    .help("Reinstall CLI tool")
+                                    .foregroundColor(.red)
+                                    .disabled(cliInstaller.isInstalling)
+                                    .help("Uninstall CLI tool")
+                                }
+                            } else {
+                                HStack(spacing: 8) {
+                                    Image(systemName: "checkmark.circle.fill")
+                                        .foregroundColor(.green)
+                                    Text("VT installed")
+                                        .foregroundColor(.secondary)
+
+                                    // Show reinstall button in debug mode
+                                    if debugMode {
+                                        Button(action: {
+                                            cliInstaller.installCLITool()
+                                        }, label: {
+                                            Image(systemName: "arrow.clockwise.circle")
+                                                .font(.system(size: 14))
+                                        })
+                                        .buttonStyle(.plain)
+                                        .foregroundColor(.accentColor)
+                                        .help("Reinstall CLI tool")
+                                    }
+                                    
+                                    Button(action: {
+                                        Task {
+                                            await cliInstaller.uninstall()
+                                        }
+                                    }, label: {
+                                        Image(systemName: "trash")
+                                            .font(.system(size: 14))
+                                    })
+                                    .buttonStyle(.plain)
+                                    .foregroundColor(.red)
+                                    .disabled(cliInstaller.isInstalling)
+                                    .help("Uninstall CLI tool")
                                 }
                             }
                         } else {


### PR DESCRIPTION
## Summary
- Implements uninstall functionality for the `vt` command line tool
- Adds a trash icon button in the settings dialog for easy uninstallation
- Closes #365

## Changes
- **CLIInstaller.swift**: Added `uninstall()` and `uninstallCLITool()` methods with sudo authentication
- **CLIInstallationSection.swift**: Added trash icon button next to "VT installed" status
- Uninstalls from both standard paths: `/usr/local/bin/vt` and `/opt/homebrew/bin/vt`
- Shows confirmation dialog before uninstalling
- Displays appropriate success/error messages

## Screenshots
The trash icon appears to the right of the "VT installed" status:
- Clean, minimal UI following macOS design conventions
- Red-colored trash icon with hover tooltip
- Available in both "installed" and "update available" states

## Test Plan
- [x] Build and run the app
- [x] Open Settings → General
- [x] Install vt command if not already installed
- [x] Click the trash icon to uninstall
- [x] Confirm the uninstall dialog appears
- [x] Verify vt is removed from system after successful uninstall
- [x] Verify UI updates to show "Install 'vt' Command" button after uninstall