### PR TITLE
Remove screen recording permission requirement

### DIFF
--- a/mac/VibeTunnel/Core/Accessibility/AXElement.swift
+++ b/mac/VibeTunnel/Core/Accessibility/AXElement.swift
@@ -419,7 +419,7 @@ extension AXElement {
 // MARK: - Application Window Enumeration
 
 extension AXElement {
-    /// Information about an application window
+    /// Information about an application window retrieved via Accessibility APIs.
     public struct WindowInfo {
         public let window: AXElement
         public let windowID: CGWindowID
@@ -440,12 +440,36 @@ extension AXElement {
         }
     }
     
-    /// Enumerates all windows from running applications, optionally filtering by a predicate
+    /// Enumerates all windows from running applications using Accessibility APIs.
+    ///
+    /// This method provides a way to discover windows without requiring screen recording
+    /// permissions. It uses the Accessibility API to enumerate windows from running
+    /// applications, making it suitable for window tracking and management tasks.
+    ///
+    /// Example usage:
+    /// ```swift
+    /// // Get all terminal windows
+    /// let terminalBundleIDs = ["com.apple.Terminal", "com.googlecode.iterm2"]
+    /// let terminalWindows = AXElement.enumerateWindows(
+    ///     bundleIdentifiers: terminalBundleIDs,
+    ///     includeMinimized: false
+    /// )
+    ///
+    /// // Get all windows with custom filtering
+    /// let largeWindows = AXElement.enumerateWindows { windowInfo in
+    ///     guard let bounds = windowInfo.bounds else { return false }
+    ///     return bounds.width > 800 && bounds.height > 600
+    /// }
+    /// ```
+    ///
     /// - Parameters:
-    ///   - bundleIdentifiers: Optional array of bundle identifiers to filter applications. If nil, all applications are enumerated.
+    ///   - bundleIdentifiers: Optional array of bundle identifiers to filter applications. 
+    ///                        If nil, all applications are enumerated.
     ///   - includeMinimized: Whether to include minimized windows in the results (default: false)
-    ///   - filter: Optional filter closure to determine which windows to include
+    ///   - filter: Optional filter closure to determine which windows to include.
+    ///             The closure receives a WindowInfo and should return true to include the window.
     /// - Returns: Array of WindowInfo for windows that match the criteria
+    /// - Note: This method requires Accessibility permission to function properly
     public static func enumerateWindows(
         bundleIdentifiers: [String]? = nil,
         includeMinimized: Bool = false,
@@ -500,7 +524,11 @@ extension AXElement {
         return allWindows
     }
     
-    /// Convenience method to enumerate windows for specific bundle identifiers
+    /// Convenience method to enumerate windows for specific bundle identifiers.
+    ///
+    /// This is a simplified version of `enumerateWindows` for the common case
+    /// of finding windows from specific applications.
+    ///
     /// - Parameters:
     ///   - bundleIdentifiers: Array of bundle identifiers to search
     ///   - includeMinimized: Whether to include minimized windows


### PR DESCRIPTION
## Summary
- Replace CGWindowListCopyWindowInfo with Accessibility-only window tracking
- Eliminate screen recording permission dialog for better user experience
- Simplify permission model to only require Accessibility and AppleScript

## Changes
1. **Added generic window enumeration to AXElement.swift**
   - New `WindowInfo` struct to hold window data
   - `enumerateWindows()` method with flexible filtering support
   - Uses only Accessibility APIs - no screen recording permission needed

2. **Updated WindowEnumerator.swift**
   - Replaced `CGWindowListCopyWindowInfo` with `AXElement.enumerateWindows()`
   - Now uses only Accessibility APIs for window tracking
   - Maintains same functionality without screen recording permission

3. **Removed screen recording permission code**
   - Removed `ScreenCaptureKit` import
   - Removed `screenRecording` from `SystemPermission` enum
   - Removed all screen recording permission checking/requesting code
   - Updated permission explanations

## Benefits
- **Simpler permissions** - Only needs Accessibility and AppleScript
- **No more screen recording dialogs** - Better user experience
- **Unified API** - All window operations now use same AX APIs
- **Better consistency** - Same approach for window enumeration and manipulation

## Test Plan
- [x] Build succeeds
- [ ] Window tracking still works correctly
- [ ] No screen recording permission dialog appears
- [ ] All terminal types are properly detected
- [ ] Window properties (title, bounds, etc.) are correctly retrieved