### PR TITLE
Fix iOS slash key scroll bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Prevent rapid iOS slash-command redraws from queuing redundant smooth terminal scrolling (via [@Ilakiancs](https://github.com/Ilakiancs)) (#590)
 - Keep mobile session header controls visible and comfortably tappable at narrow phone widths (via [@nikolasdehor](https://github.com/nikolasdehor)) (#605)
 - Jitter iOS reconnection backoff within its configured cap to spread retries after outages (via [@bianbiandashen](https://github.com/bianbiandashen)) (#593)
 - Keep `vt` git metadata alive for sessions in repositories without an upstream branch, preventing forwarder crashes (via [@ndraiman](https://github.com/ndraiman)) (#566)
@@ -48,7 +49,7 @@
 - Thanks [@sourman](https://github.com/sourman) for documenting the Zig build prerequisite.
 - Thanks [@yv-was-taken](https://github.com/yv-was-taken) for fixing global npm and Bun installs.
 - Thanks [@ChimeraFlutter](https://github.com/ChimeraFlutter) for fixing desktop terminal clipping.
-- Thanks [@Ilakiancs](https://github.com/Ilakiancs) for identifying lost argument boundaries in shell fallback execution.
+- Thanks [@Ilakiancs](https://github.com/Ilakiancs) for identifying lost shell fallback argument boundaries and redundant iOS terminal scrolling during slash-command redraws.
 - Thanks [@nikolasdehor](https://github.com/nikolasdehor) for fixing narrow mobile session headers, `vt --title-mode`, and shell fallback argument forwarding, preserving terminal link taps, and adding remote health-check regression coverage.
 - Thanks [@rothnic](https://github.com/rothnic) for defaulting to universal macOS binaries.
 

--- a/web/src/client/components/session-view/direct-keyboard-manager.test.ts
+++ b/web/src/client/components/session-view/direct-keyboard-manager.test.ts
@@ -116,6 +116,8 @@ describe('DirectKeyboardManager', () => {
     [' h', 'h'],
     ['h ', 'h'],
     ['hello world ', 'hello world'],
+    [' /', '/'],
+    [' /help', '/help'],
   ])('removes the placeholder space from %j', (inputValue, expected) => {
     const hiddenInput = getManagerState().hiddenInput;
     expect(hiddenInput).toBeTruthy();

--- a/web/src/client/components/terminal.test.ts
+++ b/web/src/client/components/terminal.test.ts
@@ -513,10 +513,12 @@ describe('Terminal', () => {
       // Set up some content
       if (mockTerminal) {
         mockTerminal.buffer.active.length = 100;
+        mockTerminal.scrollToBottom.mockClear();
       }
 
       element.scrollToBottom();
 
+      expect(mockTerminal?.scrollToBottom).toHaveBeenCalledOnce();
       // Check that we're at bottom (viewportY should be at max)
       const position = element.getScrollPosition();
       expect(position).toBeGreaterThanOrEqual(0);
@@ -619,6 +621,20 @@ describe('Terminal', () => {
 
       expect(element.getScrollPosition()).toBe(20);
       expect(element.isFollowingCursor()).toBe(false);
+    });
+
+    it('should not enqueue smooth scrolling for a burst while following output', () => {
+      if (!mockTerminal) return;
+
+      mockTerminal.scrollToBottom.mockClear();
+
+      for (let i = 0; i < 200; i++) {
+        element.write(`slash-redraw-${i}\r\n`);
+      }
+
+      expect(mockTerminal.write).toHaveBeenCalledTimes(200);
+      expect(mockTerminal.scrollToBottom).not.toHaveBeenCalled();
+      expect(element.isFollowingCursor()).toBe(true);
     });
 
     it('should translate vertical touch drags into terminal scroll lines', () => {

--- a/web/src/client/components/terminal.ts
+++ b/web/src/client/components/terminal.ts
@@ -172,7 +172,6 @@ export class Terminal extends LitElement {
     }
 
     const shouldPreserveScroll = !this.followCursorEnabled && this.preservedScrollPosition === null;
-    const shouldFollowCursor = followCursor && !shouldPreserveScroll;
     if (shouldPreserveScroll) {
       this.preservedScrollPosition = this.getScrollPosition();
     }
@@ -190,8 +189,8 @@ export class Terminal extends LitElement {
       return;
     }
 
+    // ghostty-web already follows output; another smooth scroll per write queues badly on iOS.
     this.terminal.write(data);
-    if (shouldFollowCursor) this.terminal.scrollToBottom();
   }
 
   public clear() {


### PR DESCRIPTION
## Problem

On iOS, slash-command redraws could queue smooth terminal scrolling for long after the command had completed.

Closes #570.

## Root Cause

`ghostty-web` already follows output synchronously during `write()`. VibeTunnel also called `scrollToBottom()` after every write, adding a second 120ms smooth-scroll animation for each rapid redraw. Large bursts could therefore build an animation queue.

## Fix

- Remove the redundant per-write smooth scroll while preserving explicit scroll-to-bottom behavior.
- Keep scrollback restoration unchanged when the user is reading history.
- Cover rapid 200-write bursts and direct `/` and `/help` keyboard placeholder handling.
- Credit the original contributor in the commit and changelog.

## Verification

- Focused terminal and keyboard tests: 63 passed.
- Full client coverage suite: 657 passed, 14 skipped.
- Full server suite: 571 passed, 75 skipped; one unrelated timing-sensitive shell test passed separately.
- Biome lint/format and TypeScript checks passed.
- Exact iOS 26.2 Safari simulator proof at the reported iPhone 16 Pro class viewport.
- Desktop Chrome sanity proof at 1357x830.
- Structured autoreview reported no actionable findings.

Thanks @Ilakiancs for the original investigation and patch.
