### PR TITLE
fix(native): resolve segfault in vt-fwd git detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Keep `vt` git metadata alive for sessions in repositories without an upstream branch, preventing forwarder crashes (via [@ndraiman](https://github.com/ndraiman)) (#566)
 - Keep HQ remotes registered through transient health-check failures and remove them only after three consecutive failures (via [@bianbiandashen](https://github.com/bianbiandashen) and [@nikolasdehor](https://github.com/nikolasdehor)) (#594)
 - Fix session creation "data couldn't be read" error on Mac app (#500)
 - Correct empty-session CLI setup instructions to point to Settings → General → Command Line Tool (via [@saqibameen](https://github.com/saqibameen)) (#582)
@@ -36,6 +37,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
+- Thanks [@ndraiman](https://github.com/ndraiman) for fixing native forwarder crashes while collecting git metadata.
 - Thanks [@bianbiandashen](https://github.com/bianbiandashen) for preventing transient remote health-check failures from prematurely unregistering servers.
 - Thanks [@saqibameen](https://github.com/saqibameen) for correcting the CLI setup path shown to new users.
 - Thanks [@ye4241](https://github.com/ye4241) for fixing browser SSH private-key import and public-key derivation.

--- a/native/vt-fwd/src/git.zig
+++ b/native/vt-fwd/src/git.zig
@@ -16,9 +16,8 @@ pub const GitInfo = struct {
 };
 
 pub fn detectGitInfo(allocator: std.mem.Allocator, working_dir: []const u8) GitInfo {
-    var arena = std.heap.ArenaAllocator.init(allocator);
-    const arena_alloc = arena.allocator();
-    var info = GitInfo{ .arena = arena };
+    var info = GitInfo{ .arena = std.heap.ArenaAllocator.init(allocator) };
+    const arena_alloc = info.arena.allocator();
 
     var env = std.process.getEnvMap(arena_alloc) catch return info;
     env.put("GIT_TERMINAL_PROMPT", "0") catch {};

--- a/native/vt-fwd/src/git.zig
+++ b/native/vt-fwd/src/git.zig
@@ -151,3 +151,52 @@ fn getMainRepositoryPath(allocator: std.mem.Allocator, git_file_path: []const u8
 
     return null;
 }
+
+fn expectCommandSuccess(allocator: std.mem.Allocator, cwd: []const u8, argv: []const []const u8) !void {
+    const result = try std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = argv,
+        .cwd = cwd,
+    });
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    switch (result.term) {
+        .Exited => |code| try std.testing.expectEqual(@as(u8, 0), code),
+        else => return error.CommandFailed,
+    }
+}
+
+test "detectGitInfo retains metadata without an upstream branch" {
+    const allocator = std.testing.allocator;
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+
+    const repo_path = try std.fs.path.join(allocator, &.{ ".zig-cache", "tmp", tmp.sub_path[0..] });
+    defer allocator.free(repo_path);
+    const absolute_repo_path = try std.fs.cwd().realpathAlloc(allocator, repo_path);
+    defer allocator.free(absolute_repo_path);
+
+    try expectCommandSuccess(allocator, absolute_repo_path, &.{ "git", "init", "-q", "-b", "main" });
+    try expectCommandSuccess(allocator, absolute_repo_path, &.{
+        "git",
+        "-c",
+        "user.name=VibeTunnel Test",
+        "-c",
+        "user.email=test@vibetunnel.local",
+        "commit",
+        "-q",
+        "--allow-empty",
+        "-m",
+        "initial",
+    });
+
+    var info = detectGitInfo(allocator, absolute_repo_path);
+    defer info.deinit();
+
+    try std.testing.expectEqualStrings(absolute_repo_path, info.gitRepoPath.?);
+    try std.testing.expectEqualStrings("main", info.gitBranch.?);
+    try std.testing.expectEqualStrings(absolute_repo_path, info.gitMainRepoPath.?);
+    try std.testing.expect(info.gitAheadCount == null);
+    try std.testing.expect(info.gitBehindCount == null);
+}

--- a/native/vt-fwd/src/git.zig
+++ b/native/vt-fwd/src/git.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 
 pub const GitInfo = struct {
+    arena: std.heap.ArenaAllocator,
     gitRepoPath: ?[]const u8 = null,
     gitBranch: ?[]const u8 = null,
     gitAheadCount: ?i32 = null,
@@ -8,40 +9,42 @@ pub const GitInfo = struct {
     gitHasChanges: ?bool = null,
     gitIsWorktree: ?bool = null,
     gitMainRepoPath: ?[]const u8 = null,
+
+    pub fn deinit(self: *GitInfo) void {
+        self.arena.deinit();
+    }
 };
 
 pub fn detectGitInfo(allocator: std.mem.Allocator, working_dir: []const u8) GitInfo {
-    var info = GitInfo{};
-    var env = std.process.getEnvMap(allocator) catch return info;
-    defer env.deinit();
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    const arena_alloc = arena.allocator();
+    var info = GitInfo{ .arena = arena };
+
+    var env = std.process.getEnvMap(arena_alloc) catch return info;
     env.put("GIT_TERMINAL_PROMPT", "0") catch {};
 
-    const repo_path = runGit(allocator, working_dir, &env, &.{ "git", "rev-parse", "--show-toplevel" }) orelse return info;
-    defer allocator.free(repo_path);
+    const repo_path = runGit(arena_alloc, working_dir, &env, &.{ "git", "rev-parse", "--show-toplevel" }) orelse return info;
     info.gitRepoPath = repo_path;
 
-    if (runGit(allocator, working_dir, &env, &.{ "git", "branch", "--show-current" })) |branch| {
-        defer allocator.free(branch);
+    if (runGit(arena_alloc, working_dir, &env, &.{ "git", "branch", "--show-current" })) |branch| {
         info.gitBranch = branch;
     } else {
         info.gitBranch = "";
     }
 
-    const git_file_path = std.fs.path.join(allocator, &.{ working_dir, ".git" }) catch null;
+    const git_file_path = std.fs.path.join(arena_alloc, &.{ working_dir, ".git" }) catch null;
     if (git_file_path) |path| {
-        defer allocator.free(path);
         if (std.fs.cwd().statFile(path)) |stat| {
             if (stat.kind != .directory) {
                 info.gitIsWorktree = true;
-                if (getMainRepositoryPath(allocator, path)) |main| {
+                if (getMainRepositoryPath(arena_alloc, path)) |main| {
                     info.gitMainRepoPath = main;
                 }
             }
         } else |_| {}
     }
 
-    if (runGit(allocator, working_dir, &env, &.{ "git", "rev-list", "--left-right", "--count", "HEAD...@{upstream}" })) |counts| {
-        defer allocator.free(counts);
+    if (runGit(arena_alloc, working_dir, &env, &.{ "git", "rev-list", "--left-right", "--count", "HEAD...@{upstream}" })) |counts| {
         var parts = std.mem.splitScalar(u8, counts, '\t');
         if (parts.next()) |ahead| {
             info.gitAheadCount = std.fmt.parseInt(i32, ahead, 10) catch null;
@@ -51,7 +54,7 @@ pub fn detectGitInfo(allocator: std.mem.Allocator, working_dir: []const u8) GitI
         }
     }
 
-    if (runGitStatus(allocator, working_dir, &env)) |has_changes| {
+    if (runGitStatus(arena_alloc, working_dir, &env)) |has_changes| {
         info.gitHasChanges = has_changes;
     }
 

--- a/native/vt-fwd/src/main.zig
+++ b/native/vt-fwd/src/main.zig
@@ -220,7 +220,8 @@ pub fn main() !void {
 
     const session_name = try title_mod.generateSessionName(allocator, command, cwd, home);
     const started_at = try isoTimestamp(allocator);
-    const git_info = git_mod.detectGitInfo(allocator, cwd);
+    var git_info = git_mod.detectGitInfo(allocator, cwd);
+    defer git_info.deinit();
 
     var session_info = session_mod.SessionInfo{
         .id = session_id,


### PR DESCRIPTION
## Summary
- Keep `vibetunnel-fwd` git metadata allocations alive for the full session lifetime.
- Bind allocations to the `GitInfo` arena that the caller deinitializes.
- Add regression coverage for repositories with no configured upstream.
- Drop the unrelated codesigning commit from the original stack.

## Root cause
`detectGitInfo()` returned repository and branch slices after freeing them. Later `session.json` writes dereferenced those stale slices, causing `vt` commands to segfault in repositories without an upstream branch.

The original arena patch also allocated through a copied local arena, so `GitInfo.deinit()` could not release those allocations. The rewritten stack initializes the allocator from the returned `GitInfo` arena itself.

## Validation
- Reproduced current `main` failure: 5/5 no-upstream runs exited 139 before writing `session.json`.
- Zig 0.15.2 focused runtime test: 1/1 passed with allocator leak checking.
- Documentation validation passed.
- macOS SwiftFormat/SwiftLint passed.
- Web standard typecheck, lint, format, and `vt` syntax tests passed.
- Serial server suite passed: 53 files, 572 tests; 75 skipped.
- Autoreview: no accepted/actionable findings.
- AWS Crabbox remote Linux proof on exact head `a48f1114`: Zig 0.15.2 build, full native tests, and no-upstream forwarder E2E passed (`cbx_cfbb92392962`).

GitHub required checks passed. Current path filters skip Node/Mac jobs for native-only diffs; that CI routing fix is separate from this contributor PR.
