### PR TITLE
fix: isMainModule() check fails for npm/bun global installs

### DIFF
--- a/web/src/cli.ts
+++ b/web/src/cli.ts
@@ -332,10 +332,9 @@ async function parseCommandAndExecute(): Promise<void> {
  */
 function isMainModule(): boolean {
   return (
-    !module.parent &&
-    (require.main === module ||
-      require.main === undefined ||
-      (require.main?.filename?.endsWith('/vibetunnel-cli') ?? false))
+    require.main === module ||
+    require.main === undefined ||
+    (require.main?.filename?.endsWith('/vibetunnel') ?? false)
   );
 }
 


### PR DESCRIPTION
## Summary
Fixes the `isMainModule()` function to correctly detect when VibeTunnel is run via npm/bun global install.

## Problem
When installed globally via `npm install -g vibetunnel` or `bun install -g vibetunnel`, running `vibetunnel` exits immediately with no output.

**Root cause**: The `isMainModule()` check in `web/src/cli.ts` fails because:
1. `module.parent` is set to `bin/vibetunnel` (not null/undefined)
2. `require.main.filename` ends with `/vibetunnel`, not `/vibetunnel-cli`

## Solution
- Remove the `!module.parent &&` check (unreliable when required from bin wrapper)
- Change filename check from `/vibetunnel-cli` to `/vibetunnel` to match the actual bin entry point

## How to Reproduce
1. Install globally: `npm install -g vibetunnel` or `bun install -g vibetunnel`
2. Run: `vibetunnel`
3. **Before fix**: Exits immediately with no output
4. **After fix**: Server starts normally

## Related
- Fixes #572
- Simpler solution to #579 (fixes the check directly instead of spawning a child process)

## Test Plan
- [x] Tested with bun global install on Arch Linux (Node v25.2.1)
- [x] Test with npm global install
- [x] Test with local development (`pnpm run dev`)