### PR TITLE
ci: migrate GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       mac: ${{ steps.filter.outputs.mac }}
       ios: ${{ steps.filter.outputs.ios }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: dorny/paths-filter@v3
       id: filter
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       ios: ${{ steps.filter.outputs.ios }}
     steps:
     - uses: actions/checkout@v5
-    - uses: dorny/paths-filter@v3
+    - uses: dorny/paths-filter@v4
       id: filter
       with:
         filters: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -32,7 +32,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0  # Full history for better context
 
@@ -50,7 +50,7 @@ jobs:
       - name: Check if already reviewed
         id: check-review
         if: steps.check-permissions.outputs.is_fork != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -166,7 +166,7 @@ jobs:
       - name: Clean up old Claude comments
         if: steps.check-permissions.outputs.is_fork != 'true' && steps.check-review.outputs.skip != 'true'
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
@@ -61,4 +61,3 @@ jobs:
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-

--- a/.github/workflows/cleanup-claude-comments.yml
+++ b/.github/workflows/cleanup-claude-comments.yml
@@ -25,14 +25,14 @@ jobs:
     
     steps:
       - name: Checkout scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           sparse-checkout: |
             .github/scripts/cleanup-claude-comments.js
       
       - name: Cleanup Claude comments on specific PR
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -48,7 +48,7 @@ jobs:
       
       - name: Cleanup Claude comments on closed PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -57,7 +57,7 @@ jobs:
       
       - name: Cleanup Claude comments on all recent PRs
         if: github.event_name == 'schedule'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -19,7 +19,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
@@ -34,7 +34,7 @@ jobs:
     # Node.js/pnpm not needed for iOS builds
     
     - name: Cache Homebrew packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       continue-on-error: true
       with:
         path: |
@@ -46,7 +46,7 @@ jobs:
           ${{ runner.os }}-brew-
     
     - name: Cache Swift packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       continue-on-error: true
       with:
         path: |
@@ -410,7 +410,7 @@ jobs:
     # ARTIFACT UPLOADS
     # Skip build artifact upload for PR builds to save time
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
       with:
         name: ios-build-artifacts
@@ -419,7 +419,7 @@ jobs:
     
     - name: Upload coverage artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ios-coverage
         path: |
@@ -487,10 +487,10 @@ jobs:
         rm -rf * || true
         
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Download coverage artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: ios-coverage
         path: ios-coverage-artifacts

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -40,7 +40,7 @@ jobs:
         node-version: '24'
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v6
+      uses: pnpm/action-setup@v5
       with:
         version: 10
         run_install: false

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -19,7 +19,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
@@ -32,7 +32,7 @@ jobs:
         swift --version
     
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '24'
 
@@ -48,7 +48,7 @@ jobs:
         version: 0.15.2
     
     - name: Cache Homebrew packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       continue-on-error: true
       with:
         path: |
@@ -60,7 +60,7 @@ jobs:
           ${{ runner.os }}-brew-
     
     - name: Cache Swift packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       continue-on-error: true
       with:
         path: |
@@ -332,7 +332,7 @@ jobs:
     # Skip build artifact upload for PR builds to save time
     - name: Upload build artifacts
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: mac-build-artifacts
         path: |
@@ -342,7 +342,7 @@ jobs:
     
     - name: Upload coverage artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: mac-coverage
         path: |
@@ -420,10 +420,10 @@ jobs:
         rm -rf * || true
         
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Download coverage artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: mac-coverage
         path: mac-coverage-artifacts

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -8,6 +8,9 @@ permissions:
   pull-requests: write
   issues: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 # Single job for efficient execution on shared runner
 jobs:
   build-lint-test:
@@ -37,7 +40,7 @@ jobs:
         node-version: '24'
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: 10
         run_install: false

--- a/.github/workflows/monitor-ci.yml
+++ b/.github/workflows/monitor-ci.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
     - name: Check CI Status
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       id: check-status
       with:
         script: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,6 +11,9 @@ permissions:
   pull-requests: write
   issues: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release-build-test:
     name: Build and Test Release Configuration
@@ -39,7 +42,7 @@ jobs:
         node-version: '24'
     
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: 10
         dest: ~/pnpm-${{ github.run_id }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,7 +42,7 @@ jobs:
         node-version: '24'
     
     - name: Setup pnpm
-      uses: pnpm/action-setup@v6
+      uses: pnpm/action-setup@v5
       with:
         version: 10
         dest: ~/pnpm-${{ github.run_id }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
         rm -rf * || true
         
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     
     - name: Verify Xcode
       run: |
@@ -34,7 +34,7 @@ jobs:
         swift --version
     
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '24'
     
@@ -50,7 +50,7 @@ jobs:
         version: 0.15.2
     
     - name: Cache Homebrew packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       continue-on-error: true
       with:
         path: |
@@ -100,7 +100,7 @@ jobs:
         echo "xcbeautify: $(xcbeautify --version || echo 'not found')"
     
     - name: Cache pnpm store
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       continue-on-error: true
       with:
         path: ~/.local/share/pnpm/store
@@ -231,7 +231,7 @@ jobs:
     # NOTIFY ON FAILURE
     - name: Notify on Failure
       if: failure()
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const issue = await github.rest.issues.create({

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '24'
 
@@ -331,7 +331,7 @@ jobs:
     # Upload artifacts
     - name: Upload coverage artifacts
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: node-coverage
         path: |

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -28,7 +28,7 @@ jobs:
         node-version: '24'
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v6
+      uses: pnpm/action-setup@v5
       with:
         version: 10
         run_install: false

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -8,6 +8,9 @@ permissions:
   pull-requests: write
   issues: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   node-ci:
     name: Node.js CI - Lint, Build, Test, Type Check
@@ -25,7 +28,7 @@ jobs:
         node-version: '24'
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: 10
         run_install: false

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -27,7 +27,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -35,7 +35,7 @@ jobs:
           version: 10.12.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'pnpm'
@@ -140,10 +140,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
 

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
         with:
           version: 10.12.1
 

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -16,6 +16,9 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 defaults:
   run:
     working-directory: web
@@ -30,7 +33,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.12.1
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,10 +21,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           
@@ -39,7 +39,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
           
       - name: Setup pnpm cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -111,7 +111,7 @@ jobs:
           # VIBETUNNEL_SEA: "true"
           
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: playwright-report
@@ -119,7 +119,7 @@ jobs:
           retention-days: 7
           
       - name: Upload test videos
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: playwright-videos

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: '22'
           
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
         with:
           version: 10
           

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -13,6 +13,9 @@ permissions:
   pull-requests: write
   issues: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     name: Playwright E2E Tests
@@ -29,7 +32,7 @@ jobs:
           node-version: '22'
           
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         node-version: '24'
     
     - name: Setup pnpm
-      uses: pnpm/action-setup@v6
+      uses: pnpm/action-setup@v5
       with:
         version: 10
         run_install: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         node-version: '24'
     
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: 10
         run_install: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Select Xcode 16.3
       uses: maxim-lobanov/setup-xcode@v1
@@ -33,7 +33,7 @@ jobs:
         xcode-version: '16.4'
     
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '24'
     
@@ -49,7 +49,7 @@ jobs:
         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
     
     - name: Setup pnpm cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       continue-on-error: true
       with:
         path: ${{ env.STORE_PATH }}
@@ -104,7 +104,7 @@ jobs:
         ls -la build/*.dmg build/*.zip
     
     - name: Upload Release Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: mac-release
         path: |
@@ -131,7 +131,7 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Select Xcode 16.3
       uses: maxim-lobanov/setup-xcode@v1
@@ -157,7 +157,7 @@ jobs:
           -derivedDataPath build/DerivedData
     
     - name: Upload iOS Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: ios-release
         path: ios/build/DerivedData/Build/Products/Release-iphoneos/

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -14,10 +14,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Download workflow run data
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       id: workflow-data
       with:
         script: |
@@ -55,7 +55,7 @@ jobs:
           
     - name: Format Slack message
       id: slack-message
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         script: |
           const data = ${{ steps.workflow-data.outputs.result }};

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -34,7 +34,7 @@ jobs:
           version: 10.12.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: 'pnpm'
@@ -71,7 +71,7 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -79,7 +79,7 @@ jobs:
           version: 10.12.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: 'pnpm'
@@ -106,7 +106,7 @@ jobs:
         run: pnpm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: web-build
           path: |
@@ -119,7 +119,7 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -127,7 +127,7 @@ jobs:
           version: 10.12.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: 'pnpm'
@@ -156,7 +156,7 @@ jobs:
         run: pnpm run test:server:coverage
 
       - name: Upload client coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: client-coverage-report
@@ -164,7 +164,7 @@ jobs:
           retention-days: 7
 
       - name: Upload server coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         if: always()
         with:
           name: server-coverage-report
@@ -176,7 +176,7 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Linux bootstrap (Node + Zig + deps)
         run: scripts/linux-bootstrap.sh

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
         with:
           version: 10.12.1
 
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
         with:
           version: 10.12.1
 
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@v5
         with:
           version: 10.12.1
 

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -16,6 +16,9 @@ permissions:
   pull-requests: write
   issues: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 defaults:
   run:
     working-directory: web
@@ -29,7 +32,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.12.1
 
@@ -74,7 +77,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.12.1
 
@@ -122,7 +125,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.12.1
 


### PR DESCRIPTION
## Summary

Migrate repository workflows to Node 24-capable GitHub Actions before GitHub begins forcing JavaScript actions onto Node 24 on June 16, 2026.

## Changes

- `actions/checkout`: v4 to v5
- `actions/setup-node`: v4 to v5
- `actions/cache`: v4 to v5
- `actions/upload-artifact`: v4 to v6
- `actions/download-artifact`: v4 to v7
- `actions/github-script`: v7 to v8
- `dorny/paths-filter`: v3 to v4
- `pnpm/action-setup`: v4 to v5
- Force Node 24 for workflows that still invoke an action whose latest release declares the older runtime.

The minimum Node 24-capable majors are used where newer majors introduce unrelated behavior changes. In particular, the stable pnpm action major is retained because the next major broke frozen-lockfile installs in the first hosted run.

## Proof

Exact head: `a9b187e83ccdc4e68f3307b0d7afb8cad8fcad19`

- [CI](https://github.com/amantus-ai/vibetunnel/actions/runs/27375995220): green
  - macOS build/lint/test: 6m17s
  - iOS build/lint/test: 9m47s
  - Node lint/build/test/typecheck: 3m11s
- [Web CI](https://github.com/amantus-ai/vibetunnel/actions/runs/27375995242): green
- [Playwright](https://github.com/amantus-ai/vibetunnel/actions/runs/27375995164): green, 21 passed and 3 skipped; one existing retry-marked navigation test retried
- [NPM package test](https://github.com/amantus-ai/vibetunnel/actions/runs/27375995211): green
- [Automated review](https://github.com/amantus-ai/vibetunnel/actions/runs/27375995182): green
- `actionlint` on every changed workflow: passed
- Final autoreview: no actionable findings

macOS cannot block for hours: the job has a 40-minute overall timeout, dependency resolution has a 10-minute timeout, and tests have a 20-minute timeout. iOS has a 30-minute overall timeout and a 15-minute test timeout.

No changelog entry: workflow-only maintenance with no user-facing behavior change.
