### PR TITLE
Fix keyboard input not working on Firefox/Safari (#507)

### DIFF
--- a/web/src/client/components/session-view/direct-keyboard-manager.ts
+++ b/web/src/client/components/session-view/direct-keyboard-manager.ts
@@ -78,7 +78,8 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
 
     // Add global paste listener for environments where Clipboard API doesn't work
     this.setupGlobalPasteListener();
-    this.ensureHiddenInputVisible();
+    // Don't create hidden input on initialization - only create when needed for mobile
+    // This prevents Firefox/Safari keyboard input issues on desktop
   }
 
   setInputManager(inputManager: InputManager): void {

--- a/web/src/client/components/session-view/input-manager.ts
+++ b/web/src/client/components/session-view/input-manager.ts
@@ -506,22 +506,41 @@ export class InputManager {
   isKeyboardShortcut(e: KeyboardEvent): boolean {
     // Check if we're typing in an input field or editor
     const target = e.target as HTMLElement;
-    if (
-      target.tagName === 'INPUT' ||
-      target.tagName === 'TEXTAREA' ||
-      target.tagName === 'SELECT' ||
-      target.contentEditable === 'true' ||
-      target.closest?.('.monaco-editor') ||
-      target.closest?.('[data-keybinding-context]') ||
-      target.closest?.('.editor-container') ||
-      target.closest?.('inline-edit') // Allow typing in inline-edit component
-    ) {
-      // Special exception: allow copy/paste shortcuts even in input fields (like our IME input)
-      if (isCopyPasteShortcut(e)) {
-        return true;
+
+    // Check if target exists and has proper properties
+    // In Firefox/Safari, target might be null or not have tagName
+    if (target?.tagName) {
+      // Check for form elements
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.tagName === 'SELECT' ||
+        target.contentEditable === 'true'
+      ) {
+        // Special exception: allow copy/paste shortcuts even in input fields (like our IME input)
+        if (isCopyPasteShortcut(e)) {
+          return true;
+        }
+        // Allow normal input in form fields and editors for other keys
+        return false;
       }
-      // Allow normal input in form fields and editors for other keys
-      return false;
+
+      // Check for parent elements using closest (with fallback for browsers that don't support it)
+      if (typeof target.closest === 'function') {
+        if (
+          target.closest('.monaco-editor') ||
+          target.closest('[data-keybinding-context]') ||
+          target.closest('.editor-container') ||
+          target.closest('inline-edit') // Allow typing in inline-edit component
+        ) {
+          // Special exception: allow copy/paste shortcuts even in input fields
+          if (isCopyPasteShortcut(e)) {
+            return true;
+          }
+          // Allow normal input in form fields and editors for other keys
+          return false;
+        }
+      }
     }
 
     // Check if this is a critical browser shortcut

--- a/web/src/client/components/session-view/lifecycle-event-manager.ts
+++ b/web/src/client/components/session-view/lifecycle-event-manager.ts
@@ -218,6 +218,15 @@ export class LifecycleEventManager extends ManagerEventEmitter {
       return;
     }
 
+    // Log for debugging Firefox/Safari issues
+    const activeElement = document.activeElement;
+    logger.log('Keyboard event received', {
+      key: e.key,
+      target: (e.target as HTMLElement)?.tagName,
+      activeElement: activeElement?.tagName,
+      activeElementId: (activeElement as HTMLElement)?.id,
+    });
+
     // Check if IME input is focused - block keyboard events except for editing keys
     if (document.body.getAttribute('data-ime-input-focused') === 'true') {
       if (!isIMEAllowedKey(e)) {
@@ -325,6 +334,14 @@ export class LifecycleEventManager extends ManagerEventEmitter {
 
     // Make session-view focusable
     this.callbacks.setTabIndex(0);
+
+    // Focus the element immediately for Firefox/Safari compatibility
+    // This ensures keyboard events are properly captured
+    setTimeout(() => {
+      if (!this.callbacks?.getDisableFocusManagement()) {
+        this.callbacks?.focus();
+      }
+    }, 100);
 
     // Store click handler reference for proper cleanup
     this.clickHandler = () => {
@@ -491,7 +508,11 @@ export class LifecycleEventManager extends ManagerEventEmitter {
     // Only add listeners if not already added
     if (!isMobile && !this.keyboardListenerAdded) {
       // Don't use capture phase - let browser handle shortcuts naturally
-      document.addEventListener('keydown', this.keyboardHandler);
+      // Add a slight delay for Firefox/Safari to ensure the DOM is ready
+      setTimeout(() => {
+        document.addEventListener('keydown', this.keyboardHandler);
+        logger.log('Keyboard event listener attached');
+      }, 0);
       this.keyboardListenerAdded = true;
     } else if (isMobile && !this.touchListenersAdded) {
       // Add touch event listeners for mobile swipe gestures


### PR DESCRIPTION
## Problem

Users reported being unable to type anything when using Firefox on Mac, as well as Safari on various platforms. This was a critical issue affecting cross-browser compatibility.

## Root Cause

The issue was caused by multiple factors:
1. **DirectKeyboardManager interference**: The DirectKeyboardManager was creating a hidden input element even on desktop browsers, which could steal focus from the terminal
2. **Focus management**: Firefox/Safari handle focus differently than Chrome, and the session-view element wasn't getting focus properly
3. **Event target detection**: The keyboard event handler wasn't properly checking for null/undefined targets in Firefox/Safari

## Solution

### 1. Fixed DirectKeyboardManager
- Removed automatic creation of hidden input on initialization
- Hidden input is now only created when actually needed (for mobile devices)
- This prevents the hidden input from interfering with keyboard events on desktop

### 2. Improved Focus Management
- Added immediate focus to session-view element when lifecycle is set up
- Ensures keyboard events are properly captured in Firefox/Safari
- Added slight delay to keyboard event listener attachment for DOM readiness

### 3. Enhanced Browser Compatibility
- Fixed event target detection to handle null/undefined cases
- Added optional chaining for better browser support
- Improved closest() method checks with fallback for older browsers

### 4. Added Debugging
- Added logging to help diagnose keyboard event issues
- Logs key events, target element, and active element for troubleshooting

## Testing
✅ **Confirmed working by author:**
- Keyboard input now works on Firefox (Mac)
- Keyboard input now works on Safari (Mac)
- Chrome functionality remains unchanged
- Mobile keyboard handling is preserved

## Screenshots
The author has screenshots confirming the fix works on both Firefox and Safari.

## Fixes
Closes #507