### PR TITLE
Remove WebSocket-based configuration sync

### DIFF
--- a/docs/macos-quickstart-implementation.md
+++ b/docs/macos-quickstart-implementation.md
@@ -1,0 +1,392 @@
+# macOS Quick Start Configuration Implementation Guide
+
+This guide provides Swift implementation examples for adding quick start configuration support to the VibeTunnel macOS app.
+
+## 1. Configuration Model
+
+First, create Swift models that match the configuration structure:
+
+```swift
+// QuickStartConfiguration.swift
+import Foundation
+
+struct QuickStartCommand: Codable, Identifiable, Hashable {
+    let id = UUID()
+    var name: String?
+    var command: String
+    var emoji: String?
+    
+    // Display name falls back to command if name is nil
+    var displayName: String {
+        name?.isEmpty == false ? name! : command
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case name, command, emoji
+    }
+}
+
+struct VibeTunnelConfig: Codable {
+    var version: Int
+    var quickStartCommands: [QuickStartCommand]
+    
+    static let defaultCommands = [
+        QuickStartCommand(name: nil, command: "claude", emoji: "✨"),
+        QuickStartCommand(name: nil, command: "gemini", emoji: "✨"),
+        QuickStartCommand(name: nil, command: "zsh", emoji: nil),
+        QuickStartCommand(name: nil, command: "python3", emoji: nil),
+        QuickStartCommand(name: nil, command: "node", emoji: nil),
+        QuickStartCommand(name: nil, command: "pnpm run dev", emoji: "▶️")
+    ]
+    
+    static let defaultConfig = VibeTunnelConfig(
+        version: 1,
+        quickStartCommands: defaultCommands
+    )
+}
+```
+
+## 2. Configuration Service with File Watching
+
+Create a service to manage the configuration file and watch for changes:
+
+```swift
+// QuickStartConfigurationService.swift
+import Foundation
+import Combine
+
+class QuickStartConfigurationService: ObservableObject {
+    @Published var config: VibeTunnelConfig = .defaultConfig
+    
+    private let configURL: URL
+    private var fileMonitor: DispatchSourceFileSystemObject?
+    private let queue = DispatchQueue(label: "ai.vibetunnel.config.monitor")
+    
+    init() {
+        // Setup config directory and file path
+        let homeURL = FileManager.default.homeDirectoryForCurrentUser
+        let configDir = homeURL.appendingPathComponent(".vibetunnel")
+        self.configURL = configDir.appendingPathComponent("config.json")
+        
+        // Ensure directory exists
+        try? FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        
+        // Load initial configuration
+        loadConfiguration()
+        
+        // Start file monitoring
+        startMonitoring()
+    }
+    
+    deinit {
+        stopMonitoring()
+    }
+    
+    private func loadConfiguration() {
+        do {
+            let data = try Data(contentsOf: configURL)
+            config = try JSONDecoder().decode(VibeTunnelConfig.self, from: data)
+        } catch {
+            // If file doesn't exist or is invalid, create default
+            if !FileManager.default.fileExists(atPath: configURL.path) {
+                saveConfiguration(config: .defaultConfig)
+            }
+            config = .defaultConfig
+        }
+    }
+    
+    func saveConfiguration(config: VibeTunnelConfig) {
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(config)
+            try data.write(to: configURL)
+            self.config = config
+        } catch {
+            print("Failed to save configuration: \(error)")
+        }
+    }
+    
+    private func startMonitoring() {
+        let fileDescriptor = open(configURL.path, O_EVTONLY)
+        guard fileDescriptor >= 0 else { return }
+        
+        fileMonitor = DispatchSource.makeFileSystemObjectSource(
+            fileDescriptor: fileDescriptor,
+            eventMask: [.write, .rename],
+            queue: queue
+        )
+        
+        fileMonitor?.setEventHandler { [weak self] in
+            DispatchQueue.main.async {
+                self?.loadConfiguration()
+            }
+        }
+        
+        fileMonitor?.setCancelHandler {
+            close(fileDescriptor)
+        }
+        
+        fileMonitor?.resume()
+    }
+    
+    private func stopMonitoring() {
+        fileMonitor?.cancel()
+        fileMonitor = nil
+    }
+}
+```
+
+## 3. Quick Start Editor View
+
+Create a SwiftUI view for editing quick start commands:
+
+```swift
+// QuickStartEditorView.swift
+import SwiftUI
+
+struct QuickStartEditorView: View {
+    @ObservedObject var configService: QuickStartConfigurationService
+    @Environment(\.dismiss) private var dismiss
+    @State private var commands: [QuickStartCommand] = []
+    @State private var showingAddCommand = false
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                // Header
+                HStack {
+                    Text("Quick Start Commands")
+                        .font(.headline)
+                    Spacer()
+                    Button("Add") {
+                        showingAddCommand = true
+                    }
+                }
+                .padding()
+                
+                // Command List
+                List {
+                    ForEach($commands) { $command in
+                        QuickStartItemEditor(command: $command)
+                    }
+                    .onDelete(perform: deleteCommands)
+                    .onMove(perform: moveCommands)
+                }
+                .listStyle(InsetListStyle())
+                
+                // Footer buttons
+                HStack {
+                    Button("Reset to Defaults") {
+                        commands = VibeTunnelConfig.defaultCommands
+                    }
+                    .buttonStyle(.link)
+                    
+                    Spacer()
+                    
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                    .keyboardShortcut(.escape)
+                    
+                    Button("Save") {
+                        saveChanges()
+                        dismiss()
+                    }
+                    .keyboardShortcut(.return)
+                    .buttonStyle(.borderedProminent)
+                }
+                .padding()
+            }
+            .frame(width: 500, height: 400)
+            .onAppear {
+                commands = configService.config.quickStartCommands
+            }
+            .sheet(isPresented: $showingAddCommand) {
+                AddCommandSheet(commands: $commands)
+            }
+        }
+    }
+    
+    private func deleteCommands(at offsets: IndexSet) {
+        commands.remove(atOffsets: offsets)
+    }
+    
+    private func moveCommands(from source: IndexSet, to destination: Int) {
+        commands.move(fromOffsets: source, toOffset: destination)
+    }
+    
+    private func saveChanges() {
+        var newConfig = configService.config
+        newConfig.quickStartCommands = commands
+        configService.saveConfiguration(config: newConfig)
+    }
+}
+
+struct QuickStartItemEditor: View {
+    @Binding var command: QuickStartCommand
+    
+    var body: some View {
+        HStack {
+            // Emoji picker (simplified - could use NSPopover with emoji picker)
+            TextField("🎯", text: Binding(
+                get: { command.emoji ?? "" },
+                set: { command.emoji = $0.isEmpty ? nil : $0 }
+            ))
+            .frame(width: 40)
+            .textFieldStyle(RoundedBorderTextFieldStyle())
+            
+            // Name field
+            TextField("Display Name", text: Binding(
+                get: { command.name ?? "" },
+                set: { command.name = $0.isEmpty ? nil : $0 }
+            ))
+            .textFieldStyle(RoundedBorderTextFieldStyle())
+            
+            // Command field
+            TextField("Command", text: $command.command)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .font(.system(.body, design: .monospaced))
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+struct AddCommandSheet: View {
+    @Binding var commands: [QuickStartCommand]
+    @Environment(\.dismiss) private var dismiss
+    @State private var newCommand = QuickStartCommand(name: "", command: "", emoji: nil)
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Add Quick Start Command")
+                .font(.headline)
+            
+            QuickStartItemEditor(command: $newCommand)
+                .padding()
+            
+            HStack {
+                Button("Cancel") {
+                    dismiss()
+                }
+                .keyboardShortcut(.escape)
+                
+                Button("Add") {
+                    commands.append(newCommand)
+                    dismiss()
+                }
+                .keyboardShortcut(.return)
+                .buttonStyle(.borderedProminent)
+                .disabled(newCommand.command.isEmpty)
+            }
+        }
+        .padding()
+        .frame(width: 400)
+    }
+}
+```
+
+## 4. Integration with NewSessionForm
+
+Update the `NewSessionForm.swift` to use the configuration service:
+
+```swift
+// In NewSessionForm.swift
+
+struct NewSessionForm: View {
+    @StateObject private var configService = QuickStartConfigurationService()
+    // ... other properties
+    
+    var body: some View {
+        VStack {
+            // ... existing form content
+            
+            // Quick Start section with edit button
+            HStack {
+                Text("Quick Start")
+                    .font(.headline)
+                
+                Button(action: { showingQuickStartEditor = true }) {
+                    Image(systemName: "pencil.circle")
+                        .foregroundColor(.secondary)
+                        .opacity(isHovering ? 1.0 : 0.5)
+                }
+                .buttonStyle(.plain)
+                .help("Edit quick start commands")
+                .onHover { hovering in
+                    isHovering = hovering
+                }
+            }
+            
+            // Quick command grid
+            LazyVGrid(columns: [
+                GridItem(.flexible()),
+                GridItem(.flexible()),
+                GridItem(.flexible())
+            ], spacing: 8) {
+                ForEach(configService.config.quickStartCommands) { cmd in
+                    QuickCommandButton(
+                        title: cmd.displayName,
+                        emoji: cmd.emoji,
+                        action: {
+                            command = cmd.command
+                            // Auto-select dynamic title for AI commands
+                            if cmd.command.lowercased().contains("claude") || 
+                               cmd.command.lowercased().contains("gemini") {
+                                titleMode = .dynamic
+                            }
+                        }
+                    )
+                }
+            }
+            
+            // ... rest of form
+        }
+        .sheet(isPresented: $showingQuickStartEditor) {
+            QuickStartEditorView(configService: configService)
+        }
+    }
+}
+```
+
+## 5. App Storage Integration (Optional)
+
+If you want to also sync with UserDefaults for iCloud sync:
+
+```swift
+extension QuickStartConfigurationService {
+    func syncToUserDefaults() {
+        if let data = try? JSONEncoder().encode(config) {
+            UserDefaults.standard.set(data, forKey: "quickStartConfiguration")
+        }
+    }
+    
+    func syncFromUserDefaults() {
+        guard let data = UserDefaults.standard.data(forKey: "quickStartConfiguration"),
+              let savedConfig = try? JSONDecoder().decode(VibeTunnelConfig.self, from: data) else {
+            return
+        }
+        
+        // Merge or replace based on your sync strategy
+        self.config = savedConfig
+        saveConfiguration(config: savedConfig)
+    }
+}
+```
+
+## Testing
+
+1. Launch the app and verify default quick start commands appear
+2. Click the edit button next to "Quick Start"
+3. Add, remove, reorder commands
+4. Save and verify changes persist
+5. Edit `~/.vibetunnel/config.json` manually and verify app picks up changes
+6. Test that web server also reads the updated configuration
+
+## Notes
+
+- The file watcher uses GCD's DispatchSource for efficient file monitoring
+- Configuration changes are automatically picked up without app restart
+- The UI follows macOS design patterns with proper keyboard shortcuts
+- Consider adding validation for command syntax
+- Could enhance emoji picker with a proper NSPopover emoji selector

--- a/docs/macos-websocket-removal-guide.md
+++ b/docs/macos-websocket-removal-guide.md
@@ -1,0 +1,146 @@
+# macOS WebSocket Configuration Sync Removal Guide
+
+This guide explains how to remove WebSocket-based configuration sync from the macOS app, complementing the server-side changes in PR #439.
+
+## Components to Remove
+
+### 1. RepositoryPathSyncService
+
+The `RepositoryPathSyncService.swift` monitors UserDefaults changes and sends updates via the Unix socket. Since we're removing real-time sync, this service can be simplified or removed entirely.
+
+**Current flow to remove:**
+```swift
+// In RepositoryPathSyncService.swift
+private func observeRepositoryPathChanges() {
+    // This observer sends updates to the server when repository path changes
+    repositoryPathObserver = UserDefaults.standard.observe(\.repositoryBasePath, options: [.new, .old]) { [weak self] _, change in
+        guard let self = self,
+              let newValue = change.newValue as? String,
+              let oldValue = change.oldValue as? String,
+              newValue != oldValue else { return }
+        
+        // Remove this server update call
+        Task {
+            await self.updateServerRepositoryPath(newValue)
+        }
+    }
+}
+```
+
+**Options:**
+1. **Complete removal**: Delete `RepositoryPathSyncService.swift` entirely if it's only used for sync
+2. **Simplification**: Keep the service but remove the server update functionality
+
+### 2. SystemControlHandler
+
+In `SystemControlHandler.swift`, remove handling of repository path updates from the server:
+
+```swift
+// Remove this case from handleSystemRequest
+case "repository-path-update":
+    // This entire case can be removed as we no longer receive updates from server
+    guard let path = payload["path"] as? String else {
+        return ControlResponse(/* error */)
+    }
+    
+    // Remove the temporary sync disable logic
+    RepositoryPathSyncService.shared.temporarilyDisableSync()
+    UserDefaults.standard.repositoryBasePath = path
+    
+    return ControlResponse(/* success */)
+```
+
+### 3. Unix Socket Message Removal
+
+Remove repository path update messages from being sent to the server:
+
+```swift
+// In RepositoryPathSyncService or wherever it's called
+private func updateServerRepositoryPath(_ path: String) async {
+    // Remove this entire method that sends updates to server
+    let message = ControlMessage(
+        type: .request,
+        category: .system,
+        action: "repository-path-update",
+        payload: RepositoryPathUpdateRequest(path: path, source: "mac")
+    )
+    
+    // Don't send this message anymore
+    // await unixClient.send(message)
+}
+```
+
+## Simplified Architecture
+
+After removal, the configuration flow becomes:
+
+1. **Mac App → File**: User changes settings, app writes to UserDefaults (no server notification)
+2. **File → Server**: Server watches `~/.vibetunnel/config.json` for changes
+3. **Server → Web**: Web clients get updated config on page reload via `/api/config`
+
+## Implementation Steps
+
+### Step 1: Remove RepositoryPathSyncService usage
+
+In `VibeTunnelApp.swift` or wherever it's initialized:
+```swift
+// Remove or comment out
+// RepositoryPathSyncService.shared.startMonitoring()
+```
+
+### Step 2: Clean up SystemControlHandler
+
+```swift
+// SystemControlHandler.swift
+func handleSystemRequest(_ message: ControlMessage) async -> ControlResponse {
+    switch message.action {
+    // Remove "repository-path-update" case
+    // Keep other system actions that are still needed
+    default:
+        return ControlResponse(error: "Unknown system action")
+    }
+}
+```
+
+### Step 3: Remove sync-related UserDefaults extensions
+
+If there are any UserDefaults extensions specifically for sync, remove them:
+```swift
+// Remove if exists
+extension UserDefaults {
+    func notifyServerOfRepositoryPathChange() {
+        // Remove this method
+    }
+}
+```
+
+### Step 4: Update Settings UI (if needed)
+
+If the settings UI has any real-time sync indicators, remove them:
+```swift
+// In settings view
+// Remove any "Syncing..." or "Connected" status indicators related to config sync
+```
+
+## Benefits of Removal
+
+1. **Simpler codebase**: Less complex state management
+2. **Fewer race conditions**: No need to handle sync loops
+3. **Reduced network traffic**: No constant WebSocket connections
+4. **Clearer data flow**: Configuration changes follow a predictable path
+
+## Testing After Removal
+
+1. Change repository path in Mac app settings
+2. Verify it's saved to UserDefaults
+3. Verify server NO LONGER receives immediate updates
+4. Reload web UI and confirm it shows the current path from `/api/config`
+5. Verify no WebSocket errors in Console.app
+6. Check that Unix socket still works for other operations (terminal control, git, etc.)
+
+## Migration Notes
+
+- Existing users won't notice any change in functionality
+- Configuration updates still work, just require page reload
+- All other Unix socket functionality remains intact
+- This change only affects configuration sync, not terminal operations

--- a/web/src/server/websocket/control-unix-handler.ts
+++ b/web/src/server/websocket/control-unix-handler.ts
@@ -133,7 +133,6 @@ export class ControlUnixHandler {
   private readonly socketPath: string;
   private handlers = new Map<ControlCategory, MessageHandler>();
   private messageBuffer = Buffer.alloc(0);
-  private configUpdateCallback: ((config: { repositoryBasePath: string }) => void) | null = null;
   private currentRepositoryPath: string | null = null;
 
   constructor() {
@@ -578,14 +577,7 @@ export class ControlUnixHandler {
   }
 
   /**
-   * Set a callback to be called when configuration is updated
-   */
-  setConfigUpdateCallback(callback: (config: { repositoryBasePath: string }) => void): void {
-    this.configUpdateCallback = callback;
-  }
-
-  /**
-   * Update the repository path and notify all connected clients
+   * Update the repository path
    */
   async updateRepositoryPath(path: string): Promise<boolean> {
     logger.log(`updateRepositoryPath called with path: ${path}`);
@@ -593,17 +585,7 @@ export class ControlUnixHandler {
     try {
       this.currentRepositoryPath = path;
       logger.log(`Set currentRepositoryPath to: ${this.currentRepositoryPath}`);
-
-      // Call the callback to update server configuration and broadcast to web clients
-      if (this.configUpdateCallback) {
-        logger.log('Calling configUpdateCallback...');
-        this.configUpdateCallback({ repositoryBasePath: path });
-        logger.log('configUpdateCallback completed successfully');
-        return true;
-      }
-
-      logger.warn('No config update callback set - is the server initialized?');
-      return false;
+      return true;
     } catch (error) {
       logger.error('Failed to update repository path:', error);
       return false;


### PR DESCRIPTION
## Summary
This PR removes the WebSocket-based configuration synchronization between the web client and server, as it's no longer needed with the new file-based configuration approach.

## Changes Removed

### Client-side (unified-settings.ts)
- Removed `configWebSocket` property
- Removed `connectConfigWebSocket()` method and all WebSocket connection logic
- Removed automatic sending of repository path updates via WebSocket
- Removed WebSocket cleanup in `disconnectedCallback`

### Server-side (server.ts)
- Removed `configWebSocketClients` Set that tracked connected clients
- Removed `/ws/config` WebSocket endpoint handler
- Removed message handling for repository path updates from web clients
- Removed configuration broadcast logic when Mac app updates the path

### Control Unix Handler (control-unix-handler.ts)
- Removed `configUpdateCallback` property and `setConfigUpdateCallback()` method
- Simplified `updateRepositoryPath()` to only update the local state
- Kept the repository path update handler for Mac app communication

## Key Points
- The Unix socket communication for repository path updates from the Mac app is preserved
- The Mac app can still update the repository path via the Unix socket
- Web clients will need to reload to see configuration changes (as designed)
- This simplifies the codebase by removing real-time sync that's no longer needed

## Related
- Depends on PR #436 (file-based quick start configuration)
- Part of the migration to file-based configuration management

## Test Plan
1. Verify that changing repository path in the Mac app still works
2. Verify that the web UI loads the current repository path from `/api/config`
3. Verify no WebSocket errors in browser console
4. Verify server starts without errors