### PR TITLE
feat(ui): make ngrok URL clickable with copy button in MacOS under Settings → Dashboard → Remote Access section

### DIFF
--- a/mac/VibeTunnel/Presentation/Views/Settings/DashboardSettingsView.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/DashboardSettingsView.swift
@@ -441,10 +441,20 @@ private struct RemoteAccessStatusSection: View {
                             .font(.system(size: 10))
                         Text("ngrok")
                             .font(.callout)
-                        Text("(\(status.publicUrl.replacingOccurrences(of: "https://", with: "")))")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                            .lineLimit(1)
+                        
+                        if let url = URL(string: status.publicUrl) {
+                            Link(status.publicUrl, destination: url)
+                                .font(.caption)
+                                .foregroundStyle(.blue)
+                                .lineLimit(1)
+                        } else {
+                            Text(status.publicUrl)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .lineLimit(1)
+                        }
+                        
+                        NgrokURLCopyButton(url: status.publicUrl)
                     } else {
                         Image(systemName: "circle")
                             .foregroundColor(.gray)
@@ -492,6 +502,43 @@ private struct RemoteAccessStatusSection: View {
                 .frame(maxWidth: .infinity)
                 .multilineTextAlignment(.center)
         }
+    }
+}
+
+// MARK: - Ngrok URL Copy Button
+
+private struct NgrokURLCopyButton: View {
+    let url: String
+    @State private var showCopiedFeedback = false
+    @State private var feedbackTask: DispatchWorkItem?
+    
+    var body: some View {
+        Button(action: {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(url, forType: .string)
+            
+            // Cancel previous timer if exists
+            feedbackTask?.cancel()
+            
+            withAnimation {
+                showCopiedFeedback = true
+            }
+            
+            // Create new timer
+            let task = DispatchWorkItem {
+                withAnimation {
+                    showCopiedFeedback = false
+                }
+            }
+            feedbackTask = task
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2, execute: task)
+        }, label: {
+            Image(systemName: showCopiedFeedback ? "checkmark" : "doc.on.doc")
+                .foregroundColor(showCopiedFeedback ? .green : .accentColor)
+        })
+        .buttonStyle(.borderless)
+        .help("Copy URL")
+        .font(.caption)
     }
 }
 


### PR DESCRIPTION
Please refer to the screenshot attached. I think this will be a useful feature to quickly open and verify if the ngrok tunnel is working, and also quickly copy and share the link.

Changes:
Before:
<img width="503" height="791" alt="Before" src="https://github.com/user-attachments/assets/293b17fc-680b-4083-9207-81ba65dd244e" />

After:
<img width="497" height="788" alt="After" src="https://github.com/user-attachments/assets/6e213a47-6a4e-48e2-81df-fd0e4c00ab5d" />

- Replaced plain text ngrok URL with clickable Link component
- Showing full URL with https:// prefix instead of stripping it
- Added copy button with visual feedback (changes to checkmark when copied)

The ngrok URL in Settings → Dashboard → Remote Access section is now displayed as a blue clickable link that opens in the default browser, with a convenient copy button next to it.