### PR TITLE
Fix new session dialog dark mode styling

### DIFF
--- a/web/src/client/components/session-create-form.ts
+++ b/web/src/client/components/session-create-form.ts
@@ -524,10 +524,10 @@ export class SessionCreateForm extends LitElement {
           @click=${(e: Event) => e.stopPropagation()}
           data-testid="session-create-modal"
         >
-          <div class="p-3 sm:p-4 lg:p-6 mb-1 sm:mb-2 lg:mb-3 border-b border-base relative bg-gradient-to-r from-secondary to-tertiary flex-shrink-0">
+          <div class="p-3 sm:p-4 lg:p-6 mb-1 sm:mb-2 lg:mb-3 border-b border-border/50 relative bg-gradient-to-r from-bg-secondary to-bg-tertiary flex-shrink-0">
             <h2 id="modal-title" class="text-primary text-base sm:text-lg lg:text-xl font-bold">New Session</h2>
             <button
-              class="absolute top-2 right-2 sm:top-3 sm:right-3 lg:top-5 lg:right-5 text-muted hover:text-primary transition-all duration-200 p-1.5 sm:p-2 hover:bg-tertiary rounded-lg"
+              class="absolute top-2 right-2 sm:top-3 sm:right-3 lg:top-5 lg:right-5 text-text-muted hover:text-text transition-all duration-200 p-1.5 sm:p-2 hover:bg-bg-elevated/30 rounded-lg"
               @click=${this.handleCancel}
               title="Close (Esc)"
               aria-label="Close modal"
@@ -552,7 +552,7 @@ export class SessionCreateForm extends LitElement {
           <div class="p-3 sm:p-4 lg:p-6 overflow-y-auto flex-grow max-h-[65vh] sm:max-h-[75vh] lg:max-h-[80vh]">
             <!-- Session Name -->
             <div class="mb-2 sm:mb-3 lg:mb-5">
-              <label class="form-label text-muted text-[10px] sm:text-xs lg:text-sm">Session Name (Optional):</label>
+              <label class="form-label text-text-muted text-[10px] sm:text-xs lg:text-sm">Session Name (Optional):</label>
               <input
                 type="text"
                 class="input-field py-1.5 sm:py-2 lg:py-3 text-xs sm:text-sm"
@@ -566,7 +566,7 @@ export class SessionCreateForm extends LitElement {
 
             <!-- Command -->
             <div class="mb-2 sm:mb-3 lg:mb-5">
-              <label class="form-label text-muted text-[10px] sm:text-xs lg:text-sm">Command:</label>
+              <label class="form-label text-text-muted text-[10px] sm:text-xs lg:text-sm">Command:</label>
               <input
                 type="text"
                 class="input-field py-1.5 sm:py-2 lg:py-3 text-xs sm:text-sm"
@@ -580,7 +580,7 @@ export class SessionCreateForm extends LitElement {
 
             <!-- Working Directory -->
             <div class="mb-2 sm:mb-3 lg:mb-5">
-              <label class="form-label text-muted text-[10px] sm:text-xs lg:text-sm">Working Directory:</label>
+              <label class="form-label text-text-muted text-[10px] sm:text-xs lg:text-sm">Working Directory:</label>
               <div class="flex gap-1.5 sm:gap-2">
                 <input
                   type="text"
@@ -592,7 +592,7 @@ export class SessionCreateForm extends LitElement {
                   data-testid="working-dir-input"
                 />
                 <button
-                  class="bg-bg-tertiary border border-border rounded-lg p-1.5 sm:p-2 lg:p-3 font-mono text-muted transition-all duration-200 hover:text-primary hover:bg-surface-hover hover:border-primary hover:shadow-sm flex-shrink-0"
+                  class="bg-bg-tertiary border border-border/50 rounded-lg p-1.5 sm:p-2 lg:p-3 font-mono text-text-muted transition-all duration-200 hover:text-primary hover:bg-surface-hover hover:border-primary/50 hover:shadow-sm flex-shrink-0"
                   @click=${this.handleBrowse}
                   ?disabled=${this.disabled || this.isCreating}
                   title="Browse directories"
@@ -605,8 +605,8 @@ export class SessionCreateForm extends LitElement {
                   </svg>
                 </button>
                 <button
-                  class="bg-bg-tertiary border border-border rounded-lg p-1.5 sm:p-2 lg:p-3 font-mono text-muted transition-all duration-200 hover:text-primary hover:bg-surface-hover hover:border-primary hover:shadow-sm flex-shrink-0 ${
-                    this.showRepositoryDropdown ? 'text-primary border-primary' : ''
+                  class="bg-bg-tertiary border border-border/50 rounded-lg p-1.5 sm:p-2 lg:p-3 font-mono text-text-muted transition-all duration-200 hover:text-primary hover:bg-surface-hover hover:border-primary/50 hover:shadow-sm flex-shrink-0 ${
+                    this.showRepositoryDropdown ? 'text-primary border-primary/50' : ''
                   }"
                   @click=${this.handleToggleRepositoryDropdown}
                   ?disabled=${this.disabled || this.isCreating || this.repositories.length === 0 || this.isDiscovering}
@@ -624,21 +624,21 @@ export class SessionCreateForm extends LitElement {
               ${
                 this.showRepositoryDropdown && this.repositories.length > 0
                   ? html`
-                    <div class="mt-2 bg-bg-elevated border border-border rounded-lg overflow-hidden">
+                    <div class="mt-2 bg-bg-elevated border border-border/50 rounded-lg overflow-hidden">
                       <div class="max-h-48 overflow-y-auto">
                         ${this.repositories.map(
                           (repo) => html`
                             <button
                               @click=${() => this.handleSelectRepository(repo.path)}
-                              class="w-full text-left px-3 py-2 hover:bg-surface-hover transition-colors duration-200 border-b border-border last:border-b-0"
+                              class="w-full text-left px-3 py-2 hover:bg-surface-hover transition-colors duration-200 border-b border-border/30 last:border-b-0"
                               type="button"
                             >
                               <div class="flex items-center justify-between">
                                 <div>
-                                  <div class="text-dark-text text-xs sm:text-sm font-medium">${repo.folderName}</div>
-                                  <div class="text-dark-text-muted text-[9px] sm:text-[10px] mt-0.5">${repo.relativePath}</div>
+                                  <div class="text-text text-xs sm:text-sm font-medium">${repo.folderName}</div>
+                                  <div class="text-text-muted text-[9px] sm:text-[10px] mt-0.5">${repo.relativePath}</div>
                                 </div>
-                                <div class="text-dark-text-muted text-[9px] sm:text-[10px]">
+                                <div class="text-text-muted text-[9px] sm:text-[10px]">
                                   ${new Date(repo.lastModified).toLocaleDateString()}
                                 </div>
                               </div>
@@ -656,17 +656,17 @@ export class SessionCreateForm extends LitElement {
             ${
               this.macAppConnected
                 ? html`
-                  <div class="mb-2 sm:mb-3 lg:mb-5 flex items-center justify-between bg-elevated border border-base rounded-lg p-2 sm:p-3 lg:p-4">
+                  <div class="mb-2 sm:mb-3 lg:mb-5 flex items-center justify-between bg-bg-elevated border border-border/50 rounded-lg p-2 sm:p-3 lg:p-4">
                     <div class="flex-1 pr-2 sm:pr-3 lg:pr-4">
                       <span class="text-primary text-[10px] sm:text-xs lg:text-sm font-medium">Spawn window</span>
-                      <p class="text-[9px] sm:text-[10px] lg:text-xs text-muted mt-0.5 hidden sm:block">Opens native terminal window</p>
+                      <p class="text-[9px] sm:text-[10px] lg:text-xs text-text-muted mt-0.5 hidden sm:block">Opens native terminal window</p>
                     </div>
                     <button
                       role="switch"
                       aria-checked="${this.spawnWindow}"
                       @click=${this.handleSpawnWindowChange}
-                      class="relative inline-flex h-4 w-8 sm:h-5 sm:w-10 lg:h-6 lg:w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-base ${
-                        this.spawnWindow ? 'bg-primary' : 'bg-border'
+                      class="relative inline-flex h-4 w-8 sm:h-5 sm:w-10 lg:h-6 lg:w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary/50 focus:ring-offset-2 focus:ring-offset-bg-secondary ${
+                        this.spawnWindow ? 'bg-primary' : 'bg-border/50'
                       }"
                       ?disabled=${this.disabled || this.isCreating}
                       data-testid="spawn-window-toggle"
@@ -683,10 +683,10 @@ export class SessionCreateForm extends LitElement {
             }
 
             <!-- Terminal Title Mode -->
-            <div class="mb-2 sm:mb-4 lg:mb-6 flex items-center justify-between bg-elevated border border-base rounded-lg p-2 sm:p-3 lg:p-4">
+            <div class="mb-2 sm:mb-4 lg:mb-6 flex items-center justify-between bg-bg-elevated border border-border/50 rounded-lg p-2 sm:p-3 lg:p-4">
               <div class="flex-1 pr-2 sm:pr-3 lg:pr-4">
                 <span class="text-primary text-[10px] sm:text-xs lg:text-sm font-medium">Terminal Title Mode</span>
-                <p class="text-[9px] sm:text-[10px] lg:text-xs text-muted mt-0.5 hidden sm:block">
+                <p class="text-[9px] sm:text-[10px] lg:text-xs text-text-muted mt-0.5 hidden sm:block">
                   ${this.getTitleModeDescription()}
                 </p>
               </div>
@@ -694,16 +694,16 @@ export class SessionCreateForm extends LitElement {
                 <select
                   .value=${this.titleMode}
                   @change=${this.handleTitleModeChange}
-                  class="bg-secondary border border-base rounded-lg px-1.5 py-1 pr-6 sm:px-2 sm:py-1.5 sm:pr-7 lg:px-3 lg:py-2 lg:pr-8 text-primary text-[10px] sm:text-xs lg:text-sm transition-all duration-200 hover:border-primary-hover focus:border-primary focus:outline-none appearance-none cursor-pointer"
+                  class="bg-bg-tertiary border border-border/50 rounded-lg px-1.5 py-1 pr-6 sm:px-2 sm:py-1.5 sm:pr-7 lg:px-3 lg:py-2 lg:pr-8 text-text text-[10px] sm:text-xs lg:text-sm transition-all duration-200 hover:border-primary/50 focus:border-primary focus:outline-none appearance-none cursor-pointer"
                   style="min-width: 80px"
                   ?disabled=${this.disabled || this.isCreating}
                 >
-                  <option value="${TitleMode.NONE}" class="bg-secondary text-primary" ?selected=${this.titleMode === TitleMode.NONE}>None</option>
-                  <option value="${TitleMode.FILTER}" class="bg-secondary text-primary" ?selected=${this.titleMode === TitleMode.FILTER}>Filter</option>
-                  <option value="${TitleMode.STATIC}" class="bg-secondary text-primary" ?selected=${this.titleMode === TitleMode.STATIC}>Static</option>
-                  <option value="${TitleMode.DYNAMIC}" class="bg-secondary text-primary" ?selected=${this.titleMode === TitleMode.DYNAMIC}>Dynamic</option>
+                  <option value="${TitleMode.NONE}" class="bg-bg-tertiary text-text" ?selected=${this.titleMode === TitleMode.NONE}>None</option>
+                  <option value="${TitleMode.FILTER}" class="bg-bg-tertiary text-text" ?selected=${this.titleMode === TitleMode.FILTER}>Filter</option>
+                  <option value="${TitleMode.STATIC}" class="bg-bg-tertiary text-text" ?selected=${this.titleMode === TitleMode.STATIC}>Static</option>
+                  <option value="${TitleMode.DYNAMIC}" class="bg-bg-tertiary text-text" ?selected=${this.titleMode === TitleMode.DYNAMIC}>Dynamic</option>
                 </select>
-                <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-1 sm:px-1.5 lg:px-2 text-muted">
+                <div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-1 sm:px-1.5 lg:px-2 text-text-muted">
                   <svg class="h-2.5 w-2.5 sm:h-3 sm:w-3 lg:h-4 lg:w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
                   </svg>
@@ -713,7 +713,7 @@ export class SessionCreateForm extends LitElement {
 
             <!-- Quick Start Section -->
             <div class="mb-2 sm:mb-4 lg:mb-6">
-              <label class="form-label text-muted uppercase text-[9px] sm:text-[10px] lg:text-xs tracking-wider mb-1 sm:mb-2 lg:mb-3"
+              <label class="form-label text-text-muted uppercase text-[9px] sm:text-[10px] lg:text-xs tracking-wider mb-1 sm:mb-2 lg:mb-3"
                 >Quick Start</label
               >
               <div class="grid grid-cols-2 gap-2 sm:gap-2.5 lg:gap-3 mt-1.5 sm:mt-2">
@@ -723,8 +723,8 @@ export class SessionCreateForm extends LitElement {
                       @click=${() => this.handleQuickStart(command)}
                       class="${
                         this.command === command
-                          ? 'px-2 py-1.5 sm:px-3 sm:py-2 lg:px-4 lg:py-3 rounded-lg border text-left transition-all bg-primary bg-opacity-10 border-primary text-primary hover:bg-opacity-20 font-medium text-[10px] sm:text-xs lg:text-sm'
-                          : 'px-2 py-1.5 sm:px-3 sm:py-2 lg:px-4 lg:py-3 rounded-lg border text-left transition-all bg-elevated border-base text-primary hover:bg-hover hover:border-primary hover:text-primary text-[10px] sm:text-xs lg:text-sm'
+                          ? 'px-2 py-1.5 sm:px-3 sm:py-2 lg:px-4 lg:py-3 rounded-lg border text-left transition-all bg-primary bg-opacity-10 border-primary/50 text-primary hover:bg-opacity-20 font-medium text-[10px] sm:text-xs lg:text-sm'
+                          : 'px-2 py-1.5 sm:px-3 sm:py-2 lg:px-4 lg:py-3 rounded-lg border text-left transition-all bg-bg-elevated border-border/50 text-text hover:bg-hover hover:border-primary/50 hover:text-primary text-[10px] sm:text-xs lg:text-sm'
                       }"
                       ?disabled=${this.disabled || this.isCreating}
                     >
@@ -739,7 +739,7 @@ export class SessionCreateForm extends LitElement {
 
             <div class="flex gap-1.5 sm:gap-2 lg:gap-3 mt-2 sm:mt-3 lg:mt-4 xl:mt-6">
               <button
-                class="flex-1 bg-elevated border border-base text-primary px-2 py-1 sm:px-3 sm:py-1.5 lg:px-4 lg:py-2 xl:px-6 xl:py-3 rounded-lg font-mono text-[10px] sm:text-xs lg:text-sm transition-all duration-200 hover:bg-hover hover:border-light"
+                class="flex-1 bg-bg-elevated border border-border/50 text-text px-2 py-1 sm:px-3 sm:py-1.5 lg:px-4 lg:py-2 xl:px-6 xl:py-3 rounded-lg font-mono text-[10px] sm:text-xs lg:text-sm transition-all duration-200 hover:bg-hover hover:border-border"
                 @click=${this.handleCancel}
                 ?disabled=${this.isCreating}
               >


### PR DESCRIPTION
## Summary
- Fixed the new session dialog to have consistent dark mode styling
- Softened hard borders throughout the dialog using 50% opacity
- Fixed the terminal title mode picker that was showing in light mode colors

## Changes
- Updated all borders to use `border-border/50` for softer appearance
- Fixed terminal title mode select dropdown to use dark theme colors (`bg-bg-tertiary`, `text-text`)
- Updated all text labels to use proper `text-text-muted` color tokens
- Made spawn window toggle and repository dropdown consistent with dark theme
- Updated quick start buttons to use softer borders and proper dark colors
- Fixed hover states to use appropriate dark theme colors

## Test plan
- [x] Open new session dialog in dark mode
- [x] Verify all borders are softer (50% opacity)
- [x] Check that terminal title mode picker uses dark theme colors
- [x] Verify all form elements match the dark theme
- [x] Test hover states on all interactive elements
- [x] Ensure text is readable with proper contrast