### PR TITLE
fix(ios): resolve terminal rendering issues and input echo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Restore iOS terminal rendering, preserve output received during Ghostty startup, and stream stdout for immediate input echo (via [@waxzce](https://github.com/waxzce)) (#577)
 - Keep Korean and other CJK IME composition events intact and position desktop candidate windows at the terminal cursor (via [@jiangwenhan](https://github.com/jiangwenhan)) (#617)
 - Prevent rapid iOS slash-command redraws from queuing redundant smooth terminal scrolling (via [@Ilakiancs](https://github.com/Ilakiancs)) (#590)
 - Keep mobile session header controls visible and comfortably tappable at narrow phone widths (via [@nikolasdehor](https://github.com/nikolasdehor)) (#605)
@@ -42,6 +43,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
+- Thanks [@waxzce](https://github.com/waxzce) for restoring reliable iOS terminal rendering and input echo.
 - Thanks [@jiangwenhan](https://github.com/jiangwenhan) for improving Korean and CJK terminal input.
 - Thanks [@Tyoneva](https://github.com/Tyoneva) for improving web app installation and icon support.
 - Thanks [@ndraiman](https://github.com/ndraiman) for fixing native forwarder crashes while collecting git metadata.

--- a/ios/README.md
+++ b/ios/README.md
@@ -50,6 +50,7 @@
 1. Ensure `VibeTunnel/Resources/ghostty/ghostty-web.js` is included in the target
 2. Ensure `VibeTunnel/Resources/ghostty/ghostty-vt.wasm` is included in the target
 3. These files are vendored from `web/node_modules/ghostty-web/dist`
+4. Xcode may flatten the synchronized `ghostty` folder into the app bundle root; the runtime supports both layouts
 
 ### 4. Configure Info.plist
 
@@ -140,6 +141,7 @@ VibeTunnel/
 - **Minimum iOS**: 18.0 (uses latest SwiftUI features)
 - **Swift**: 6.0 compatible
 - **Dependencies**: ghostty-web resources for terminal emulation
+- **Terminal transport**: interactive terminals stream stdout for low-latency echo; session previews use canonical snapshots
 - **Architecture**: MVVM with SwiftUI and Combine
 
 ### Logging with vtlog

--- a/ios/VibeTunnel/Services/BufferWebSocketClient.swift
+++ b/ios/VibeTunnel/Services/BufferWebSocketClient.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Terminal event types that match the server's output.
 /// Represents various events that can occur during terminal interaction.
 enum TerminalWebSocketEvent {
+    case replayStarted
     case header(width: Int, height: Int)
     case output(timestamp: Double, data: String)
     case resize(timestamp: Double, dimensions: String)
@@ -10,6 +11,11 @@ enum TerminalWebSocketEvent {
     case bufferUpdate(snapshot: BufferSnapshot)
     case bell
     case alert(title: String?, message: String)
+}
+
+enum TerminalSubscriptionMode: Equatable {
+    case snapshots
+    case stdout
 }
 
 /// Binary buffer snapshot data.
@@ -90,11 +96,17 @@ class BufferWebSocketClient: NSObject {
         let payload: Data
     }
 
+    private struct Subscription {
+        let mode: TerminalSubscriptionMode
+        let handler: @MainActor (TerminalWebSocketEvent) -> Void
+    }
+
     private var webSocket: WebSocketProtocol?
     private let webSocketFactory: WebSocketFactory
-    private var subscriptions = [String: (TerminalWebSocketEvent) -> Void]()
+    private var subscriptions = [String: Subscription]()
     private var reconnectTask: Task<Void, Never>?
     private var reconnectAttempts = 0
+    private var hasConnected = false
     private var isConnecting = false
     private var pingTask: Task<Void, Never>?
     private(set) var authenticationService: AuthenticationService?
@@ -218,7 +230,7 @@ class BufferWebSocketClient: NSObject {
         switch type {
         case .snapshotVT:
             if let event = decodeTerminalEvent(from: payload),
-               let handler = subscriptions[sessionId]
+               let handler = subscriptions[sessionId]?.handler
             {
                 handler(event)
             }
@@ -227,9 +239,8 @@ class BufferWebSocketClient: NSObject {
             self.handleV3Event(sessionId: sessionId, payload: payload)
 
         case .stdout:
-            // Optional: map to output events if needed later.
             if let text = String(data: payload, encoding: .utf8),
-               let handler = subscriptions[sessionId]
+               let handler = subscriptions[sessionId]?.handler
             {
                 handler(.output(timestamp: Date().timeIntervalSince1970, data: text))
             }
@@ -237,7 +248,7 @@ class BufferWebSocketClient: NSObject {
         case .error:
             let message = String(data: payload, encoding: .utf8) ?? "Unknown error"
             self.logger.warning("Server error: \(message)")
-            if let handler = subscriptions[sessionId] {
+            if let handler = subscriptions[sessionId]?.handler {
                 handler(.alert(title: "Server Error", message: message))
             }
 
@@ -247,18 +258,31 @@ class BufferWebSocketClient: NSObject {
     }
 
     private func handleV3Event(sessionId: String, payload: Data) {
-        guard let handler = subscriptions[sessionId] else { return }
+        guard let handler = subscriptions[sessionId]?.handler else { return }
         struct V3Event: Decodable {
             let kind: String
             let exitCode: Int?
+            let dimensions: String?
+            let header: AsciinemaHeader?
         }
 
         guard let event = try? JSONDecoder().decode(V3Event.self, from: payload) else {
             return
         }
 
-        if event.kind == "exit" {
+        switch event.kind {
+        case "exit":
             handler(.exit(code: event.exitCode ?? 0))
+        case "header":
+            if let header = event.header {
+                handler(.header(width: header.width, height: header.height))
+            }
+        case "resize":
+            if let dimensions = event.dimensions {
+                handler(.resize(timestamp: Date().timeIntervalSince1970, dimensions: dimensions))
+            }
+        default:
+            break
         }
     }
 
@@ -313,7 +337,7 @@ class BufferWebSocketClient: NSObject {
         let hasBell = (flags & 0x01) != 0
         if hasBell {
             // Send bell event separately
-            if let handler = subscriptions.values.first {
+            if let handler = subscriptions.values.first?.handler {
                 handler(.bell)
             }
         }
@@ -653,22 +677,22 @@ class BufferWebSocketClient: NSObject {
         return 1
     }
 
-    func subscribe(to sessionId: String, handler: @escaping (TerminalWebSocketEvent) -> Void) {
+    func subscribe(
+        to sessionId: String,
+        mode: TerminalSubscriptionMode = .snapshots,
+        handler: @escaping @MainActor (TerminalWebSocketEvent) -> Void)
+    {
         Task { @MainActor [weak self] in
             guard let self else { return }
 
             // Store the handler
-            self.subscriptions[sessionId] = handler
+            self.subscriptions[sessionId] = Subscription(mode: mode, handler: handler)
 
             // Send subscription message immediately if connected
             if self.isConnected {
-                try? await self.sendV3Subscribe(sessionId: sessionId)
+                try? await self.sendV3Subscribe(sessionId: sessionId, mode: mode)
             }
         }
-    }
-
-    private func subscribe(to sessionId: String) async throws {
-        try await self.sendV3Subscribe(sessionId: sessionId)
     }
 
     func unsubscribe(from sessionId: String) {
@@ -685,8 +709,14 @@ class BufferWebSocketClient: NSObject {
         }
     }
 
-    private func sendV3Subscribe(sessionId: String) async throws {
-        let flags: UInt32 = V3SubscribeFlags.snapshots.rawValue | V3SubscribeFlags.events.rawValue
+    private func sendV3Subscribe(sessionId: String, mode: TerminalSubscriptionMode) async throws {
+        let streamFlag: UInt32 = switch mode {
+        case .snapshots:
+            V3SubscribeFlags.snapshots.rawValue
+        case .stdout:
+            V3SubscribeFlags.stdout.rawValue
+        }
+        let flags = streamFlag | V3SubscribeFlags.events.rawValue
         var payload = Data(count: 12)
         payload.withUnsafeMutableBytes { bytes in
             bytes.storeBytes(of: flags.littleEndian, toByteOffset: 0, as: UInt32.self)
@@ -859,6 +889,7 @@ class BufferWebSocketClient: NSObject {
 
         self.subscriptions.removeAll()
         self.isConnected = false
+        self.hasConnected = false
     }
 
     deinit {
@@ -872,6 +903,8 @@ class BufferWebSocketClient: NSObject {
 extension BufferWebSocketClient: WebSocketDelegate {
     func webSocketDidConnect(_ webSocket: WebSocketProtocol) {
         self.logger.info("Connected")
+        let isReconnect = self.hasConnected
+        self.hasConnected = true
         self.isConnected = true
         self.isConnecting = false
         self.reconnectAttempts = 0
@@ -881,9 +914,12 @@ extension BufferWebSocketClient: WebSocketDelegate {
         Task { @MainActor [weak self] in
             guard let self else { return }
 
-            let sessionIds = Array(self.subscriptions.keys)
-            for sessionId in sessionIds {
-                try? await self.sendV3Subscribe(sessionId: sessionId)
+            let subscriptions = self.subscriptions
+            for (sessionId, subscription) in subscriptions {
+                if isReconnect, subscription.mode == .stdout {
+                    subscription.handler(.replayStarted)
+                }
+                try? await self.sendV3Subscribe(sessionId: sessionId, mode: subscription.mode)
             }
         }
     }

--- a/ios/VibeTunnel/Views/Terminal/GhosttyWebView.swift
+++ b/ios/VibeTunnel/Views/Terminal/GhosttyWebView.swift
@@ -1,6 +1,51 @@
 import SwiftUI
 import WebKit
 
+struct TerminalWriteBuffer {
+    private(set) var isReady = false
+    private var pendingData = ""
+
+    mutating func receive(_ data: String) -> String? {
+        guard self.isReady else {
+            self.pendingData += data
+            return nil
+        }
+        return data
+    }
+
+    mutating func markReady() -> String? {
+        guard !self.isReady else { return nil }
+        self.isReady = true
+
+        guard !self.pendingData.isEmpty else { return nil }
+        defer { self.pendingData.removeAll() }
+        return self.pendingData
+    }
+
+    mutating func discardPending() {
+        self.pendingData.removeAll()
+    }
+}
+
+enum GhosttyResourceLocator {
+    static func scriptURL(in bundle: Bundle = .main) -> URL? {
+        self.scriptURL { subdirectory in
+            if let subdirectory {
+                bundle.url(
+                    forResource: "ghostty-web",
+                    withExtension: "js",
+                    subdirectory: subdirectory)
+            } else {
+                bundle.url(forResource: "ghostty-web", withExtension: "js")
+            }
+        }
+    }
+
+    static func scriptURL(using lookup: (String?) -> URL?) -> URL? {
+        lookup("ghostty") ?? lookup(nil)
+    }
+}
+
 /// WebView-based terminal using ghostty-web (WASM + canvas).
 struct GhosttyWebView: UIViewRepresentable {
     struct TerminalSize: Equatable {
@@ -57,7 +102,7 @@ struct GhosttyWebView: UIViewRepresentable {
         weak var webView: WKWebView?
         private let logger = Logger(category: "GhosttyWebView")
         private var bufferRenderer = TerminalBufferRenderer()
-        private var isReady = false
+        private var writeBuffer = TerminalWriteBuffer()
         private var pendingTerminalSize: TerminalSize?
         private var lastTerminalSize: TerminalSize?
 
@@ -202,6 +247,10 @@ struct GhosttyWebView: UIViewRepresentable {
                         if (term) term.clear();
                     }
 
+                    function reset() {
+                        if (term) term.reset();
+                    }
+
                     function resize() {
                         if (fitAddon) fitAddon.fit();
                     }
@@ -212,14 +261,39 @@ struct GhosttyWebView: UIViewRepresentable {
                         term.resize(cols, rows);
                     }
 
+                    function getBufferContent() {
+                        if (!term) return '';
+
+                        const buffer = term.buffer.active;
+                        const lines = [];
+                        for (let i = 0; i < buffer.length; i++) {
+                            const line = buffer.getLine(i);
+                            if (!line) continue;
+
+                            const text = line.translateToString(true);
+                            if (line.isWrapped && lines.length > 0) {
+                                lines[lines.length - 1] += text;
+                            } else {
+                                lines.push(text);
+                            }
+                        }
+
+                        while (lines.length > 0 && lines[lines.length - 1] === '') {
+                            lines.pop();
+                        }
+                        return lines.join('\\n');
+                    }
+
                     window.ghosttyAPI = {
                         writeToTerminal,
                         updateFontSize,
                         updateTheme,
                         scrollToBottom,
                         clear,
+                        reset,
                         resize,
-                        setTerminalSize
+                        setTerminalSize,
+                        getBufferContent
                     };
 
                     window.addEventListener('load', initTerminal);
@@ -233,11 +307,7 @@ struct GhosttyWebView: UIViewRepresentable {
             </html>
             """
 
-            guard let ghosttyURL = Bundle.main.url(
-                forResource: "ghostty-web",
-                withExtension: "js",
-                subdirectory: "ghostty")
-            else {
+            guard let ghosttyURL = GhosttyResourceLocator.scriptURL() else {
                 self.logger.error("ghostty-web.js missing from bundle")
                 return
             }
@@ -294,7 +364,7 @@ struct GhosttyWebView: UIViewRepresentable {
             if size == self.lastTerminalSize { return }
             self.lastTerminalSize = size
 
-            if self.isReady {
+            if self.writeBuffer.isReady {
                 self.setTerminalSize(cols: size.cols, rows: size.rows)
             } else {
                 self.pendingTerminalSize = size
@@ -302,10 +372,12 @@ struct GhosttyWebView: UIViewRepresentable {
         }
 
         func handleTerminalReady() {
-            self.isReady = true
             if let size = pendingTerminalSize {
                 self.setTerminalSize(cols: size.cols, rows: size.rows)
                 self.pendingTerminalSize = nil
+            }
+            if let pendingData = self.writeBuffer.markReady() {
+                self.feedData(pendingData)
             }
         }
 
@@ -327,6 +399,7 @@ struct GhosttyWebView: UIViewRepresentable {
         }
 
         func feedData(_ data: String) {
+            guard let data = writeBuffer.receive(data) else { return }
             let followCursor = self.parent.viewModel?.isAutoScrollEnabled ?? true
             guard let payload = jsonString(data) else { return }
             self.webView?
@@ -351,12 +424,25 @@ struct GhosttyWebView: UIViewRepresentable {
             self.webView?.evaluateJavaScript("window.ghosttyAPI.clear()")
         }
 
+        func resetForReplay() {
+            self.bufferRenderer = TerminalBufferRenderer()
+            self.writeBuffer.discardPending()
+            self.webView?.evaluateJavaScript("window.ghosttyAPI.reset()")
+        }
+
         func setMaxWidth(_ maxWidth: Int) {
             self.logger.info("Max width set to: \(maxWidth == 0 ? "unlimited" : "\(maxWidth) columns")")
         }
 
-        func getBufferContent() -> String? {
-            self.bufferRenderer.bufferContent()
+        func getBufferContent() async -> String? {
+            guard let webView else { return nil }
+
+            do {
+                return try await webView.evaluateJavaScript("window.ghosttyAPI.getBufferContent()") as? String
+            } catch {
+                self.logger.error("Failed to read terminal buffer: \(error)")
+                return nil
+            }
         }
 
         private func makeThemeJSON(_ theme: TerminalTheme) -> String {
@@ -391,7 +477,7 @@ struct GhosttyWebView: UIViewRepresentable {
             return self.jsonString(fontFamily) ?? "\"monospace\""
         }
 
-        private func jsonString<T: Encodable>(_ value: T) -> String? {
+        private func jsonString(_ value: some Encodable) -> String? {
             guard let data = try? JSONEncoder().encode(value) else { return nil }
             return String(data: data, encoding: .utf8)
         }

--- a/ios/VibeTunnel/Views/Terminal/TerminalView.swift
+++ b/ios/VibeTunnel/Views/Terminal/TerminalView.swift
@@ -193,11 +193,7 @@ struct TerminalView: View {
         }
         .onKeyPress(keys: ["c"]) { press in
             if press.modifiers.contains(.command), !press.modifiers.contains(.shift) {
-                // Copy to clipboard
-                if let content = viewModel.getBufferContent() {
-                    UIPasteboard.general.string = content
-                    HapticFeedback.notification(.success)
-                }
+                self.viewModel.copyBuffer()
                 return .handled
             }
             return .ignored
@@ -247,17 +243,19 @@ struct TerminalView: View {
     // MARK: - Export Functions
 
     private func exportTerminalBuffer() {
-        guard let bufferContent = viewModel.getBufferContent() else { return }
+        Task { @MainActor in
+            guard let bufferContent = await viewModel.getBufferContent() else { return }
 
-        let fileName = "\(session.displayName)_\(Date().timeIntervalSince1970).txt"
-        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+            let fileName = "\(session.displayName)_\(Date().timeIntervalSince1970).txt"
+            let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
 
-        do {
-            try bufferContent.write(to: tempURL, atomically: true, encoding: .utf8)
-            self.exportedFileURL = tempURL
-            self.showingExportSheet = true
-        } catch {
-            logger.error("Failed to export terminal buffer: \(error)")
+            do {
+                try bufferContent.write(to: tempURL, atomically: true, encoding: .utf8)
+                self.exportedFileURL = tempURL
+                self.showingExportSheet = true
+            } catch {
+                logger.error("Failed to export terminal buffer: \(error)")
+            }
         }
     }
 
@@ -584,6 +582,11 @@ struct TerminalView: View {
 @MainActor
 @Observable
 class TerminalViewModel {
+    private enum PendingTerminalRenderEvent {
+        case output(String)
+        case snapshot(BufferSnapshot)
+    }
+
     var isConnecting = true
     var isConnected = false
     var errorMessage: String?
@@ -604,7 +607,12 @@ class TerminalViewModel {
     private var resizeDebounceTask: Task<Void, Never>?
     private var hasPerformedInitialResize = false
     private var isPerformingInitialResize = false
-    weak var terminalCoordinator: (any TerminalCoordinating)?
+    private var pendingTerminalEvents: [PendingTerminalRenderEvent] = []
+    weak var terminalCoordinator: (any TerminalCoordinating)? {
+        didSet {
+            self.flushPendingTerminalEvents()
+        }
+    }
 
     init(session: Session) {
         self.session = session
@@ -630,10 +638,8 @@ class TerminalViewModel {
         self.errorMessage = nil
 
         // Subscribe to terminal events first (stores the handler)
-        self.bufferWebSocketClient.subscribe(to: self.session.id) { [weak self] event in
-            Task { @MainActor in
-                self?.handleWebSocketEvent(event)
-            }
+        self.bufferWebSocketClient.subscribe(to: self.session.id, mode: .stdout) { [weak self] event in
+            self?.handleWebSocketEvent(event)
         }
 
         // Connect to WebSocket - it will automatically subscribe to stored sessions
@@ -684,8 +690,12 @@ class TerminalViewModel {
     }
 
     @MainActor
-    private func handleWebSocketEvent(_ event: TerminalWebSocketEvent) {
+    func handleWebSocketEvent(_ event: TerminalWebSocketEvent) {
         switch event {
+        case .replayStarted:
+            self.pendingTerminalEvents.removeAll()
+            self.terminalCoordinator?.resetForReplay()
+
         case let .header(width, height):
             // Initial terminal setup
             logger.info("Terminal initialized: \(width)x\(height)")
@@ -694,20 +704,7 @@ class TerminalViewModel {
         // The terminal will be resized when created
 
         case let .output(_, data):
-            // Feed output data directly to the terminal
-            if let coordinator = terminalCoordinator {
-                coordinator.feedData(data)
-            } else {
-                // Queue the data to be fed once coordinator is ready
-                logger.warning("Terminal coordinator not ready, queueing data")
-                Task {
-                    // Wait a bit for coordinator to be initialized
-                    try? await Task.sleep(nanoseconds: 100_000_000) // 0.1s
-                    if let coordinator = self.terminalCoordinator {
-                        coordinator.feedData(data)
-                    }
-                }
-            }
+            self.renderTerminalEvent(.output(data))
             // Record output if recording
             self.castRecorder.recordOutput(data)
 
@@ -740,13 +737,7 @@ class TerminalViewModel {
             // Session has exited - no need to load additional content
 
         case let .bufferUpdate(snapshot):
-            // Update terminal buffer directly
-            if let coordinator = terminalCoordinator {
-                coordinator.updateBuffer(from: snapshot)
-            } else {
-                // Fallback: buffer updates not available yet
-                logger.warning("Direct buffer update not available")
-            }
+            self.renderTerminalEvent(.snapshot(snapshot))
 
         case .bell:
             // Terminal bell - play sound and/or haptic feedback
@@ -755,6 +746,36 @@ class TerminalViewModel {
         case let .alert(title, message):
             // Terminal alert - show notification
             self.handleTerminalAlert(title: title, message: message)
+        }
+    }
+
+    private func renderTerminalEvent(_ event: PendingTerminalRenderEvent) {
+        guard let coordinator = terminalCoordinator else {
+            self.pendingTerminalEvents.append(event)
+            return
+        }
+        self.renderTerminalEvent(event, on: coordinator)
+    }
+
+    private func flushPendingTerminalEvents() {
+        guard let coordinator = terminalCoordinator, !self.pendingTerminalEvents.isEmpty else { return }
+
+        let events = self.pendingTerminalEvents
+        self.pendingTerminalEvents.removeAll()
+        for event in events {
+            self.renderTerminalEvent(event, on: coordinator)
+        }
+    }
+
+    private func renderTerminalEvent(
+        _ event: PendingTerminalRenderEvent,
+        on coordinator: any TerminalCoordinating)
+    {
+        switch event {
+        case let .output(data):
+            coordinator.feedData(data)
+        case let .snapshot(snapshot):
+            coordinator.updateBuffer(from: snapshot)
         }
     }
 
@@ -906,15 +927,17 @@ class TerminalViewModel {
     }
 
     func copyBuffer() {
-        if let content = getBufferContent() {
-            UIPasteboard.general.string = content
-            HapticFeedback.notification(.success)
+        Task { @MainActor in
+            if let content = await getBufferContent() {
+                UIPasteboard.general.string = content
+                HapticFeedback.notification(.success)
+            }
         }
     }
 
-    func getBufferContent() -> String? {
+    func getBufferContent() async -> String? {
         // Get the current terminal buffer content
-        self.terminalCoordinator?.getBufferContent()
+        await self.terminalCoordinator?.getBufferContent()
     }
 
     @MainActor
@@ -989,7 +1012,8 @@ class TerminalViewModel {
 protocol TerminalCoordinating: AnyObject {
     func feedData(_ data: String)
     func updateBuffer(from snapshot: BufferSnapshot)
+    func resetForReplay()
     func scrollToBottom()
     func setMaxWidth(_ maxWidth: Int)
-    func getBufferContent() -> String?
+    func getBufferContent() async -> String?
 }

--- a/ios/VibeTunnelTests/Mocks/MockWebSocketFactory.swift
+++ b/ios/VibeTunnelTests/Mocks/MockWebSocketFactory.swift
@@ -10,7 +10,7 @@ class MockBufferWebSocketClient: BufferWebSocketClient {
     var unsubscribeCalled = false
     var lastSubscribedSessionId: String?
 
-    private var eventHandlers: [String: (TerminalWebSocketEvent) -> Void] = [:]
+    private var eventHandlers: [String: @MainActor (TerminalWebSocketEvent) -> Void] = [:]
 
     override func connect() {
         self.connectCalled = true
@@ -24,11 +24,15 @@ class MockBufferWebSocketClient: BufferWebSocketClient {
         super.disconnect()
     }
 
-    override func subscribe(to sessionId: String, handler: @escaping (TerminalWebSocketEvent) -> Void) {
+    override func subscribe(
+        to sessionId: String,
+        mode: TerminalSubscriptionMode = .snapshots,
+        handler: @escaping @MainActor (TerminalWebSocketEvent) -> Void)
+    {
         self.subscribeCalled = true
         self.lastSubscribedSessionId = sessionId
         self.eventHandlers[sessionId] = handler
-        super.subscribe(to: sessionId, handler: handler)
+        super.subscribe(to: sessionId, mode: mode, handler: handler)
     }
 
     override func unsubscribe(from sessionId: String) {

--- a/ios/VibeTunnelTests/Services/BufferWebSocketClientTests.swift
+++ b/ios/VibeTunnelTests/Services/BufferWebSocketClientTests.swift
@@ -51,7 +51,7 @@ final class BufferWebSocketClientTests {
         // Arrange - server with HTTPS available
         let httpsConfig = ServerConfig(
             host: "100.64.0.1",
-            port: 4_020,
+            port: 4020,
             name: "Test Server",
             tailscaleHostname: "test-machine.tailnet.ts.net",
             tailscaleIP: "100.64.0.1",
@@ -59,8 +59,7 @@ final class BufferWebSocketClientTests {
             preferTailscale: true,
             httpsAvailable: true,
             isPublic: false,
-            preferSSL: true
-        )
+            preferSSL: true)
         TestFixtures.saveServerConfig(httpsConfig)
 
         // Create new client to pick up the config
@@ -73,7 +72,7 @@ final class BufferWebSocketClientTests {
         try await Task.sleep(nanoseconds: 100_000_000) // 100ms
 
         // Assert - should use WSS with HTTPS hostname
-        #expect(mockFactory.createdWebSockets.count == 1)
+        #expect(self.mockFactory.createdWebSockets.count == 1)
         let mockWebSocket = try #require(mockFactory.lastCreatedWebSocket)
         #expect(mockWebSocket.lastConnectURL?.scheme == "wss")
         #expect(mockWebSocket.lastConnectURL?.host == "test-machine.tailnet.ts.net")
@@ -159,11 +158,80 @@ final class BufferWebSocketClientTests {
 
         // Assert - Check if subscribe frame was sent (v3 type 10)
         let frames = mockWebSocket.sentDataMessages().compactMap { TestFixtures.decodeV3Frame($0) }
-        #expect(frames.contains { $0.type == 10 && $0.sessionId == sessionId })
+        let subscribeFrame = try #require(frames.first { $0.type == 10 && $0.sessionId == sessionId })
+        #expect(subscribeFrame.payload.count == 12)
+
+        let flags = subscribeFrame.payload.withUnsafeBytes { bytes in
+            bytes.loadUnaligned(as: UInt32.self).littleEndian
+        }
+        #expect(flags == 0b110)
+    }
+
+    @Test("Interactive subscriptions request stdout without snapshots")
+    func interactiveSessionSubscription() async throws {
+        let sessionId = "interactive-session"
+
+        self.client.connect()
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let mockWebSocket = try #require(mockFactory.lastCreatedWebSocket)
+        self.client.subscribe(to: sessionId, mode: .stdout) { _ in }
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        let frames = mockWebSocket.sentDataMessages().compactMap { TestFixtures.decodeV3Frame($0) }
+        let subscribeFrame = try #require(frames.first { $0.type == 10 && $0.sessionId == sessionId })
+        let flags = subscribeFrame.payload.withUnsafeBytes { bytes in
+            bytes.loadUnaligned(as: UInt32.self).littleEndian
+        }
+
+        #expect(flags == 0b101)
+    }
+
+    @Test("Interactive subscriptions decode header and resize events")
+    func interactiveSessionEvents() async throws {
+        let sessionId = "interactive-session-events"
+        var receivedEvents: [TerminalWebSocketEvent] = []
+
+        self.client.subscribe(to: sessionId, mode: .stdout) { event in
+            receivedEvents.append(event)
+        }
+        self.client.connect()
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        let mockWebSocket = try #require(mockFactory.lastCreatedWebSocket)
+        let headerPayload = try #require(
+            #"{"kind":"header","header":{"version":2,"width":132,"height":43}}"#.data(using: .utf8))
+        let resizePayload = try #require(
+            #"{"kind":"resize","dimensions":"100x30"}"#.data(using: .utf8))
+
+        mockWebSocket.simulateMessages([
+            .data(TestFixtures.wrappedV3Frame(sessionId: sessionId, type: 22, payload: headerPayload)),
+            .data(TestFixtures.wrappedV3Frame(sessionId: sessionId, type: 22, payload: resizePayload)),
+        ])
+        try await waitFor { receivedEvents.count == 2 }
+
+        guard case let .header(width, height) = receivedEvents[0] else {
+            Issue.record("Expected header event")
+            return
+        }
+        #expect(width == 132)
+        #expect(height == 43)
+
+        guard case let .resize(_, dimensions) = receivedEvents[1] else {
+            Issue.record("Expected resize event")
+            return
+        }
+        #expect(dimensions == "100x30")
     }
 
     @Test("Handles reconnection after disconnection", .timeLimit(.minutes(1)))
     func reconnection() async throws {
+        let sessionId = "reconnecting-session"
+        var receivedEvents: [TerminalWebSocketEvent] = []
+        self.client.subscribe(to: sessionId, mode: .stdout) { event in
+            receivedEvents.append(event)
+        }
+
         // Connect
         self.client.connect()
         try await Task.sleep(nanoseconds: 100_000_000) // 100ms
@@ -182,6 +250,26 @@ final class BufferWebSocketClientTests {
         // Assert
         let secondWebSocket = try #require(mockFactory.lastCreatedWebSocket)
         #expect(secondWebSocket !== firstWebSocket)
+
+        try await waitFor {
+            secondWebSocket.sentDataMessages()
+                .compactMap { TestFixtures.decodeV3Frame($0) }
+                .contains { $0.type == 10 && $0.sessionId == sessionId }
+        }
+        let subscribeFrame = try #require(
+            secondWebSocket.sentDataMessages()
+                .compactMap { TestFixtures.decodeV3Frame($0) }
+                .first { $0.type == 10 && $0.sessionId == sessionId })
+        let flags = subscribeFrame.payload.withUnsafeBytes { bytes in
+            bytes.loadUnaligned(as: UInt32.self).littleEndian
+        }
+        #expect(flags == 0b101)
+        #expect(receivedEvents.contains { event in
+            if case .replayStarted = event {
+                return true
+            }
+            return false
+        })
     }
 
     @Test("Sends ping messages periodically", .disabled("Ping timing is unpredictable in tests"))

--- a/ios/VibeTunnelTests/Views/GhosttyWebViewTests.swift
+++ b/ios/VibeTunnelTests/Views/GhosttyWebViewTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import VibeTunnel
+
+@Suite("GhosttyWebView Tests")
+struct GhosttyWebViewTests {
+    @Test("Prefers Ghostty resources in their source subdirectory")
+    func nestedResourcePreferred() {
+        let nestedURL = URL(fileURLWithPath: "/tmp/ghostty/ghostty-web.js")
+        let rootURL = URL(fileURLWithPath: "/tmp/ghostty-web.js")
+        var requestedSubdirectories: [String?] = []
+
+        let result = GhosttyResourceLocator.scriptURL { subdirectory in
+            requestedSubdirectories.append(subdirectory)
+            return subdirectory == "ghostty" ? nestedURL : rootURL
+        }
+
+        #expect(result == nestedURL)
+        #expect(requestedSubdirectories == ["ghostty"])
+    }
+
+    @Test("Falls back to flattened iOS bundle resources")
+    func rootResourceFallback() {
+        let rootURL = URL(fileURLWithPath: "/tmp/ghostty-web.js")
+        var requestedSubdirectories: [String?] = []
+
+        let result = GhosttyResourceLocator.scriptURL { subdirectory in
+            requestedSubdirectories.append(subdirectory)
+            return subdirectory == nil ? rootURL : nil
+        }
+
+        #expect(result == rootURL)
+        #expect(requestedSubdirectories == ["ghostty", nil])
+    }
+
+    @Test("Preserves output received before terminal readiness")
+    func buffersOutputUntilReady() {
+        var buffer = TerminalWriteBuffer()
+
+        #expect(buffer.receive("first") == nil)
+        #expect(buffer.receive("-second") == nil)
+        #expect(buffer.markReady() == "first-second")
+        #expect(buffer.receive("-third") == "-third")
+        #expect(buffer.markReady() == nil)
+    }
+
+    @Test("Drops stale pending output before reconnect replay")
+    func discardsPendingOutputForReplay() {
+        var buffer = TerminalWriteBuffer()
+
+        #expect(buffer.receive("stale") == nil)
+        buffer.discardPending()
+        #expect(buffer.receive("replayed") == nil)
+        #expect(buffer.markReady() == "replayed")
+    }
+}

--- a/ios/VibeTunnelTests/Views/TerminalViewModelTests.swift
+++ b/ios/VibeTunnelTests/Views/TerminalViewModelTests.swift
@@ -1,0 +1,80 @@
+import Testing
+@testable import VibeTunnel
+
+@MainActor
+private final class RecordingTerminalCoordinator: TerminalCoordinating {
+    private(set) var events: [String] = []
+
+    func feedData(_ data: String) {
+        self.events.append("output:\(data)")
+    }
+
+    func updateBuffer(from snapshot: BufferSnapshot) {
+        self.events.append("snapshot:\(snapshot.cols)x\(snapshot.rows)")
+    }
+
+    func resetForReplay() {
+        self.events.append("reset")
+    }
+
+    func scrollToBottom() {
+        _ = ()
+    }
+
+    func setMaxWidth(_ maxWidth: Int) {
+        _ = maxWidth
+    }
+
+    func getBufferContent() async -> String? {
+        nil
+    }
+}
+
+@Suite("TerminalViewModel Tests")
+@MainActor
+struct TerminalViewModelTests {
+    @Test("Flushes pre-coordinator terminal events in arrival order")
+    func flushesPendingTerminalEvents() {
+        let viewModel = TerminalViewModel(session: TestFixtures.validSession)
+        let snapshot = BufferSnapshot(
+            cols: 80,
+            rows: 24,
+            viewportY: 0,
+            cursorX: 0,
+            cursorY: 0,
+            cells: [])
+
+        viewModel.handleWebSocketEvent(.output(timestamp: 0, data: "first"))
+        viewModel.handleWebSocketEvent(.bufferUpdate(snapshot: snapshot))
+        viewModel.handleWebSocketEvent(.output(timestamp: 1, data: "second"))
+
+        let coordinator = RecordingTerminalCoordinator()
+        viewModel.terminalCoordinator = coordinator
+
+        #expect(coordinator.events == [
+            "output:first",
+            "snapshot:80x24",
+            "output:second",
+        ])
+
+        viewModel.handleWebSocketEvent(.output(timestamp: 2, data: "third"))
+        #expect(coordinator.events.last == "output:third")
+    }
+
+    @Test("Resets terminal before rendering reconnect replay")
+    func resetsBeforeReconnectReplay() {
+        let viewModel = TerminalViewModel(session: TestFixtures.validSession)
+        let coordinator = RecordingTerminalCoordinator()
+        viewModel.terminalCoordinator = coordinator
+
+        viewModel.handleWebSocketEvent(.output(timestamp: 0, data: "old"))
+        viewModel.handleWebSocketEvent(.replayStarted)
+        viewModel.handleWebSocketEvent(.output(timestamp: 1, data: "complete history"))
+
+        #expect(coordinator.events == [
+            "output:old",
+            "reset",
+            "output:complete history",
+        ])
+    }
+}


### PR DESCRIPTION
## Summary

- locate Ghostty resources in both the source subdirectory and Xcode's flattened bundle layout
- preserve terminal output received before the renderer is ready
- use stdout plus terminal events for interactive sessions while retaining snapshots for session previews
- reset and replay complete terminal history after reconnect without duplicate rendering
- read the live Ghostty buffer for Copy All and text export

## Regression coverage

- resource lookup in nested and flattened bundle layouts
- ordered pre-ready output buffering and stale-output discard before reconnect replay
- snapshot and interactive subscription flags
- interactive header and resize event decoding
- reconnect reset before complete-history replay
- ordered terminal events before coordinator attachment

## Verification

- focused iOS terminal and WebSocket tests passed
- full iOS test suite passed
- generic iOS Release device build passed
- exact final simulator build verified on iPhone 17 Pro and iPad Pro 11-inch (M4), both running iOS 26.0
- verified cold history rendering, input echo before Return, command output after Return, and live-buffer Copy All
- SwiftLint and SwiftFormat checks passed for changed Swift files

## CI scope

This is an iOS-only patch. Repository path filters select the iOS job and skip macOS CI. The iOS workflow has a 30-minute job timeout and a 15-minute test-step timeout.
