### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/monitor-ci.yml
+++ b/.github/workflows/monitor-ci.yml
@@ -70,7 +70,7 @@ jobs:
     
     - name: Find Comment
       if: steps.check-status.outputs.should_comment == 'true'
-      uses: peter-evans/find-comment@v3
+      uses: peter-evans/find-comment@v4
       id: fc
       with:
         issue-number: ${{ steps.check-status.outputs.pr_number }}
@@ -79,7 +79,7 @@ jobs:
     
     - name: Create or Update Comment
       if: steps.check-status.outputs.should_comment == 'true'
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@v5
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ steps.check-status.outputs.pr_number }}


### PR DESCRIPTION
## Summary

Upgrade the monitor workflow's comment actions to their current Node 24 releases.

## Changes

| Action | Old | New | Release |
|--------|-----|-----|---------|
| `peter-evans/find-comment` | `v3` | `v4` | [v4.0.0](https://github.com/peter-evans/find-comment/releases/tag/v4.0.0) |
| `peter-evans/create-or-update-comment` | `v4` | `v5` | [v5.0.0](https://github.com/peter-evans/create-or-update-comment/releases/tag/v5.0.0) |

The workflow keeps its existing major-version tag policy. The published `v4` and `v5` tags currently resolve to `b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad` and `e8674b075228eee787fea43ef493e45ece1004c9`.

## Validation

- Confirmed both releases use Node 24 and require runner `2.327.1` or newer.
- Confirmed the Blacksmith runner used by this workflow reports `2.334.0`.
- Compared the action manifests: all inputs used by `monitor-ci.yml` remain supported.
- `actionlint -ignore 'label "blacksmith-8vcpu-ubuntu-2404-arm" is unknown' .github/workflows/monitor-ci.yml`
- Ruby YAML parse
- `git diff --check`
- Maintainer autoreview: no actionable findings
