### PR TITLE
feat(mac): add custom bind address support for server configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Allow the macOS app to bind the server to validated custom IPv4 or IPv6 addresses, including dual-stack `::`, with correct IPv6 dashboard URLs (via [@waxzce](https://github.com/waxzce)) (#576)
 - Restore iOS terminal rendering, preserve output received during Ghostty startup, and stream stdout for immediate input echo (via [@waxzce](https://github.com/waxzce)) (#577)
 - Keep Korean and other CJK IME composition events intact and position desktop candidate windows at the terminal cursor (via [@jiangwenhan](https://github.com/jiangwenhan)) (#617)
 - Prevent rapid iOS slash-command redraws from queuing redundant smooth terminal scrolling (via [@Ilakiancs](https://github.com/Ilakiancs)) (#590)
@@ -43,7 +44,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
-- Thanks [@waxzce](https://github.com/waxzce) for restoring reliable iOS terminal rendering and input echo.
+- Thanks [@waxzce](https://github.com/waxzce) for adding configurable IPv4/IPv6 server binding and restoring reliable iOS terminal rendering and input echo.
 - Thanks [@jiangwenhan](https://github.com/jiangwenhan) for improving Korean and CJK terminal input.
 - Thanks [@Tyoneva](https://github.com/Tyoneva) for improving web app installation and icon support.
 - Thanks [@ndraiman](https://github.com/ndraiman) for fixing native forwarder crashes while collecting git metadata.

--- a/mac/VibeTunnel/Core/Constants/UserDefaultsKeys.swift
+++ b/mac/VibeTunnel/Core/Constants/UserDefaultsKeys.swift
@@ -6,6 +6,7 @@ enum UserDefaultsKeys {
 
     static let serverPort = "serverPort"
     static let dashboardAccessMode = "dashboardAccessMode"
+    static let customBindAddress = "customBindAddress"
     static let cleanupOnStartup = "cleanupOnStartup"
     static let preventSleepWhenRunning = "preventSleepWhenRunning"
     static let useDevelopmentServer = "useDevelopmentServer"

--- a/mac/VibeTunnel/Core/Models/AppConstants.swift
+++ b/mac/VibeTunnel/Core/Models/AppConstants.swift
@@ -18,6 +18,7 @@ enum AppConstants {
         // Server Configuration
         static let serverPort = "serverPort"
         static let dashboardAccessMode = "dashboardAccessMode"
+        static let customBindAddress = "customBindAddress"
         static let cleanupOnStartup = "cleanupOnStartup"
         static let authenticationMode = "authenticationMode"
 
@@ -51,6 +52,7 @@ enum AppConstants {
     enum DashboardAccessModeRawValues {
         static let localhost = "localhost"
         static let network = "network"
+        static let custom = "custom"
     }
 
     /// Default values for UserDefaults

--- a/mac/VibeTunnel/Core/Models/DashboardAccessMode.swift
+++ b/mac/VibeTunnel/Core/Models/DashboardAccessMode.swift
@@ -6,29 +6,37 @@ import Foundation
 /// Controls whether the web interface is accessible only locally or
 /// from other devices on the network.
 enum DashboardAccessMode: String, CaseIterable {
-    // Raw values are automatically inferred as "localhost" and "network"
+    // Raw values are automatically inferred as "localhost", "network", and "custom"
     // These must match AppConstants.DashboardAccessModeRawValues
     case localhost
     case network
+    case custom
 
     var displayName: String {
         switch self {
         case .localhost: "Localhost only"
         case .network: "Network"
+        case .custom: "Custom address"
         }
     }
 
-    var bindAddress: String {
+    var fixedBindAddress: ServerBindAddress? {
         switch self {
-        case .localhost: "127.0.0.1"
-        case .network: "0.0.0.0"
+        case .localhost: ServerBindAddress("127.0.0.1")
+        case .network: ServerBindAddress("0.0.0.0")
+        case .custom: nil
         }
+    }
+
+    func resolvedBindAddress(customAddress: String?) -> ServerBindAddress {
+        self.fixedBindAddress ?? customAddress.flatMap(ServerBindAddress.init) ?? ServerBindAddress("127.0.0.1")!
     }
 
     var description: String {
         switch self {
         case .localhost: "Only accessible from this Mac."
         case .network: "Accessible from other devices on this network."
+        case .custom: "Bind to a specific IPv4 or IPv6 address."
         }
     }
 }

--- a/mac/VibeTunnel/Core/Models/ServerBindAddress.swift
+++ b/mac/VibeTunnel/Core/Models/ServerBindAddress.swift
@@ -1,0 +1,71 @@
+import Darwin
+import Foundation
+
+/// A validated IPv4 or IPv6 literal used for server binding and dashboard URLs.
+struct ServerBindAddress: Equatable {
+    enum Family: Equatable {
+        case ipv4
+        case ipv6
+    }
+
+    let value: String
+    let family: Family
+
+    init?(_ rawValue: String) {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        var ipv4Address = in_addr()
+        if value.withCString({ inet_pton(AF_INET, $0, &ipv4Address) }) == 1 {
+            self.value = value
+            self.family = .ipv4
+            return
+        }
+
+        var ipv6Address = in6_addr()
+        if value.withCString({ inet_pton(AF_INET6, $0, &ipv6Address) }) == 1 {
+            self.value = value
+            self.family = .ipv6
+            return
+        }
+
+        return nil
+    }
+
+    var connectableAddress: Self {
+        switch self.value {
+        case "0.0.0.0":
+            Self("127.0.0.1")!
+        case "::":
+            Self("::1")!
+        default:
+            self
+        }
+    }
+
+    var urlHost: String {
+        switch self.family {
+        case .ipv4:
+            self.value
+        case .ipv6:
+            "[\(self.value)]"
+        }
+    }
+
+    func endpoint(port: String) -> String {
+        "\(self.urlHost):\(port)"
+    }
+
+    func url(port: String, endpoint: String = "/") -> URL? {
+        guard let portNumber = Int(port) else {
+            return nil
+        }
+
+        var components = URLComponents()
+        components.scheme = "http"
+        // Foundation on supported macOS versions returns nil for raw IPv6 literals here.
+        components.host = self.urlHost
+        components.port = portNumber
+        components.path = endpoint.hasPrefix("/") ? endpoint : "/\(endpoint)"
+        return components.url
+    }
+}

--- a/mac/VibeTunnel/Core/Services/ServerManager.swift
+++ b/mac/VibeTunnel/Core/Services/ServerManager.swift
@@ -69,30 +69,73 @@ class ServerManager {
         self.bunServer?.authMode ?? "os"
     }
 
+    var dashboardAccessMode: DashboardAccessMode {
+        let rawValue = UserDefaults.standard.string(forKey: UserDefaultsKeys.dashboardAccessMode) ?? AppConstants
+            .Defaults
+            .dashboardAccessMode
+        return DashboardAccessMode(rawValue: rawValue) ?? .network
+    }
+
+    var customBindAddress: String? {
+        UserDefaults.standard.string(forKey: UserDefaultsKeys.customBindAddress)
+    }
+
     var bindAddress: String {
         get {
-            // Get the raw value from UserDefaults, defaulting to the app default
-            let rawValue = UserDefaults.standard.string(forKey: UserDefaultsKeys.dashboardAccessMode) ?? AppConstants
-                .Defaults
-                .dashboardAccessMode
-            let mode = DashboardAccessMode(rawValue: rawValue) ?? .network
-
-            // Log for debugging
-            // logger
-            //     .debug(
-            //         "bindAddress getter: rawValue='\(rawValue)', mode=\(mode.rawValue),
-            //         bindAddress=\(mode.bindAddress)"
-            //     )
-
-            return mode.bindAddress
+            self.dashboardAccessMode.resolvedBindAddress(customAddress: self.customBindAddress).value
         }
         set {
-            // Find the mode that matches this bind address
-            if let mode = DashboardAccessMode.allCases.first(where: { $0.bindAddress == newValue }) {
-                UserDefaults.standard.set(mode.rawValue, forKey: UserDefaultsKeys.dashboardAccessMode)
-                self.logger.debug("bindAddress setter: set mode=\(mode.rawValue) for bindAddress=\(newValue)")
-            }
+            _ = self.updateBindConfiguration(address: newValue)
         }
+    }
+
+    @discardableResult
+    func updateBindConfiguration(address: String) -> Bool {
+        guard let bindAddress = ServerBindAddress(address) else {
+            return false
+        }
+
+        let mode: DashboardAccessMode = switch bindAddress.value {
+        case "127.0.0.1": .localhost
+        case "0.0.0.0": .network
+        default: .custom
+        }
+
+        return self.updateBindConfiguration(mode: mode, customAddress: bindAddress.value)
+    }
+
+    @discardableResult
+    func updateBindConfiguration(mode: DashboardAccessMode, customAddress: String? = nil) -> Bool {
+        if mode == .custom {
+            guard let customAddress, let bindAddress = ServerBindAddress(customAddress) else {
+                return false
+            }
+            UserDefaults.standard.set(bindAddress.value, forKey: UserDefaultsKeys.customBindAddress)
+        }
+
+        UserDefaults.standard.set(mode.rawValue, forKey: UserDefaultsKeys.dashboardAccessMode)
+        self.logger.debug("Updated bind configuration: mode=\(mode.rawValue), address=\(self.bindAddress)")
+        return true
+    }
+
+    var dashboardAddress: ServerBindAddress {
+        if self.dashboardAccessMode == .network,
+           let localAddress = NetworkUtility.getLocalIPAddress().flatMap(ServerBindAddress.init)
+        {
+            return localAddress
+        }
+
+        return self.dashboardAccessMode
+            .resolvedBindAddress(customAddress: self.customBindAddress)
+            .connectableAddress
+    }
+
+    var dashboardEndpoint: String {
+        self.dashboardAddress.endpoint(port: self.port)
+    }
+
+    func dashboardURL(endpoint: String = "/") -> URL? {
+        self.dashboardAddress.url(port: self.port, endpoint: endpoint)
     }
 
     private var cleanupOnStartup: Bool {
@@ -649,7 +692,10 @@ class ServerManager {
 
     /// Build a URL for the local server with the given endpoint
     func buildURL(endpoint: String) -> URL? {
-        URL(string: "\(URLConstants.localServerBase):\(self.port)\(endpoint)")
+        self.dashboardAccessMode
+            .resolvedBindAddress(customAddress: self.customBindAddress)
+            .connectableAddress
+            .url(port: self.port, endpoint: endpoint)
     }
 
     /// Build a URL for the local server with the given endpoint and query parameters

--- a/mac/VibeTunnel/Presentation/Components/Menu/ServerInfoSection.swift
+++ b/mac/VibeTunnel/Presentation/Components/Menu/ServerInfoSection.swift
@@ -164,14 +164,8 @@ struct ServerAddressRow: View {
             Button(action: {
                 if let providedUrl = url {
                     NSWorkspace.shared.open(providedUrl)
-                } else if self.computedAddress.starts(with: "127.0.0.1:") {
-                    // For localhost, use DashboardURLBuilder
-                    if let dashboardURL = DashboardURLBuilder.dashboardURL(port: serverManager.port) {
-                        NSWorkspace.shared.open(dashboardURL)
-                    }
-                } else if let url = URL(string: "http://\(computedAddress)") {
-                    // For other addresses (network IP, etc.), construct URL directly
-                    NSWorkspace.shared.open(url)
+                } else if let dashboardURL = serverManager.dashboardURL() {
+                    NSWorkspace.shared.open(dashboardURL)
                 }
             }, label: {
                 Text(self.computedAddress)
@@ -206,15 +200,7 @@ struct ServerAddressRow: View {
             return self.address
         }
 
-        // Default behavior for local server
-        let bindAddress = self.serverManager.bindAddress
-        if bindAddress == "127.0.0.1" {
-            return "127.0.0.1:\(self.serverManager.port)"
-        } else if let localIP = NetworkUtility.getLocalIPAddress() {
-            return "\(localIP):\(self.serverManager.port)"
-        } else {
-            return "0.0.0.0:\(self.serverManager.port)"
-        }
+        return self.serverManager.dashboardEndpoint
     }
 
     private var urlToCopy: String {
@@ -223,12 +209,7 @@ struct ServerAddressRow: View {
             return providedUrl.absoluteString
         }
 
-        // For local addresses, build the full URL
-        if self.computedAddress.starts(with: "127.0.0.1:") {
-            return "http://\(self.computedAddress)"
-        } else {
-            return "http://\(self.computedAddress)"
-        }
+        return self.serverManager.dashboardURL()?.absoluteString ?? "http://\(self.computedAddress)"
     }
 
     private func copyToClipboard() {

--- a/mac/VibeTunnel/Presentation/Components/TooltipProvider.swift
+++ b/mac/VibeTunnel/Presentation/Components/TooltipProvider.swift
@@ -25,15 +25,7 @@ enum TooltipProvider {
 
         // Server status
         if serverManager.isRunning {
-            let bindAddress = serverManager.bindAddress
-            if bindAddress == "127.0.0.1" {
-                tooltipParts.append("Server: 127.0.0.1:\(serverManager.port)")
-            } else if let localIP = NetworkUtility.getLocalIPAddress() {
-                tooltipParts.append("Server: \(localIP):\(serverManager.port)")
-            } else {
-                // Fallback when no local IP is found
-                tooltipParts.append("Server: 0.0.0.0:\(serverManager.port)")
-            }
+            tooltipParts.append("Server: \(serverManager.dashboardEndpoint)")
 
             // ngrok status
             if ngrokService.isActive, let publicURL = ngrokService.publicUrl {

--- a/mac/VibeTunnel/Presentation/Views/Settings/DashboardSettingsView.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/DashboardSettingsView.swift
@@ -138,7 +138,6 @@ private struct ServerStatusSection: View {
 
     @State private var portConflict: PortConflict?
     @State private var isCheckingPort = false
-    @State private var localIPAddress: String?
     @State private var isShowingKillPortConflictConfirm = false
     @State private var isKillingPortConflictProcess = false
     @State private var killPortConflictErrorMessage: String?
@@ -191,8 +190,6 @@ private struct ServerStatusSection: View {
                     AccessModeView(
                         accessMode: self.accessMode,
                         accessModeString: self.$accessModeString,
-                        serverPort: self.serverPort,
-                        localIPAddress: self.localIPAddress,
                         restartServerWithNewBindAddress: self.restartServerWithNewBindAddress)
 
                     // Editable Port
@@ -207,13 +204,11 @@ private struct ServerStatusSection: View {
                     }
 
                     LabeledContent("Base URL") {
-                        let baseAddress = self.serverManager.bindAddress == "0.0.0.0" ? "127.0.0.1" : self.serverManager
-                            .bindAddress
-                        if let serverURL = URL(string: "http://\(baseAddress):\(serverPort)") {
-                            Link("http://\(baseAddress):\(self.serverPort)", destination: serverURL)
+                        if let serverURL = serverManager.dashboardURL() {
+                            Link(serverURL.absoluteString, destination: serverURL)
                                 .font(.system(.body, design: .monospaced))
                         } else {
-                            Text("http://\(baseAddress):\(self.serverPort)")
+                            Text("Unavailable")
                                 .font(.system(.body, design: .monospaced))
                         }
                     }
@@ -347,13 +342,9 @@ private struct ServerStatusSection: View {
             .padding(.vertical, 4)
             .task {
                 await self.checkPortAvailability()
-                await self.updateLocalIPAddress()
             }
             .task(id: self.serverPort) {
                 await self.checkPortAvailability()
-            }
-            .task(id: self.accessModeString) {
-                await self.updateLocalIPAddress()
             }
             .alert(
                 "Failed to kill process",
@@ -369,43 +360,18 @@ private struct ServerStatusSection: View {
             Text("Server Configuration")
                 .font(.headline)
         } footer: {
-            // Dashboard URL display
-            if self.accessMode == .localhost {
+            if let url = serverManager.dashboardURL() {
                 HStack(spacing: 5) {
                     Text("Dashboard available at")
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    if let url = DashboardURLBuilder.dashboardURL(port: serverPort) {
-                        Link(url.absoluteString, destination: url)
-                            .font(.caption)
-                            .foregroundStyle(.blue)
-                    }
+                    Link(url.absoluteString, destination: url)
+                        .font(.caption)
+                        .foregroundStyle(.blue)
                 }
                 .frame(maxWidth: .infinity)
                 .multilineTextAlignment(.center)
-            } else if self.accessMode == .network {
-                if let ip = localIPAddress {
-                    HStack(spacing: 5) {
-                        Text("Dashboard available at")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-
-                        if let url = URL(string: "http://\(ip):\(serverPort)") {
-                            Link(url.absoluteString, destination: url)
-                                .font(.caption)
-                                .foregroundStyle(.blue)
-                        }
-                    }
-                    .frame(maxWidth: .infinity)
-                    .multilineTextAlignment(.center)
-                } else {
-                    Text("Fetching local IP address...")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity)
-                        .multilineTextAlignment(.center)
-                }
             }
         }
     }
@@ -416,16 +382,13 @@ private struct ServerStatusSection: View {
         }
     }
 
-    private func restartServerWithNewBindAddress() {
+    private func restartServerWithNewBindAddress(_ mode: DashboardAccessMode, customAddress: String?) {
         Task {
             await ServerConfigurationHelpers.restartServerWithNewBindAddress(
-                accessMode: self.accessMode,
+                accessMode: mode,
+                customAddress: customAddress,
                 serverManager: self.serverManager)
         }
-    }
-
-    private func updateLocalIPAddress() async {
-        self.localIPAddress = await ServerConfigurationHelpers.updateLocalIPAddress(accessMode: self.accessMode)
     }
 
     private func checkPortAvailability() async {

--- a/mac/VibeTunnel/Presentation/Views/Settings/RemoteAccessSettingsView.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/RemoteAccessSettingsView.swift
@@ -219,6 +219,7 @@ struct RemoteAccessSettingsView: View {
         Task {
             await ServerConfigurationHelpers.restartServerWithNewBindAddress(
                 accessMode: self.accessMode,
+                customAddress: self.serverManager.customBindAddress,
                 serverManager: self.serverManager)
         }
     }

--- a/mac/VibeTunnel/Presentation/Views/Settings/ServerConfigurationComponents.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/ServerConfigurationComponents.swift
@@ -8,8 +8,7 @@ struct ServerConfigurationSection: View {
     let accessMode: DashboardAccessMode
     @Binding var accessModeString: String
     @Binding var serverPort: String
-    let localIPAddress: String?
-    let restartServerWithNewBindAddress: () -> Void
+    let restartServerWithNewBindAddress: (DashboardAccessMode, String?) -> Void
     let restartServerWithNewPort: (Int) -> Void
     let serverManager: ServerManager
 
@@ -19,8 +18,6 @@ struct ServerConfigurationSection: View {
                 AccessModeView(
                     accessMode: self.accessMode,
                     accessModeString: self.$accessModeString,
-                    serverPort: self.serverPort,
-                    localIPAddress: self.localIPAddress,
                     restartServerWithNewBindAddress: self.restartServerWithNewBindAddress)
 
                 PortConfigurationView(
@@ -32,43 +29,18 @@ struct ServerConfigurationSection: View {
             Text("Server Configuration")
                 .font(.headline)
         } footer: {
-            // Dashboard URL display
-            if self.accessMode == .localhost {
+            if let url = serverManager.dashboardURL() {
                 HStack(spacing: 5) {
                     Text("Dashboard available at")
                         .font(.caption)
                         .foregroundStyle(.secondary)
 
-                    if let url = DashboardURLBuilder.dashboardURL(port: serverPort) {
-                        Link(url.absoluteString, destination: url)
-                            .font(.caption)
-                            .foregroundStyle(.blue)
-                    }
+                    Link(url.absoluteString, destination: url)
+                        .font(.caption)
+                        .foregroundStyle(.blue)
                 }
                 .frame(maxWidth: .infinity)
                 .multilineTextAlignment(.center)
-            } else if self.accessMode == .network {
-                if let ip = localIPAddress {
-                    HStack(spacing: 5) {
-                        Text("Dashboard available at")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-
-                        if let url = URL(string: "http://\(ip):\(serverPort)") {
-                            Link(url.absoluteString, destination: url)
-                                .font(.caption)
-                                .foregroundStyle(.blue)
-                        }
-                    }
-                    .frame(maxWidth: .infinity)
-                    .multilineTextAlignment(.center)
-                } else {
-                    Text("Fetching local IP address...")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity)
-                        .multilineTextAlignment(.center)
-                }
             }
         }
     }
@@ -79,17 +51,22 @@ struct ServerConfigurationSection: View {
 struct AccessModeView: View {
     let accessMode: DashboardAccessMode
     @Binding var accessModeString: String
-    let serverPort: String
-    let localIPAddress: String?
-    let restartServerWithNewBindAddress: () -> Void
+    let restartServerWithNewBindAddress: (DashboardAccessMode, String?) -> Void
 
     @AppStorage(AppConstants.UserDefaultsKeys.tailscaleServeEnabled)
     private var tailscaleServeEnabled = false
+    @AppStorage(AppConstants.UserDefaultsKeys.customBindAddress)
+    private var customBindAddress = ""
 
     @Environment(TailscaleService.self)
     private var tailscaleService
     @Environment(TailscaleServeStatusService.self)
     private var tailscaleServeStatus
+
+    @FocusState private var isCustomAddressFieldFocused: Bool
+    @State private var pendingAccessMode: DashboardAccessMode?
+    @State private var pendingCustomAddress = ""
+    @State private var customAddressError: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -107,15 +84,53 @@ struct AccessModeView: View {
                         .foregroundColor(.blue)
                         .help("Tailscale Serve active - locked to localhost for security")
                 } else {
-                    Picker("", selection: self.$accessModeString) {
+                    Picker("", selection: self.accessModeSelection) {
                         ForEach(DashboardAccessMode.allCases, id: \.rawValue) { mode in
                             Text(mode.displayName)
                                 .tag(mode.rawValue)
                         }
                     }
                     .labelsHidden()
-                    .onChange(of: self.accessModeString) { _, _ in
-                        self.restartServerWithNewBindAddress()
+                }
+            }
+
+            if self.displayedAccessMode == .custom, !self.shouldLockToLocalhost {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text("Bind Address")
+                            .font(.callout)
+                        Spacer()
+                        TextField("127.0.0.1 or ::", text: self.$pendingCustomAddress)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 180)
+                            .font(.system(.body, design: .monospaced))
+                            .focused(self.$isCustomAddressFieldFocused)
+                            .onSubmit {
+                                self.validateAndApplyCustomAddress()
+                            }
+                            .onAppear {
+                                self.pendingCustomAddress = self.customBindAddress
+                            }
+                            .onChange(of: self.pendingCustomAddress) { _, _ in
+                                self.customAddressError = nil
+                            }
+
+                        Button("Apply") {
+                            self.validateAndApplyCustomAddress()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled(self.pendingCustomAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+
+                    Text("Use :: to listen on both IPv6 and IPv4.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    if let customAddressError {
+                        Label(customAddressError, systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundStyle(.red)
                     }
                 }
             }
@@ -133,7 +148,7 @@ struct AccessModeView: View {
             }
 
             // Show info when Tailscale Serve is active and locked
-            if self.shouldLockToLocalhost, self.accessMode == .network {
+            if self.shouldLockToLocalhost, self.displayedAccessMode != .localhost {
                 HStack(spacing: 4) {
                     Image(systemName: "info.circle.fill")
                         .foregroundColor(.blue)
@@ -151,6 +166,50 @@ struct AccessModeView: View {
         self.tailscaleServeEnabled &&
             self.tailscaleService.isRunning &&
             self.tailscaleServeStatus.isRunning
+    }
+
+    private var displayedAccessMode: DashboardAccessMode {
+        self.pendingAccessMode ?? self.accessMode
+    }
+
+    private var accessModeSelection: Binding<String> {
+        Binding(
+            get: { self.displayedAccessMode.rawValue },
+            set: { rawValue in
+                guard let mode = DashboardAccessMode(rawValue: rawValue) else {
+                    return
+                }
+
+                if mode == .custom {
+                    self.pendingAccessMode = .custom
+                    self.pendingCustomAddress = self.customBindAddress
+                    self.customAddressError = nil
+                } else {
+                    self.pendingAccessMode = nil
+                    self.accessModeString = mode.rawValue
+                    self.restartServerWithNewBindAddress(mode, nil)
+                }
+            })
+    }
+
+    private func validateAndApplyCustomAddress() {
+        let address = self.pendingCustomAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let bindAddress = ServerBindAddress(address) else {
+            self.customAddressError = if address.hasPrefix("[") || address.hasSuffix("]") {
+                "Enter IPv6 addresses without brackets."
+            } else {
+                "Enter a valid IPv4 or IPv6 address."
+            }
+            self.isCustomAddressFieldFocused = true
+            return
+        }
+
+        self.pendingCustomAddress = bindAddress.value
+        self.customBindAddress = bindAddress.value
+        self.accessModeString = DashboardAccessMode.custom.rawValue
+        self.pendingAccessMode = nil
+        self.customAddressError = nil
+        self.restartServerWithNewBindAddress(.custom, bindAddress.value)
     }
 }
 
@@ -270,14 +329,22 @@ enum ServerConfigurationHelpers {
         // Session monitoring will automatically detect the port change
     }
 
-    static func restartServerWithNewBindAddress(accessMode: DashboardAccessMode, serverManager: ServerManager) async {
-        // Restart server to pick up the new bind address from UserDefaults
-        // (accessModeString is already persisted via @AppStorage)
+    static func restartServerWithNewBindAddress(
+        accessMode: DashboardAccessMode,
+        customAddress: String? = nil,
+        serverManager: ServerManager)
+        async
+    {
+        guard serverManager.updateBindConfiguration(mode: accessMode, customAddress: customAddress) else {
+            self.logger.error("Rejected invalid bind configuration")
+            return
+        }
+
         self.logger
             .info(
-                "Restarting server due to access mode change: \(accessMode.displayName) -> \(accessMode.bindAddress)")
+                "Restarting server due to access mode change: \(accessMode.displayName) -> \(serverManager.bindAddress)")
         await serverManager.restart()
-        self.logger.info("Server restarted with bind address \(accessMode.bindAddress)")
+        self.logger.info("Server restarted with bind address \(serverManager.bindAddress)")
 
         // Wait for server to be fully ready before restarting session monitor
         try? await Task.sleep(for: .seconds(1))

--- a/mac/VibeTunnelTests/ModelTests.swift
+++ b/mac/VibeTunnelTests/ModelTests.swift
@@ -122,15 +122,18 @@ struct ModelTests {
         func dashboardaccessmodeValidation(mode: DashboardAccessMode) {
             // Each mode should have valid properties
             #expect(!mode.displayName.isEmpty)
-            #expect(!mode.bindAddress.isEmpty)
             #expect(!mode.description.isEmpty)
 
             // Verify bind addresses
             switch mode {
             case .localhost:
-                #expect(mode.bindAddress == "127.0.0.1")
+                #expect(mode.fixedBindAddress?.value == "127.0.0.1")
             case .network:
-                #expect(mode.bindAddress == "0.0.0.0")
+                #expect(mode.fixedBindAddress?.value == "0.0.0.0")
+            case .custom:
+                #expect(mode.fixedBindAddress == nil)
+                #expect(mode.resolvedBindAddress(customAddress: "::").value == "::")
+                #expect(mode.resolvedBindAddress(customAddress: "invalid").value == "127.0.0.1")
             }
         }
 
@@ -138,12 +141,14 @@ struct ModelTests {
         func dashboardaccessmodeRawValues() {
             #expect(DashboardAccessMode.localhost.rawValue == AppConstants.DashboardAccessModeRawValues.localhost)
             #expect(DashboardAccessMode.network.rawValue == AppConstants.DashboardAccessModeRawValues.network)
+            #expect(DashboardAccessMode.custom.rawValue == AppConstants.DashboardAccessModeRawValues.custom)
         }
 
         @Test
         func dashboardaccessmodeDescriptions() {
             #expect(DashboardAccessMode.localhost.description.contains("this Mac"))
             #expect(DashboardAccessMode.network.description.contains("other devices"))
+            #expect(DashboardAccessMode.custom.description.contains("IPv4 or IPv6"))
         }
 
         @Test
@@ -154,7 +159,7 @@ struct ModelTests {
             // Verify we can create a mode from the default
             let mode = DashboardAccessMode(rawValue: AppConstants.Defaults.dashboardAccessMode)
             #expect(mode == .network)
-            #expect(mode?.bindAddress == "0.0.0.0")
+            #expect(mode?.fixedBindAddress?.value == "0.0.0.0")
         }
 
         @Test
@@ -164,6 +169,53 @@ struct ModelTests {
 
             let emptyMode = DashboardAccessMode(rawValue: "")
             #expect(emptyMode == nil)
+        }
+    }
+
+    // MARK: - ServerBindAddress Tests
+
+    @Suite("ServerBindAddress Tests")
+    struct ServerBindAddressTests {
+        @Test(arguments: [
+            ("127.0.0.1", ServerBindAddress.Family.ipv4),
+            ("0.0.0.0", ServerBindAddress.Family.ipv4),
+            ("::1", ServerBindAddress.Family.ipv6),
+            ("::", ServerBindAddress.Family.ipv6),
+            ("2001:db8::1", ServerBindAddress.Family.ipv6),
+        ])
+        func acceptsIPv4AndIPv6(value: String, family: ServerBindAddress.Family) {
+            let address = ServerBindAddress(value)
+            #expect(address?.value == value)
+            #expect(address?.family == family)
+        }
+
+        @Test(arguments: ["", "localhost", "256.0.0.1", "192.168.1", "[::1]", "2001:db8:::1"])
+        func rejectsInvalidAddressLiterals(value: String) {
+            #expect(ServerBindAddress(value) == nil)
+        }
+
+        @Test
+        func trimsAddressWhitespace() {
+            #expect(ServerBindAddress("  ::1 \n")?.value == "::1")
+        }
+
+        @Test
+        func buildsBracketedIPv6URLs() {
+            let loopback = ServerBindAddress("::1")
+            #expect(loopback?.endpoint(port: "4020") == "[::1]:4020")
+            #expect(
+                loopback?.url(port: "4020", endpoint: "/api/health")?.absoluteString ==
+                    "http://[::1]:4020/api/health")
+        }
+
+        @Test
+        func mapsWildcardAddressesToUsableLoopbackURLs() {
+            let ipv4Wildcard = ServerBindAddress("0.0.0.0")
+            let ipv6Wildcard = ServerBindAddress("::")
+
+            #expect(ipv4Wildcard?.connectableAddress.value == "127.0.0.1")
+            #expect(ipv6Wildcard?.connectableAddress.value == "::1")
+            #expect(ipv6Wildcard?.connectableAddress.url(port: "4020")?.absoluteString == "http://[::1]:4020/")
         }
     }
 

--- a/mac/VibeTunnelTests/ServerManagerTests.swift
+++ b/mac/VibeTunnelTests/ServerManagerTests.swift
@@ -124,7 +124,7 @@ final class ServerManagerTests {
         UserDefaults.standard.set(mode.rawValue, forKey: "dashboardAccessMode")
 
         // Check bind address reflects the mode
-        #expect(self.manager.bindAddress == mode.bindAddress)
+        #expect(self.manager.bindAddress == mode.fixedBindAddress?.value)
 
         // Restore original mode
         UserDefaults.standard.set(originalMode, forKey: "dashboardAccessMode")
@@ -152,6 +152,21 @@ final class ServerManagerTests {
     func bindAddressSetter() {
         // Store original value
         let originalMode = UserDefaults.standard.string(forKey: "dashboardAccessMode")
+        let originalCustomAddress = UserDefaults.standard.string(forKey: UserDefaultsKeys.customBindAddress)
+
+        defer {
+            if let originalMode {
+                UserDefaults.standard.set(originalMode, forKey: "dashboardAccessMode")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "dashboardAccessMode")
+            }
+
+            if let originalCustomAddress {
+                UserDefaults.standard.set(originalCustomAddress, forKey: UserDefaultsKeys.customBindAddress)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.customBindAddress)
+            }
+        }
 
         // Test setting via bind address
         self.manager.bindAddress = "127.0.0.1"
@@ -166,16 +181,65 @@ final class ServerManagerTests {
                 .network)
         #expect(self.manager.bindAddress == "0.0.0.0")
 
-        // Test invalid bind address (should not change UserDefaults)
-        self.manager.bindAddress = "192.168.1.1"
-        #expect(self.manager.bindAddress == "0.0.0.0") // Should still be the last valid value
+        self.manager.bindAddress = "::"
+        #expect(
+            UserDefaults.standard.string(forKey: "dashboardAccessMode") == AppConstants.DashboardAccessModeRawValues
+                .custom)
+        #expect(UserDefaults.standard.string(forKey: UserDefaultsKeys.customBindAddress) == "::")
+        #expect(self.manager.bindAddress == "::")
 
-        // Restore original value
-        if let originalMode {
-            UserDefaults.standard.set(originalMode, forKey: "dashboardAccessMode")
-        } else {
-            UserDefaults.standard.removeObject(forKey: "dashboardAccessMode")
+        self.manager.bindAddress = "192.168.1.1"
+        #expect(self.manager.bindAddress == "192.168.1.1")
+
+        // Invalid bind addresses should not change the last valid configuration.
+        self.manager.bindAddress = "not-an-address"
+        #expect(self.manager.bindAddress == "192.168.1.1")
+    }
+
+    @Test
+    func customIPv6ConfigurationPersistsAndBuildsValidURLs() {
+        let originalMode = UserDefaults.standard.string(forKey: UserDefaultsKeys.dashboardAccessMode)
+        let originalCustomAddress = UserDefaults.standard.string(forKey: UserDefaultsKeys.customBindAddress)
+        let originalPort = self.manager.port
+
+        defer {
+            self.manager.port = originalPort
+            if let originalMode {
+                UserDefaults.standard.set(originalMode, forKey: UserDefaultsKeys.dashboardAccessMode)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.dashboardAccessMode)
+            }
+            if let originalCustomAddress {
+                UserDefaults.standard.set(originalCustomAddress, forKey: UserDefaultsKeys.customBindAddress)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.customBindAddress)
+            }
         }
+
+        self.manager.port = "4567"
+        #expect(self.manager.updateBindConfiguration(mode: .custom, customAddress: "::"))
+        #expect(self.manager.dashboardAccessMode == .custom)
+        #expect(self.manager.customBindAddress == "::")
+        #expect(self.manager.bindAddress == "::")
+        #expect(self.manager.buildURL(endpoint: "/api/health")?.absoluteString == "http://[::1]:4567/api/health")
+        #expect(self.manager.dashboardURL()?.absoluteString == "http://[::1]:4567/")
+        #expect(self.manager.dashboardEndpoint == "[::1]:4567")
+    }
+
+    @Test
+    func rejectsInvalidCustomConfiguration() {
+        let originalMode = UserDefaults.standard.string(forKey: UserDefaultsKeys.dashboardAccessMode)
+        defer {
+            if let originalMode {
+                UserDefaults.standard.set(originalMode, forKey: UserDefaultsKeys.dashboardAccessMode)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.dashboardAccessMode)
+            }
+        }
+
+        UserDefaults.standard.set(DashboardAccessMode.network.rawValue, forKey: UserDefaultsKeys.dashboardAccessMode)
+        #expect(!self.manager.updateBindConfiguration(mode: .custom, customAddress: "localhost"))
+        #expect(self.manager.dashboardAccessMode == .network)
     }
 
     @Test(

--- a/web/src/server/middleware/auth.test.ts
+++ b/web/src/server/middleware/auth.test.ts
@@ -1,9 +1,11 @@
+import type { NetworkInterfaceInfo } from 'node:os';
+import { networkInterfaces } from 'node:os';
 import type { NextFunction, Response } from 'express';
 import express from 'express';
 import request from 'supertest';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AuthService } from '../services/auth-service.js';
-import { type AuthenticatedRequest, createAuthMiddleware } from './auth.js';
+import { type AuthenticatedRequest, createAuthMiddleware, isLocalMachineAddress } from './auth.js';
 
 // Mock the logger
 vi.mock('../utils/logger.js', () => ({
@@ -40,6 +42,7 @@ describe('Auth Middleware', () => {
 
     mockNext = vi.fn();
     mockRes = {
+      setHeader: vi.fn().mockReturnThis(),
       status: vi.fn().mockReturnThis(),
       json: vi.fn().mockReturnThis(),
     } as unknown as Response;
@@ -254,6 +257,62 @@ describe('Auth Middleware', () => {
       expect(response3.status).toBe(200);
     });
 
+    it('should accept a valid local token from a non-loopback interface', () => {
+      const localInterfaceAddress = Object.values(networkInterfaces())
+        .flatMap((addresses) => addresses ?? [])
+        .find((entry) => !entry.internal)?.address;
+      expect(localInterfaceAddress).toBeDefined();
+
+      const middleware = createAuthMiddleware({
+        allowLocalBypass: true,
+        localAuthToken: 'secret-token',
+        authService: mockAuthService,
+      });
+      const req = {
+        headers: {
+          host: localInterfaceAddress,
+          'x-vibetunnel-local': 'secret-token',
+        },
+        hostname: localInterfaceAddress?.includes(':')
+          ? `[${localInterfaceAddress}]`
+          : localInterfaceAddress,
+        socket: {
+          remoteAddress: localInterfaceAddress,
+        },
+        path: '/test',
+      } as unknown as AuthenticatedRequest;
+
+      middleware(req, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalled();
+      expect(req.authMethod).toBe('local-bypass');
+    });
+
+    it('should reject a valid local token from a remote address', () => {
+      const middleware = createAuthMiddleware({
+        allowLocalBypass: true,
+        localAuthToken: 'secret-token',
+        authService: mockAuthService,
+      });
+      const req = {
+        headers: {
+          host: 'localhost',
+          'x-vibetunnel-local': 'secret-token',
+        },
+        hostname: 'localhost',
+        socket: {
+          remoteAddress: '203.0.113.10',
+        },
+        query: {},
+        path: '/test',
+      } as unknown as AuthenticatedRequest;
+
+      middleware(req, mockRes, mockNext);
+
+      expect(mockNext).not.toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+    });
+
     it('should reject requests with forwarded headers even from localhost', async () => {
       const middleware = createAuthMiddleware({
         allowLocalBypass: true,
@@ -374,6 +433,46 @@ describe('Auth Middleware', () => {
   });
 
   describe('IPv6 localhost handling', () => {
+    it('should recognize IPv4-mapped and scoped local interface addresses', () => {
+      const interfaces = {
+        en0: [
+          {
+            address: '192.0.2.10',
+            netmask: '255.255.255.0',
+            family: 'IPv4',
+            mac: '00:00:00:00:00:00',
+            internal: false,
+            cidr: '192.0.2.10/24',
+          },
+          {
+            address: 'fe80::1234%en0',
+            netmask: 'ffff:ffff:ffff:ffff::',
+            family: 'IPv6',
+            mac: '00:00:00:00:00:00',
+            internal: false,
+            cidr: 'fe80::1234/64',
+            scopeid: 4,
+          },
+          {
+            address: '2001:db8::1',
+            netmask: 'ffff:ffff:ffff:ffff::',
+            family: 'IPv6',
+            mac: '00:00:00:00:00:00',
+            internal: false,
+            cidr: '2001:db8::1/64',
+            scopeid: 0,
+          },
+        ],
+      } as unknown as NodeJS.Dict<NetworkInterfaceInfo[]>;
+
+      expect(isLocalMachineAddress('::ffff:192.0.2.10', interfaces)).toBe(true);
+      expect(isLocalMachineAddress('fe80::1234%en0', interfaces)).toBe(true);
+      expect(isLocalMachineAddress('[2001:0DB8:0000:0000:0000:0000:0000:0001]', interfaces)).toBe(
+        true
+      );
+      expect(isLocalMachineAddress('203.0.113.10', interfaces)).toBe(false);
+    });
+
     it('should accept ::1 as localhost for Tailscale auth', async () => {
       const middleware = createAuthMiddleware({
         allowTailscaleAuth: true,

--- a/web/src/server/middleware/auth.ts
+++ b/web/src/server/middleware/auth.ts
@@ -1,3 +1,5 @@
+import { BlockList, isIP } from 'node:net';
+import { networkInterfaces } from 'node:os';
 import type { NextFunction, Request, Response } from 'express';
 import type { AuthService } from '../services/auth-service.js';
 import { createLogger } from '../utils/logger.js';
@@ -23,14 +25,46 @@ export interface AuthenticatedRequest extends Request {
   tailscaleUser?: TailscaleUser;
 }
 
-// Helper function to check if request is from localhost
-function isLocalRequest(req: Request): boolean {
-  // Get the real client IP
-  const clientIp = req.ip || req.socket.remoteAddress || '';
+const loopbackAddresses = new Set(['127.0.0.1', '::1', 'localhost']);
 
-  // Check for localhost IPs
-  const localIPs = ['127.0.0.1', '::1', '::ffff:127.0.0.1', 'localhost'];
-  const ipIsLocal = localIPs.includes(clientIp);
+function normalizeAddress(address: string): string {
+  const withoutBrackets =
+    address.startsWith('[') && address.endsWith(']') ? address.slice(1, -1) : address;
+  const withoutScope = withoutBrackets.split('%', 1)[0];
+  return withoutScope.startsWith('::ffff:') ? withoutScope.slice(7) : withoutScope;
+}
+
+export function isLocalMachineAddress(address: string, interfaces = networkInterfaces()): boolean {
+  const normalizedAddress = normalizeAddress(address);
+  if (loopbackAddresses.has(normalizedAddress)) {
+    return true;
+  }
+
+  const addressVersion = isIP(normalizedAddress);
+  if (addressVersion === 0) {
+    return false;
+  }
+
+  const localAddresses = new BlockList();
+  for (const addresses of Object.values(interfaces)) {
+    for (const entry of addresses ?? []) {
+      const localAddress = normalizeAddress(entry.address);
+      const localAddressVersion = isIP(localAddress);
+      if (localAddressVersion !== 0) {
+        localAddresses.addAddress(localAddress, localAddressVersion === 4 ? 'ipv4' : 'ipv6');
+      }
+    }
+  }
+
+  return localAddresses.check(normalizedAddress, addressVersion === 4 ? 'ipv4' : 'ipv6');
+}
+
+// Helper function to check if request is from localhost or, with a valid token, this machine.
+function isLocalRequest(req: Request, allowLocalInterface: boolean): boolean {
+  const clientIp = req.socket.remoteAddress || '';
+  const ipIsLocal =
+    loopbackAddresses.has(normalizeAddress(clientIp)) ||
+    (allowLocalInterface && isLocalMachineAddress(clientIp));
 
   // Additional security checks to prevent spoofing
   const noForwardedFor = !req.headers['x-forwarded-for'];
@@ -39,7 +73,8 @@ function isLocalRequest(req: Request): boolean {
 
   // Check hostname
   const hostIsLocal =
-    req.hostname === 'localhost' || req.hostname === '127.0.0.1' || req.hostname === '[::1]';
+    loopbackAddresses.has(normalizeAddress(req.hostname)) ||
+    (allowLocalInterface && isLocalMachineAddress(req.hostname));
 
   logger.debug(
     `Local request check - IP: ${clientIp}, Host: ${req.hostname}, ` +
@@ -161,11 +196,16 @@ export function createAuthMiddleware(config: AuthConfig) {
     }
 
     // Check for local bypass if enabled
-    if (config.allowLocalBypass && isLocalRequest(req)) {
+    const providedLocalToken = req.headers['x-vibetunnel-local'];
+    const hasValidLocalToken =
+      typeof providedLocalToken === 'string' &&
+      Boolean(config.localAuthToken) &&
+      providedLocalToken === config.localAuthToken;
+
+    if (config.allowLocalBypass && isLocalRequest(req, hasValidLocalToken)) {
       // If a local auth token is configured, check for it
       if (config.localAuthToken) {
-        const providedToken = req.headers['x-vibetunnel-local'] as string;
-        if (providedToken === config.localAuthToken) {
+        if (hasValidLocalToken) {
           logger.debug('Local request authenticated with token');
           req.authMethod = 'local-bypass';
           req.userId = 'local-user';


### PR DESCRIPTION
## Summary

Adds a validated custom bind-address mode to the macOS app, including IPv4, IPv6, and dual-stack `::` support. Fixes #569.

Thanks to @waxzce for the original contribution.

## Changes

- add a persisted Custom address mode alongside Localhost and Network
- validate literal IPv4 and IPv6 addresses with the system address parser
- support dual-stack binding through `::`
- format IPv6 dashboard endpoints and URLs with brackets
- show explicit validation errors and keep invalid values from restarting the server
- centralize dashboard/bind URL construction across settings, menu, tooltips, and internal requests
- allow token-authenticated internal requests through real local interface addresses while still rejecting forwarded or remote requests
- add focused Swift and server-auth regression coverage
- add the user-facing changelog entry with contributor credit

## Exact app proof

Built and launched the final Debug app bundle with its matching embedded standalone server.

- real Wi-Fi IPv4 bind: unauthenticated protected API request returned 401; app-token request returned 200
- real interface IPv6 bind: unauthenticated protected API request returned 401; app-token request returned 200
- dual-stack `::`: IPv4 and IPv6 loopback requests both returned 200 with the app token
- full app quit/relaunch preserved Custom + `::`; both address families remained reachable
- settings UI showed the bracketed IPv6 dashboard URL and explicit dual-stack guidance
- original user defaults, processes, and test listener were restored after proof

## Test plan

- [x] focused auth middleware tests: 20 passed
- [x] Node 24 TypeScript checks: server, client, and service worker passed
- [x] client coverage suite passed
- [x] server coverage suite: 579 passed, 75 skipped
- [x] Biome lint passed across 401 files
- [x] SwiftFormat passed
- [x] SwiftLint passed with only three pre-existing warnings in an untouched file
- [x] full macOS app test suite passed with Xcode 26.4
- [x] final standalone server and macOS app builds passed
- [x] autoreview completed with no actionable findings
- [x] Public Model Identifier Gate passed across exact diff, tests, workflows, logs, generated artifacts, app bundle, and public proof

The macOS workflow has a 40-minute job timeout, with build and test phases separately capped at 10 and 20 minutes, so it cannot block for hours.
