### PR TITLE
fix: OSX Notification Service Authentication & Local Signing Fixes

### DIFF
--- a/mac/VibeTunnel/Core/Services/NotificationService.swift
+++ b/mac/VibeTunnel/Core/Services/NotificationService.swift
@@ -21,6 +21,9 @@ final class NotificationService: NSObject, @preconcurrency UNUserNotificationCen
     private var isConnected = false
     private var recentlyNotifiedSessions = Set<String>()
     private var notificationCleanupTimer: Timer?
+    private var reconnectTask: Task<Void, Never>?
+    private var reconnectDelay: TimeInterval = 1.0
+    private let maxReconnectDelay: TimeInterval = 30.0
 
     /// Public property to check SSE connection status
     var isSSEConnected: Bool { isConnected }
@@ -93,6 +96,11 @@ final class NotificationService: NSObject, @preconcurrency UNUserNotificationCen
 
         super.init()
 
+        // Set delegate immediately on initialization
+        // This ensures it's set before the app finishes launching, which is required for proper notification handling
+        UNUserNotificationCenter.current().delegate = self
+        logger.info("✅ NotificationService set as UNUserNotificationCenter delegate in init()")
+
         // Defer dependency setup to avoid circular initialization
         Task { @MainActor in
             self.serverProvider = ServerManager.shared
@@ -110,11 +118,7 @@ final class NotificationService: NSObject, @preconcurrency UNUserNotificationCen
     func start() async {
         logger.info("🚀 NotificationService.start() called")
 
-        // Set delegate here to ensure it's done at the right time
-        UNUserNotificationCenter.current().delegate = self
-        logger.info("✅ NotificationService set as UNUserNotificationCenter delegate in start()")
-
-        // Debug: Log current delegate to verify it's set
+        // Delegate is already set in init(), but we can log it for debugging
         let currentDelegate = UNUserNotificationCenter.current().delegate
         logger.info("🔍 Current UNUserNotificationCenter delegate: \(String(describing: currentDelegate))")
         // Check if notifications are enabled in config
@@ -170,6 +174,8 @@ final class NotificationService: NSObject, @preconcurrency UNUserNotificationCen
 
     /// Stop monitoring server events
     func stop() {
+        reconnectTask?.cancel()
+        reconnectTask = nil
         disconnect()
     }
 
@@ -441,7 +447,10 @@ final class NotificationService: NSObject, @preconcurrency UNUserNotificationCen
 
     /// Open System Settings to the Notifications pane
     func openNotificationSettings() {
-        if let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") {
+        // Try to open directly to the app's settings
+        if let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension?id=sh.vibetunnel.vibetunnel") {
+            NSWorkspace.shared.open(url)
+        } else if let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") {
             NSWorkspace.shared.open(url)
         }
     }
@@ -547,10 +556,13 @@ final class NotificationService: NSObject, @preconcurrency UNUserNotificationCen
         // Add authorization header if auth token is available.
         // When auth mode is "none", there's no token, and that's okay.
         if let authToken = serverProvider.localAuthToken {
-            headers["Authorization"] = "Bearer \(authToken)"
+            // Use x-vibetunnel-local header for local bypass authentication
+            // The backend middleware specifically checks this header for localhost requests
+            headers[NetworkConstants.localAuthHeader] = authToken
+            
             // Show token prefix for debugging (first 10 chars only for security)
             let tokenPrefix = String(authToken.prefix(10))
-            logger.info("🔑 Using auth token for SSE connection: \(tokenPrefix, privacy: .public)...")
+            logger.info("🔑 Using local auth token for SSE connection: \(tokenPrefix, privacy: .public)...")
         } else {
             logger.info("🔓 Connecting to SSE without an auth token (auth mode: '\(serverProvider.authMode)')")
         }
@@ -565,6 +577,7 @@ final class NotificationService: NSObject, @preconcurrency UNUserNotificationCen
                 guard let self else { return }
                 self.logger.info("✅ Connected to notification event stream")
                 self.isConnected = true
+                self.reconnectDelay = 1.0 // Reset backoff
                 // Post notification for UI update
                 NotificationCenter.default.post(name: .notificationServiceConnectionChanged, object: nil)
             }
@@ -579,7 +592,9 @@ final class NotificationService: NSObject, @preconcurrency UNUserNotificationCen
                 self.isConnected = false
                 // Post notification for UI update
                 NotificationCenter.default.post(name: .notificationServiceConnectionChanged, object: nil)
-                // Don't reconnect here - let server state changes trigger reconnection
+                
+                // Attempt to reconnect if server is running
+                self.scheduleReconnect()
             }
         }
 
@@ -906,6 +921,32 @@ final class NotificationService: NSObject, @preconcurrency UNUserNotificationCen
         }
     }
 
+    private func scheduleReconnect() {
+        guard configProvider?.notificationsEnabled ?? false else { return }
+        guard serverProvider?.isRunning ?? false else { return }
+        
+        reconnectTask?.cancel()
+        
+        let delay = reconnectDelay
+        logger.info("🔄 Scheduling reconnection in \(delay) seconds...")
+        
+        reconnectTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            
+            guard !Task.isCancelled else { return }
+            
+            // Double check conditions
+            guard self.configProvider?.notificationsEnabled ?? false else { return }
+            guard self.serverProvider?.isRunning ?? false else { return }
+            
+            self.logger.info("🔁 Attempting reconnection...")
+            self.connect()
+            
+            // Increase delay for next attempt
+            self.reconnectDelay = min(self.reconnectDelay * 1.5, self.maxReconnectDelay)
+        }
+    }
+
     /// Send a test notification through the server to verify the full flow
     @MainActor
     func sendServerTestNotification() async {
@@ -946,8 +987,8 @@ final class NotificationService: NSObject, @preconcurrency UNUserNotificationCen
 
         // Add auth token if available
         if let authToken = serverProvider?.localAuthToken {
-            request.setValue("Bearer \(authToken)", forHTTPHeaderField: "Authorization")
-            logger.debug("Added auth token to request")
+            request.setValue(authToken, forHTTPHeaderField: NetworkConstants.localAuthHeader)
+            logger.debug("Added local auth token to request")
         }
 
         do {

--- a/mac/scripts/build.sh
+++ b/mac/scripts/build.sh
@@ -106,7 +106,8 @@ fi
 # Prepare code signing arguments
 CODE_SIGN_ARGS=""
 if [[ "${CI:-false}" == "true" ]] || [[ "$SIGN_APP" == false ]]; then
-    # In CI or when not signing, disable code signing entirely
+    # In CI or when not signing, disable code signing entirely during build
+    # We will manually apply ad-hoc signing later for local builds
     CODE_SIGN_ARGS="CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CODE_SIGN_ENTITLEMENTS=\"\" ENABLE_HARDENED_RUNTIME=NO PROVISIONING_PROFILE_SPECIFIER=\"\" DEVELOPMENT_TEAM=\"\""
 fi
 
@@ -179,6 +180,19 @@ echo "Cleaning up unwanted files from bundle..."
 rm -f "$APP_PATH/Contents/Resources/Local.xcconfig"
 rm -rf "$APP_PATH/Contents/Resources/web/public/tests"
 echo "✓ Removed development files from bundle"
+
+# Apply ad-hoc signature for local builds (if not CI and not signing with cert)
+if [[ "${CI:-false}" != "true" ]] && [[ "$SIGN_APP" == false ]]; then
+    echo "Applying ad-hoc signature for local build..."
+    ENTITLEMENTS_PATH="$MAC_DIR/VibeTunnel/VibeTunnel.entitlements"
+    if [[ -f "$ENTITLEMENTS_PATH" ]]; then
+        codesign --force --deep --sign - --entitlements "$ENTITLEMENTS_PATH" "$APP_PATH"
+        echo "✓ App signed with ad-hoc signature and entitlements"
+    else
+        echo "⚠️ Entitlements file not found at $ENTITLEMENTS_PATH, signing without entitlements"
+        codesign --force --deep --sign - "$APP_PATH"
+    fi
+fi
 
 # Sign the app if requested
 if [[ "$SIGN_APP" == true ]]; then


### PR DESCRIPTION
I was testing adding intel mac support (#557 ) and got hung up on the notifications not working for my local build. That turned out to be a red herring and is something I thought we might be able to avoid when using local builds. 

## Issue and Resolution Summary

This adds ad-hoc signing to the application so that a local build:
- **Issue 1**: shows up in the mac notification settings (changes to mac/scripts/build.sh). Originally would never show up in the notification settings panel and the notifications toggle within the mac vibetunnel app settings would auto toggle back off after toggling it on.
- **Issue2**: add more robust notification service connection to server with fixed authentication using the local auth token (see mac/VibeTunnel/Core/Services/NotificationService.swift). Originally, i would see the issue in the settings panel about the connection (see screenshot below)

## Screenshots

### Before

<img width="545" height="785" alt="image" src="https://github.com/user-attachments/assets/bb496f5e-fb9e-4e43-85c4-f20179895cfd" />

### After

<img width="1260" height="791" alt="image" src="https://github.com/user-attachments/assets/0f5c829c-c722-4e63-931f-ba709eac33ad" />

## Issue Details for Full Context (generated by Gemini 3 Pro)

Here is a summary formatted for your Pull Request description.

#### Context & Motivation
This PR addresses two critical issues preventing the Notification Service from functioning correctly in local development environments:

1.  **macOS Code Signing Requirements:** The `UNUserNotificationCenter` framework on macOS requires applications to be code-signed to reliably register delegates and persist notification permissions. Unsigned binaries often fail to receive delegate callbacks or maintain permission status across app launches, blocking local development of notification features.
2.  **Authentication Protocol Mismatch:** The macOS client's `NotificationService` was attempting to authenticate with the local VibeTunnel server using standard Bearer token authentication. However, the server's authentication middleware is configured to validate local loopback connections specifically via the `X-VibeTunnel-Local` header, causing valid tokens to be rejected when sent via the `Authorization` header.

#### Changes

**1. Build Script (build.sh)**
*   Implemented ad-hoc code signing for local builds using `codesign --force --deep --sign -`.
*   This ensures locally built binaries possess a valid signature, satisfying macOS security requirements for User Notifications without requiring a developer certificate.
*   Logic was added to ensure this only applies to non-CI environments, preserving existing workflows for CI/CD pipelines.

**2. Notification Service (NotificationService.swift)**
*   Updated the Server-Sent Events (SSE) connection logic to transmit the local authentication token via the `X-VibeTunnel-Local` header.
*   This aligns the client implementation with the server's auth.ts middleware, which checks `req.headers['x-vibetunnel-local']` for the local bypass token.

#### Original Issue Description
After resolving the initial code signing requirements to allow the application to register with the macOS Notification Center, the `NotificationService` continued to fail to receive events.

Despite the application successfully retrieving a valid local authentication token, the connection to the SSE endpoint (`/api/events`) was consistently rejected or treated as unauthenticated by the server. Investigation revealed that the client was sending the token in the `Authorization: Bearer <token>` header. The server middleware, designed to handle local connections securely, ignored this header for the local bypass flow and instead looked for the token in `X-VibeTunnel-Local`. This mismatch caused the notification service to silently fail to connect, preventing the delivery of terminal events (session start, command completion, etc.) to the macOS desktop.

#### References
*   **Apple Developer Documentation:** [UNUserNotificationCenter](https://developer.apple.com/documentation/usernotifications) (Signing requirements for user notifications)
*   **macOS Man Pages:** `codesign(1)` - Ad-hoc signing usage