### PR TITLE
Tweak: don't create log messages that won't get logged

### DIFF
--- a/ios/VibeTunnel/Utils/Logger.swift
+++ b/ios/VibeTunnel/Utils/Logger.swift
@@ -46,28 +46,33 @@ struct Logger {
         self.osLogger = os.Logger(subsystem: "sh.vibetunnel.ios", category: category)
     }
 
-    func verbose(_ message: String) {
+    func verbose(_ message: @autoclosure () -> String) {
         guard LogLevel.verbose >= Self.globalLevel else { return }
+        let message = message()
         self.osLogger.trace("\(message, privacy: .public)")
     }
 
-    func debug(_ message: String) {
+    func debug(_ message: @autoclosure () -> String) {
         guard LogLevel.debug >= Self.globalLevel else { return }
+        let message = message()
         self.osLogger.debug("\(message, privacy: .public)")
     }
 
-    func info(_ message: String) {
+    func info(_ message: @autoclosure () -> String) {
         guard LogLevel.info >= Self.globalLevel else { return }
+        let message = message()
         self.osLogger.info("\(message, privacy: .public)")
     }
 
-    func warning(_ message: String) {
+    func warning(_ message: @autoclosure () -> String) {
         guard LogLevel.warning >= Self.globalLevel else { return }
+        let message = message()
         self.osLogger.warning("\(message, privacy: .public)")
     }
 
-    func error(_ message: String) {
+    func error(_ message: @autoclosure () -> String) {
         guard LogLevel.error >= Self.globalLevel else { return }
+        let message = message()
         self.osLogger.error("\(message, privacy: .public)")
     }
 }

--- a/ios/VibeTunnelTests/Utils/LoggerTests.swift
+++ b/ios/VibeTunnelTests/Utils/LoggerTests.swift
@@ -83,6 +83,29 @@ struct LoggerTests {
         #expect(true)
     }
 
+    @Test("Logger avoids evaluating filtered messages")
+    func loggerLazyMessages() {
+        let logger = Logger(category: "Test")
+        let originalLogLevel = Logger.globalLevel
+        defer {
+            Logger.globalLevel = originalLogLevel
+        }
+
+        var didEvaluate = false
+        func makeMessage() -> String {
+            didEvaluate = true
+            return "Lazy message"
+        }
+
+        Logger.globalLevel = .error
+        logger.debug(makeMessage())
+        #expect(didEvaluate == false)
+
+        Logger.globalLevel = .verbose
+        logger.debug(makeMessage())
+        #expect(didEvaluate == true)
+    }
+
     @Test("Default log level based on build configuration")
     func defaultLogLevel() {
         // Reset to see what the default is


### PR DESCRIPTION
Started reading the iOS source and noticed a minor thing: the `Logger` wrapper struct creates the concrete message `String` *before* checking if it should actually get logged. 

This PR moves message-creation after the log-level check. 

PS: it'd be cleaner to forward the `@autoclosure` (e.g. `osLogger.debug("\(message(), privacy: .public)")`), but doing that would obligate `message` to also be `@escaping`, which wouldn't be advisable.