### PR TITLE
Improve theme toggle UI with better icon and tooltips

### DIFF
--- a/web/src/client/components/theme-toggle-icon.ts
+++ b/web/src/client/components/theme-toggle-icon.ts
@@ -103,15 +103,18 @@ export class ThemeToggleIcon extends LitElement {
       case 'system':
         return html`
           <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor">
-            <path fill-rule="evenodd" d="M3 5a2 2 0 012-2h10a2 2 0 012 2v8a2 2 0 01-2 2h-2.22l.123.489.804.804A1 1 0 0113 18H7a1 1 0 01-.707-1.707l.804-.804L7.22 15H5a2 2 0 01-2-2V5zm5.771 7H5V5h10v7H8.771z" clip-rule="evenodd"/>
+            <path d="M10 2C5.858 2 2.5 5.358 2.5 9.5S5.858 17 10 17s7.5-3.358 7.5-7.5S14.142 2 10 2zM10 15.5V4.5c3.314 0 6 2.686 6 6s-2.686 6-6 6z"/>
           </svg>
         `;
     }
   }
 
   private getTooltip() {
-    const current = this.theme.charAt(0).toUpperCase() + this.theme.slice(1);
-    const next = this.theme === 'light' ? 'Dark' : this.theme === 'dark' ? 'System' : 'Light';
+    const current =
+      this.theme === 'system'
+        ? 'Auto (System)'
+        : this.theme.charAt(0).toUpperCase() + this.theme.slice(1);
+    const next = this.theme === 'light' ? 'Dark' : this.theme === 'dark' ? 'Auto' : 'Light';
     return `Theme: ${current} (click for ${next})`;
   }
 


### PR DESCRIPTION
## Summary
- Extracted theme toggle improvements from PR #429
- Improved visual clarity of the theme toggle button
- Enhanced user experience with clearer tooltips

## Changes
- **Updated system theme icon**: Replaced computer monitor icon with a half-light/half-dark circle design for better visual representation
- **Improved tooltip text**: System theme now shows as "Auto (System)" instead of just "System" for clearer communication
- **Consistent tooltip flow**: When cycling themes, the tooltip now shows "Auto" instead of "System" for the next state

## Test Plan
- [ ] Verify theme toggle button displays correct icons for all three states (light, dark, system)
- [ ] Check that tooltips show appropriate text for each state
- [ ] Confirm theme switching still works correctly
- [ ] Test in both light and dark modes

## Related
This PR extracts only the theme toggle improvements from #429, separating them from the terminal focus functionality changes.