### PR TITLE
Fix file browser Git Changes mode behavior

### DIFF
--- a/web/src/client/components/file-browser.ts
+++ b/web/src/client/components/file-browser.ts
@@ -268,18 +268,21 @@ export class FileBrowser extends LitElement {
       // Use the absolute path provided by the server
       this.loadDirectory(file.path);
     } else {
+      // Clear previous state when selecting a new file
+      if (this.selectedFile?.path !== file.path) {
+        this.preview = null;
+        this.diff = null;
+        this.diffContent = null;
+        this.showDiff = false;
+      }
       // Set the selected file
       this.selectedFile = file;
       // On mobile, switch to preview view
       if (this.isMobile) {
         this.mobileView = 'preview';
       }
-      // If git changes filter is active and file has changes, show diff by default
-      if (this.gitFilter === 'changed' && file.gitStatus && file.gitStatus !== 'unchanged') {
-        this.loadDiff(file);
-      } else {
-        this.loadPreview(file);
-      }
+      // Always show file content by default, regardless of git filter
+      this.loadPreview(file);
     }
   }
 
@@ -408,7 +411,7 @@ export class FileBrowser extends LitElement {
       `;
     }
 
-    if (this.showDiff && this.diff) {
+    if (this.showDiff && (this.diff || this.diffContent)) {
       return this.renderDiff();
     }
 


### PR DESCRIPTION
## Summary
- Fixed file selection in Git Changes mode to show file content immediately instead of diff
- Fixed View Diff/View File button functionality 
- Fixed issue where selecting a new file would show the previous file's content

## Changes
- Always show file content by default when selecting files, not diff
- Clear previous file state (preview, diff, diffContent) when selecting a new file to prevent stale data
- Fix View Diff button to properly toggle between file and diff views
- Ensure diff content is checked along with diff data when rendering

## Test Plan
1. Open file browser in Chrome
2. Enable "Git Changes" filter
3. Click on a modified file - it should show the file content immediately (not diff)
4. Click "View Diff" button - it should show the diff
5. Click "View File" button - it should go back to file content
6. Click another file - it should show the new file's content (not the previous file)

Fixes #443