### PR TITLE
Add Poltergeist integration for automatic builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,9 @@ mac/build-test/
 .aider*
 /.crush
 /.grok
+
+# Poltergeist
+.poltergeist.log
+.poltergeist/
+/tmp/poltergeist/
+.watchmanconfig

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,29 @@ VibeTunnel is a macOS application that allows users to access their terminal ses
 
 ### Building the Project
 
-#### macOS App
+#### macOS App with Poltergeist (Recommended if installed)
+
+If Poltergeist is installed, it will automatically rebuild the app when you make changes:
+
+```bash
+# First, ensure Poltergeist is running in the project root
+poltergeist
+
+# The app will automatically rebuild on file changes
+# Check Poltergeist menu bar app for build status
+```
+
+#### macOS App without Poltergeist (Fallback)
+
+If Poltergeist is not available, use direct Xcode builds:
+
 ```bash
 cd mac
+# Build using xcodebuild directly
+xcodebuild -project VibeTunnel.xcodeproj -scheme VibeTunnel -configuration Debug build
+
+# Or use the build script for release builds
 ./scripts/build.sh                           # Build release version
-./scripts/build.sh --configuration Debug     # Build debug version
 ./scripts/build.sh --sign                    # Build with code signing
 ```
 
@@ -254,6 +272,60 @@ The agent will:
 3. Address SwiftFormat violations
 4. Resolve any warning messages
 5. Verify the build succeeds after fixes
+
+## Poltergeist Integration
+
+Poltergeist is an intelligent file watcher and auto-builder that can automatically rebuild VibeTunnel when you make changes. When working on VibeTunnel development, check if Poltergeist is available and use it for automatic builds.
+
+### Checking for Poltergeist
+
+```bash
+# Check if Poltergeist is installed
+which poltergeist
+
+# Check if Poltergeist is already running for this project
+ps aux | grep poltergeist | grep -v grep
+```
+
+### Using Poltergeist for Development
+
+If Poltergeist is installed:
+
+1. **Start Poltergeist** in the project root:
+   ```bash
+   cd /path/to/vibetunnel
+   poltergeist
+   ```
+
+2. **Monitor build status** via the Poltergeist menu bar app (macOS) or terminal output
+
+3. **Make changes** - Poltergeist will automatically rebuild when it detects changes to:
+   - Swift files in `mac/` 
+   - Xcode project files
+   - Configuration files
+
+### Fallback Without Poltergeist
+
+If Poltergeist is not available, fall back to direct Xcode builds:
+
+```bash
+# Debug build
+cd mac
+xcodebuild -project VibeTunnel.xcodeproj -scheme VibeTunnel -configuration Debug build
+
+# Release build
+./scripts/build.sh
+```
+
+### Poltergeist Configuration
+
+The project includes `poltergeist.config.json` which configures:
+- **vibetunnel** target: Builds the macOS app in Debug configuration
+- **vibetunnel-ios** target: Builds the iOS app (disabled by default)
+- Intelligent debouncing to prevent excessive rebuilds
+- Build notifications via macOS notification center
+
+To enable iOS builds, edit `poltergeist.config.json` and set `"enabled": true` for the vibetunnel-ios target.
 
 ## NO BACKWARDS COMPATIBILITY - EVER!
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 - [npm Package](#npm-package)
 - [Building from Source](#building-from-source)
 - [Development](#development)
+- [Poltergeist Integration](#poltergeist-integration)
 - [Documentation](#documentation)
 - [macOS Permissions](#macos-permissions)
 - [Contributing](#contributing)
@@ -915,6 +916,44 @@ VIBETUNNEL_LOG_LEVEL=silent vt npm test
 ```
 
 **Note**: All logs are always written to `~/.vibetunnel/log.txt` regardless of verbosity level. The verbosity settings only control what's displayed in the terminal.
+
+## Poltergeist Integration
+
+[Poltergeist](https://github.com/poltergeist/poltergeist) is an intelligent file watcher and auto-builder that can automatically rebuild VibeTunnel as you develop. This is particularly useful for native app development where manual rebuilds can interrupt your flow.
+
+### Setting Up Poltergeist
+
+1. **Install Poltergeist** (if not already installed):
+   ```bash
+   npm install -g poltergeist
+   ```
+
+2. **Start Poltergeist** in the VibeTunnel directory:
+   ```bash
+   cd /path/to/vibetunnel
+   poltergeist
+   ```
+
+3. **Make changes** - Poltergeist will automatically rebuild when it detects changes to:
+   - Swift files in `mac/` or `ios/`
+   - Xcode project files
+   - Configuration files
+
+### Poltergeist Features
+
+- **Automatic Rebuilds**: Detects file changes and rebuilds instantly
+- **Smart Debouncing**: Prevents excessive rebuilds during rapid edits
+- **Build Notifications**: macOS notifications for build success/failure
+- **Menu Bar Integration**: Monitor build status from the macOS menu bar
+- **Parallel Builds**: Can build macOS and iOS targets simultaneously
+
+### Configuration
+
+VibeTunnel includes a `poltergeist.config.json` that configures:
+- **vibetunnel** target: Builds the macOS app in Debug configuration
+- **vibetunnel-ios** target: Builds the iOS app (disabled by default)
+
+To enable iOS builds, edit `poltergeist.config.json` and set `"enabled": true` for the vibetunnel-ios target.
 
 ## Documentation
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -9,10 +9,17 @@ The main build orchestration happens through shell scripts in `mac/scripts/` tha
 
 ### macOS Application Build
 
-**Development Build** - Quick build without code signing:
+**Development Build with Poltergeist** (Recommended):
+```bash
+# Start Poltergeist for automatic rebuilds
+poltergeist
+# Make changes - app rebuilds automatically
+```
+
+**Development Build without Poltergeist**:
 ```bash
 cd mac
-./scripts/build.sh --configuration Debug
+xcodebuild -project VibeTunnel.xcodeproj -scheme VibeTunnel -configuration Debug build
 ```
 
 **Release Build** - Full build with code signing:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -718,8 +718,11 @@ cleanupOnStartup: Bool = true
 # Complete build
 cd mac && ./scripts/build.sh --configuration Release --sign
 
-# Development build
-cd mac && ./scripts/build.sh --configuration Debug
+# Development build (with Poltergeist if available)
+poltergeist  # Automatic rebuilds on file changes
+
+# Or manual build
+cd mac && xcodebuild -project VibeTunnel.xcodeproj -scheme VibeTunnel -configuration Debug build
 ```
 
 **Build Phases**:

--- a/poltergeist.config.json
+++ b/poltergeist.config.json
@@ -1,9 +1,9 @@
 {
   "version": "1.0",
-  "projectType": "multi-platform",
+  "projectType": "swift",
   "targets": [
     {
-      "name": "vibetunnel-mac",
+      "name": "vibetunnel",
       "type": "app-bundle",
       "enabled": true,
       "buildCommand": "cd mac && ./scripts/build.sh --configuration Debug",
@@ -19,27 +19,6 @@
       "debounceInterval": 3000,
       "environment": {
         "CONFIGURATION": "Debug"
-      }
-    },
-    {
-      "name": "vibetunnel-web",
-      "type": "executable",
-      "enabled": true,
-      "buildCommand": "cd web && pnpm run build",
-      "outputPath": "./web/dist/server/server.js",
-      "watchPaths": [
-        "web/src/**/*.ts",
-        "web/src/**/*.js",
-        "web/src/**/*.css",
-        "web/src/**/*.html",
-        "web/package.json",
-        "web/tsconfig.json",
-        "web/vite.config.ts"
-      ],
-      "settlingDelay": 1000,
-      "debounceInterval": 2000,
-      "environment": {
-        "NODE_ENV": "development"
       }
     },
     {
@@ -72,7 +51,7 @@
       ".next",
       "out"
     ],
-    "projectType": "multi-platform",
+    "projectType": "swift",
     "maxFileEvents": 10000,
     "recrawlThreshold": 5,
     "settlingDelay": 1000

--- a/poltergeist.config.json
+++ b/poltergeist.config.json
@@ -1,0 +1,110 @@
+{
+  "version": "1.0",
+  "projectType": "multi-platform",
+  "targets": [
+    {
+      "name": "vibetunnel-mac",
+      "type": "app-bundle",
+      "enabled": true,
+      "buildCommand": "cd mac && ./scripts/build.sh --configuration Debug",
+      "outputPath": "./mac/build/Debug/VibeTunnel.app",
+      "watchPaths": [
+        "mac/**/*.swift",
+        "mac/**/*.xcodeproj/**",
+        "mac/**/*.xcconfig",
+        "mac/**/*.entitlements",
+        "mac/**/*.plist"
+      ],
+      "settlingDelay": 1500,
+      "debounceInterval": 3000,
+      "environment": {
+        "CONFIGURATION": "Debug"
+      }
+    },
+    {
+      "name": "vibetunnel-web",
+      "type": "executable",
+      "enabled": true,
+      "buildCommand": "cd web && pnpm run build",
+      "outputPath": "./web/dist/server/server.js",
+      "watchPaths": [
+        "web/src/**/*.ts",
+        "web/src/**/*.js",
+        "web/src/**/*.css",
+        "web/src/**/*.html",
+        "web/package.json",
+        "web/tsconfig.json",
+        "web/vite.config.ts"
+      ],
+      "settlingDelay": 1000,
+      "debounceInterval": 2000,
+      "environment": {
+        "NODE_ENV": "development"
+      }
+    },
+    {
+      "name": "vibetunnel-ios",
+      "type": "app-bundle",
+      "enabled": false,
+      "buildCommand": "cd ios && xcodebuild -project VibeTunnel-iOS.xcodeproj -scheme VibeTunnel-iOS -sdk iphonesimulator build",
+      "outputPath": "./ios/build/Debug-iphonesimulator/VibeTunnel.app",
+      "watchPaths": [
+        "ios/**/*.swift",
+        "ios/**/*.xcodeproj/**",
+        "ios/**/*.xcconfig",
+        "ios/**/*.entitlements",
+        "ios/**/*.plist"
+      ],
+      "settlingDelay": 1500,
+      "debounceInterval": 3000
+    }
+  ],
+  "watchman": {
+    "useDefaultExclusions": true,
+    "excludeDirs": [
+      "node_modules",
+      "dist",
+      "build",
+      "DerivedData",
+      ".git",
+      ".poltergeist",
+      "coverage",
+      ".next",
+      "out"
+    ],
+    "projectType": "multi-platform",
+    "maxFileEvents": 10000,
+    "recrawlThreshold": 5,
+    "settlingDelay": 1000
+  },
+  "buildScheduling": {
+    "parallelization": 2,
+    "prioritization": {
+      "enabled": true,
+      "focusDetectionWindow": 300000,
+      "priorityDecayTime": 1800000,
+      "buildTimeoutMultiplier": 2.0
+    }
+  },
+  "notifications": {
+    "enabled": true,
+    "buildStart": false,
+    "buildSuccess": true,
+    "buildFailed": true,
+    "successSound": "Glass",
+    "failureSound": "Basso",
+    "icon": "./mac/VibeTunnel/Assets.xcassets/AppIcon.appiconset/icon_128x128.png"
+  },
+  "performance": {
+    "profile": "balanced",
+    "autoOptimize": true,
+    "metrics": {
+      "enabled": true,
+      "reportInterval": 300
+    }
+  },
+  "logging": {
+    "level": "info",
+    "file": ".poltergeist.log"
+  }
+}


### PR DESCRIPTION
## Summary

Integrates Poltergeist file watcher and auto-builder to provide automatic rebuilds during development, replacing manual debug build workflows.

## Changes

### Configuration
- Added `poltergeist.config.json` with targets for macOS and iOS apps
- Updated `.gitignore` to exclude Poltergeist-generated files
- Configured intelligent debouncing and build notifications

### Documentation Updates
- **CLAUDE.md**: Added Poltergeist as the primary build method with xcodebuild fallback
- **README.md**: Added comprehensive Poltergeist Integration section
- **docs/build-system.md**: Updated to prefer Poltergeist for development builds
- **docs/spec.md**: Updated build instructions to mention Poltergeist

## Benefits

1. **Automatic Rebuilds**: No more manual rebuilds - changes trigger builds automatically
2. **Better Developer Experience**: Focus on coding instead of build commands
3. **Smart Debouncing**: Prevents excessive rebuilds during rapid edits
4. **Build Notifications**: Get notified of build success/failure via macOS notifications
5. **Fallback Support**: Documentation includes xcodebuild commands for when Poltergeist isn't available

## Usage

With Poltergeist installed:
```bash
cd /path/to/vibetunnel
poltergeist
# Make changes - automatic rebuilds happen
```

Without Poltergeist (fallback):
```bash
cd mac
xcodebuild -project VibeTunnel.xcodeproj -scheme VibeTunnel -configuration Debug build
```

## Testing

- [x] Poltergeist config validates correctly
- [x] Documentation is clear and comprehensive
- [x] Fallback instructions work without Poltergeist

## Related

This simplifies the development workflow by removing the need for manual debug builds, making it easier for contributors and improving the development experience when working with Claude Code.