### PR TITLE
fix(web): correct CLI installation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug Fixes
 - Fix session creation "data couldn't be read" error on Mac app (#500)
+- Correct empty-session CLI setup instructions to point to Settings → General → Command Line Tool (via [@saqibameen](https://github.com/saqibameen)) (#582)
 - Import standard OpenSSH and PKCS#8 Ed25519 private keys with correct public-key derivation and strict integrity validation (via [@ye4241](https://github.com/ye4241)) (#638)
 - Persist JWT signing secrets across server restarts without weakening file permissions or concurrent startup safety (via [@matthias-scale](https://github.com/matthias-scale)) (#637)
 - Restore mobile terminal touch scrolling, responsive width fitting, pinch zoom, and scrollback retention during output and layout changes (via [@Nachx639](https://github.com/Nachx639)) (#645)
@@ -32,6 +33,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
+- Thanks [@saqibameen](https://github.com/saqibameen) for correcting the CLI setup path shown to new users.
 - Thanks [@ye4241](https://github.com/ye4241) for fixing browser SSH private-key import and public-key derivation.
 - Thanks [@matthias-scale](https://github.com/matthias-scale) for preserving authenticated browser sessions across server restarts.
 - Thanks [@Nachx639](https://github.com/Nachx639) for adding log rotation, improving mobile keyboard behavior, terminal scrolling, and tap targets, and fixing tmux detach behavior, dependency security, Terminal Settings width sync, and exited-session overlay layering.

--- a/web/src/client/components/session-list.test.ts
+++ b/web/src/client/components/session-list.test.ts
@@ -140,6 +140,10 @@ describe('SessionList', () => {
       const bodyText = element.textContent;
       // The actual empty state message is "No terminal sessions yet!"
       expect(bodyText).toContain('No terminal sessions yet!');
+      expect(bodyText).toContain(
+        "Settings → General → Command Line Tool, click on Install 'vt' Command"
+      );
+      expect(bodyText).not.toContain('Settings → Advanced → Install CLI Tools');
     });
 
     it('should show loading state', async () => {

--- a/web/src/client/components/session-list.ts
+++ b/web/src/client/components/session-list.ts
@@ -818,7 +818,7 @@ export class SessionList extends LitElement {
                             </div>
                             <div class="text-sm text-text-muted space-y-1">
                               <div>→ Click the VibeTunnel menu bar icon</div>
-                              <div>→ Go to Settings → Advanced → Install CLI Tools</div>
+                              <div>→ Go to Settings → General → Command Line Tool, click on Install 'vt' Command</div>
                             </div>
                           </div>
 


### PR DESCRIPTION
## Summary
- Replace the stale `Settings → Advanced → Install CLI Tools` empty-state guidance.
- Point new users to `Settings → General → Command Line Tool`, then `Install 'vt' Command`.
- Add regression coverage and the maintainer changelog/contributor entries.

## Verification
- Confirmed the current macOS settings labels in `SettingsTab`, `GeneralSettingsView`, and `CLIInstallationSection`.
- Existing-profile Chrome proof at `http://127.0.0.1:4022/`: rendered empty state showed the complete updated path.
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec vitest run --mode=client --maxWorkers=4` (34 files; 653 passed, 14 skipped)
- Structured autoreview: no actionable findings.
