### PR TITLE
chore: Remove unused ScreenCaptureKit import from ServerManager

### DIFF
--- a/mac/VibeTunnel/Core/Services/ServerManager.swift
+++ b/mac/VibeTunnel/Core/Services/ServerManager.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Observation
 import OSLog
-@preconcurrency import ScreenCaptureKit
 import SwiftUI
 
 /// Errors that can occur during server operations


### PR DESCRIPTION
Clean up unused ScreenCaptureKit dependency that was intended to be removed as part of https://github.com/amantus-ai/vibetunnel/pull/451