### PR TITLE
fix(ios): add jitter to reconnection backoff to prevent thundering herd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Jitter iOS reconnection backoff within its configured cap to spread retries after outages (via [@bianbiandashen](https://github.com/bianbiandashen)) (#593)
 - Keep `vt` git metadata alive for sessions in repositories without an upstream branch, preventing forwarder crashes (via [@ndraiman](https://github.com/ndraiman)) (#566)
 - Keep HQ remotes registered through transient health-check failures and remove them only after three consecutive failures (via [@bianbiandashen](https://github.com/bianbiandashen) and [@nikolasdehor](https://github.com/nikolasdehor)) (#594)
 - Fix session creation "data couldn't be read" error on Mac app (#500)
@@ -38,7 +39,7 @@
 
 ### 👥 Contributors
 - Thanks [@ndraiman](https://github.com/ndraiman) for fixing native forwarder crashes while collecting git metadata.
-- Thanks [@bianbiandashen](https://github.com/bianbiandashen) for preventing transient remote health-check failures from prematurely unregistering servers.
+- Thanks [@bianbiandashen](https://github.com/bianbiandashen) for preventing transient remote health-check failures from prematurely unregistering servers and spreading iOS reconnect attempts after outages.
 - Thanks [@saqibameen](https://github.com/saqibameen) for correcting the CLI setup path shown to new users.
 - Thanks [@ye4241](https://github.com/ye4241) for fixing browser SSH private-key import and public-key derivation.
 - Thanks [@matthias-scale](https://github.com/matthias-scale) for preserving authenticated browser sessions across server restarts.

--- a/ios/VibeTunnel/Services/BufferWebSocketClient.swift
+++ b/ios/VibeTunnel/Services/BufferWebSocketClient.swift
@@ -831,7 +831,9 @@ class BufferWebSocketClient: NSObject {
     private func scheduleReconnect() {
         guard self.reconnectTask == nil else { return }
 
-        let delay = min(pow(2.0, Double(reconnectAttempts)), 30.0)
+        let delay = ReconnectionManager.calculateBackoff(
+            attempt: self.reconnectAttempts + 1,
+            maxDelay: 30.0)
         self.reconnectAttempts += 1
 
         self.logger.info("Reconnecting in \(delay)s (attempt \(self.reconnectAttempts))")

--- a/ios/VibeTunnel/Services/ReconnectionManager.swift
+++ b/ios/VibeTunnel/Services/ReconnectionManager.swift
@@ -88,8 +88,7 @@ class ReconnectionManager {
                 self.currentRetry += 1
 
                 if self.currentRetry < self.maxRetries {
-                    // Calculate exponential backoff
-                    let backoffSeconds = min(pow(2.0, Double(currentRetry - 1)), 60.0)
+                    let backoffSeconds = Self.calculateBackoff(attempt: self.currentRetry)
                     self.nextRetryTime = Date().addingTimeInterval(backoffSeconds)
 
                     try? await Task.sleep(for: .seconds(backoffSeconds))
@@ -110,15 +109,22 @@ class ReconnectionManager {
 // MARK: - Exponential Backoff Calculator
 
 extension ReconnectionManager {
-    /// Calculate the next retry delay using exponential backoff
+    /// Calculate the next retry delay using bounded exponential backoff jitter.
     static func calculateBackoff(
         attempt: Int,
         baseDelay: TimeInterval = 1.0,
-        maxDelay: TimeInterval = 60.0)
+        maxDelay: TimeInterval = 60.0,
+        jitterFactor: Double = 0.3,
+        randomUnit: Double = Double.random(in: 0...1))
         -> TimeInterval
     {
         let exponentialDelay = baseDelay * pow(2.0, Double(attempt - 1))
-        return min(exponentialDelay, maxDelay)
+        let cappedDelay = min(exponentialDelay, maxDelay)
+        let boundedJitterFactor = min(max(jitterFactor, 0), 1)
+        let boundedRandomUnit = min(max(randomUnit, 0), 1)
+        let minimumDelay = cappedDelay * (1 - boundedJitterFactor)
+
+        return minimumDelay + (cappedDelay - minimumDelay) * boundedRandomUnit
     }
 }
 

--- a/ios/VibeTunnelTests/WebSocketReconnectionTests.swift
+++ b/ios/VibeTunnelTests/WebSocketReconnectionTests.swift
@@ -1,32 +1,28 @@
 import Foundation
 import Testing
+@testable import VibeTunnel
 
 @Suite("WebSocket Reconnection Tests", .tags(.critical, .websocket))
 struct WebSocketReconnectionTests {
     // MARK: - Reconnection Strategy Tests
 
-    @Test("Exponential backoff calculation", .disabled("Timing out in CI"))
+    @Test("Exponential backoff uses bounded jitter")
+    @MainActor
     func exponentialBackoff() {
-        // Test exponential backoff with jitter
-        let baseDelay = 1.0
-        let maxDelay = 60.0
+        let firstMinimum = ReconnectionManager.calculateBackoff(attempt: 1, randomUnit: 0)
+        let firstMaximum = ReconnectionManager.calculateBackoff(attempt: 1, randomUnit: 1)
+        let cappedMinimum = ReconnectionManager.calculateBackoff(attempt: 7, randomUnit: 0)
+        let cappedMaximum = ReconnectionManager.calculateBackoff(attempt: 7, randomUnit: 1)
+        let noJitter = ReconnectionManager.calculateBackoff(
+            attempt: 4,
+            jitterFactor: 0,
+            randomUnit: 0)
 
-        // Calculate delays for multiple attempts
-        var delays: [Double] = []
-        for attempt in 0..<10 {
-            let delay = min(baseDelay * pow(2.0, Double(attempt)), maxDelay)
-            let jitteredDelay = delay * (0.5 + Double.random(in: 0...0.5))
-            delays.append(jitteredDelay)
-
-            // Verify bounds
-            #expect(jitteredDelay >= baseDelay * 0.5)
-            #expect(jitteredDelay <= maxDelay)
-        }
-
-        // Verify progression (later delays should generally be larger)
-        for i in 1..<5 {
-            #expect(delays[i] >= delays[0])
-        }
+        #expect(abs(firstMinimum - 0.7) < 0.000_001)
+        #expect(firstMaximum == 1)
+        #expect(abs(cappedMinimum - 42) < 0.000_001)
+        #expect(cappedMaximum == 60)
+        #expect(noJitter == 8)
     }
 
     @Test("Maximum retry attempts")

--- a/ios/VibeTunnelTests/WebSocketReconnectionTests.swift
+++ b/ios/VibeTunnelTests/WebSocketReconnectionTests.swift
@@ -231,7 +231,7 @@ struct WebSocketReconnectionTests {
     // MARK: - State Persistence
 
     @Test("Connection state persistence")
-    func statePersistence() {
+    func statePersistence() throws {
         struct ConnectionState: Codable {
             let url: String
             let sessionId: String?
@@ -254,7 +254,7 @@ struct WebSocketReconnectionTests {
         // Decode
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        let decoded = try? decoder.decode(ConnectionState.self, from: data!)
+        let decoded = try? decoder.decode(ConnectionState.self, from: try #require(data))
 
         #expect(decoded?.url == state.url)
         #expect(decoded?.sessionId == state.sessionId)


### PR DESCRIPTION
## Summary

Add bounded jitter to the iOS exponential reconnection backoff so clients recovering from the same outage do not retry in lockstep.

## Implementation

- share `ReconnectionManager.calculateBackoff` between API and buffer WebSocket reconnection paths
- randomize each delay within 70-100% of the exponential delay
- keep the configured 30-second and 60-second caps as true maximums
- preserve existing retry policies: `ReconnectionManager` remains finite; `BufferWebSocketClient` continues retrying until explicitly disconnected or reconnected
- inject the random unit value for deterministic regression coverage

The original branch added positive jitter after applying the cap, which could exceed the configured maximum. It also stopped buffer WebSocket retries permanently after ten failures. The rewritten branch removes both regressions while retaining the contributor's load-spreading intent.

## Verification

- focused SwiftFormat and SwiftLint: passed
- full local iOS simulator suite: 318 tests, 304 passed, 14 skipped, 0 failed
- hosted iOS build, lint, and test job: passed in 7m51s
- `git diff --check`: passed
- autoreview: no actionable findings

Hosted proof: https://github.com/amantus-ai/vibetunnel/actions/runs/27374127108/job/80893873581

## Regression Coverage

`WebSocketReconnectionTests.exponentialBackoff` deterministically verifies:

- the 30% lower jitter bound
- the unjittered upper bound
- the configured maximum cap
- zero-jitter behavior
