### PR TITLE
Fix authenticate-pam module missing in npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,7 +109,7 @@
 ### 👥 Contributors
 
 First-time contributors to VibeTunnel:
-- [@gopi-kori](https://github.com/gopi-kori) - Made ngrok URLs clickable with copy button in Settings (#422)
+- [@gopikori](https://github.com/gopikori) - Made ngrok URLs clickable with copy button in Settings (#422)
 - [@claudemini](https://github.com/claudemini) - Improved theme toggle UI with better icon and tooltips (#438)
 
 Additional contributors:


### PR DESCRIPTION
## Summary
Fixes the issue where the `authenticate-pam` module was missing from the npm package in beta 14, causing PAM authentication warnings on Linux systems.

## The Problem
In beta 14, users saw this warning:
```
⚠️ authenticate-pam not found - Linux PAM authentication disabled
```

The root cause was that the build script was looking for authenticate-pam in a hardcoded pnpm path that didn't match the actual installation structure, so the module wasn't copied to the npm package.

## The Solution
- Updated `copyAuthenticatePam()` function to search multiple possible locations
- Use `fs.statSync()` to properly follow symlinks
- Add fallback paths for different pnpm versions and structures
- Provide detailed logging when the module can't be found

## Code Changes
1. **Flexible path detection**: Try multiple paths including direct `node_modules` and various pnpm structures
2. **Better symlink handling**: Use `fs.statSync()` instead of `fs.existsSync()` to properly detect symlinked directories
3. **Improved diagnostics**: Log which paths were searched if the module isn't found

## Testing
- [x] Path detection correctly finds authenticate-pam in current pnpm structure
- [x] Build script will now include authenticate-pam in the npm package
- [x] All code quality checks pass

## Impact
This ensures that Linux users installing VibeTunnel from npm will have PAM authentication support available, allowing them to log in with their system credentials instead of relying on environment variables.