### PR TITLE
Fix blinking cursor in binary terminal mode

### DIFF
--- a/web/src/client/styles.css
+++ b/web/src/client/styles.css
@@ -1321,20 +1321,18 @@ body.initial-session-load .session-flex-responsive > session-card:nth-child(n + 
 /* Enhanced cursor styling */
 .terminal-char.cursor {
   animation: cursor-blink 1s infinite;
-  background-color: rgb(var(--color-primary));
-  color: rgb(10 10 10); /* Always dark text on cursor */
+  background-color: #23d18b !important; /* Green cursor */
+  color: #000000 !important; /* Black text on cursor */
 }
 
 @keyframes cursor-blink {
   0%,
   50% {
     opacity: 1;
-    background-color: rgb(var(--color-primary));
   }
   51%,
   100% {
-    opacity: 0.4;
-    background-color: rgb(var(--color-primary));
+    opacity: 0.3;
   }
 }
 

--- a/web/src/client/utils/terminal-renderer.ts
+++ b/web/src/client/utils/terminal-renderer.ts
@@ -161,10 +161,7 @@ function getCellStyling(cell: IBufferCell, isCursor: boolean): { classes: string
     }
   }
 
-  // Override background for cursor
-  if (isCursor) {
-    style += `background-color: #23d18b;`;
-  }
+  // Don't set background color for cursor - let CSS animation handle it
 
   // Get text attributes
   if (cell.isBold()) classes += ' bold';
@@ -234,10 +231,7 @@ function getCellStylingFromBuffer(
     }
   }
 
-  // Override background for cursor
-  if (isCursor) {
-    style += `background-color: #23d18b;`;
-  }
+  // Don't set background color for cursor - let CSS animation handle it
 
   // Get text attributes from bit flags
   const attrs = cell.attributes || 0;


### PR DESCRIPTION
## Summary
- Fixed the missing blinking cursor in binary terminal mode
- Cursor now properly blinks with green color like in standard terminals

## Changes
1. **Removed inline style override**: The terminal renderer was setting an inline `background-color` that prevented the CSS animation from working
2. **Fixed cursor position calculation**: Removed client-side viewport truncation that was causing incorrect cursor position mapping
3. **Added session status check**: Cursor only shows when session is "running", not when exited
4. **Updated cursor CSS**: Made cursor more visible with green color (#23d18b) and proper blinking animation

## Root Cause
The server already sends only the visible terminal area (terminal.rows worth of lines), but the client was doing additional truncation which caused the cursor position to be incorrectly calculated. Additionally, inline styles were overriding the CSS animation.

## Test Plan
- [x] Verified cursor blinks properly in binary terminal mode
- [x] Cursor appears in correct position
- [x] Cursor hides when session is exited
- [x] Animation works smoothly without flicker