### PR TITLE
docs: add Tailscale Serve enablement requirement to setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ The server runs as a standalone Node.js executable with embedded modules, provid
    - **Android**: [Download from Google Play](https://play.google.com/store/apps/details?id=com.tailscale.ipn)
    - **Other platforms**: [All Downloads](https://tailscale.com/download)
 3. Sign in to both devices with the same account
-4. If using VibeTunnel's Tailscale Serve integration, ensure Tailscale Serve is enabled in your [tailnet settings](https://login.tailscale.com/admin/settings/features)
+4. If using VibeTunnel's Tailscale Serve integration, ensure Tailscale Serve is enabled in your [tailnet settings](https://login.tailscale.com/f/serve)
 5. Find your Mac's Tailscale hostname in the Tailscale menu bar app (e.g., `my-mac.tailnet-name.ts.net`)
 6. Access VibeTunnel at `http://[your-tailscale-hostname]:4020`
 


### PR DESCRIPTION
## Summary
This is my first PR to this repo. Please let me know if I'm missing anything.

Adds documentation about enabling Tailscale Serve feature in tailnet settings, which is required when using VibeTunnel's Tailscale Serve integration.

## Changes
- Added step 4 to Tailscale setup guide mentioning the requirement to enable Tailscale Serve in tailnet settings
- Included direct link to tailnet settings page for easy access

## Motivation
Users were encountering "No serve config" errors when trying to use Tailscale Serve integration because the feature wasn't enabled at the tailnet level. This update helps users avoid this common setup issue.