### PR TITLE
fix(server): add tolerance for transient health check failures in RemoteRegistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Keep HQ remotes registered through transient health-check failures and remove them only after three consecutive failures (via [@bianbiandashen](https://github.com/bianbiandashen) and [@nikolasdehor](https://github.com/nikolasdehor)) (#594)
 - Fix session creation "data couldn't be read" error on Mac app (#500)
 - Correct empty-session CLI setup instructions to point to Settings → General → Command Line Tool (via [@saqibameen](https://github.com/saqibameen)) (#582)
 - Import standard OpenSSH and PKCS#8 Ed25519 private keys with correct public-key derivation and strict integrity validation (via [@ye4241](https://github.com/ye4241)) (#638)
@@ -35,6 +36,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
+- Thanks [@bianbiandashen](https://github.com/bianbiandashen) for preventing transient remote health-check failures from prematurely unregistering servers.
 - Thanks [@saqibameen](https://github.com/saqibameen) for correcting the CLI setup path shown to new users.
 - Thanks [@ye4241](https://github.com/ye4241) for fixing browser SSH private-key import and public-key derivation.
 - Thanks [@matthias-scale](https://github.com/matthias-scale) for preserving authenticated browser sessions across server restarts.
@@ -43,7 +45,7 @@
 - Thanks [@yv-was-taken](https://github.com/yv-was-taken) for fixing global npm and Bun installs.
 - Thanks [@ChimeraFlutter](https://github.com/ChimeraFlutter) for fixing desktop terminal clipping.
 - Thanks [@Ilakiancs](https://github.com/Ilakiancs) for identifying lost argument boundaries in shell fallback execution.
-- Thanks [@nikolasdehor](https://github.com/nikolasdehor) for fixing `vt --title-mode` and shell fallback argument forwarding and preserving terminal link taps.
+- Thanks [@nikolasdehor](https://github.com/nikolasdehor) for fixing `vt --title-mode` and shell fallback argument forwarding, preserving terminal link taps, and adding remote health-check regression coverage.
 - Thanks [@rothnic](https://github.com/rothnic) for defaulting to universal macOS binaries.
 
 ## [1.0.0-beta.15] - 2025-08-02

--- a/web/src/server/services/remote-registry.test.ts
+++ b/web/src/server/services/remote-registry.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RemoteRegistry } from './remote-registry.js';
+
+vi.mock('../server.js', () => ({
+  isShuttingDown: () => false,
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  createLogger: () => ({
+    log: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+describe('RemoteRegistry health checks', () => {
+  let registry: RemoteRegistry;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    registry = new RemoteRegistry();
+  });
+
+  afterEach(() => {
+    registry.destroy();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  function registerRemote(id: string) {
+    return registry.register({
+      id,
+      name: `remote-${id}`,
+      url: `http://remote-${id}.example`,
+      token: 'token',
+    });
+  }
+
+  function deferredResponse() {
+    let reject!: (reason?: unknown) => void;
+    const promise = new Promise<Response>((_resolve, rejectPromise) => {
+      reject = rejectPromise;
+    });
+    return { promise, reject };
+  }
+
+  it('keeps a remote registered after a transient failure', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('temporary network failure'));
+
+    const remote = registerRemote('one-failure');
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(registry.getRemote(remote.id)).toBe(remote);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('unregisters a remote after three consecutive failures', async () => {
+    fetchMock.mockRejectedValue(new Error('network unavailable'));
+
+    registerRemote('three-failures');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(registry.getRemote('three-failures')).toBeDefined();
+
+    await vi.advanceTimersByTimeAsync(15000);
+    expect(registry.getRemote('three-failures')).toBeDefined();
+
+    await vi.advanceTimersByTimeAsync(15000);
+    expect(registry.getRemote('three-failures')).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('resets the failure threshold after a successful health check', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('temporary network failure'))
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockRejectedValue(new Error('network unavailable'));
+
+    registerRemote('recovered');
+    await vi.advanceTimersByTimeAsync(0);
+
+    await vi.advanceTimersByTimeAsync(15000);
+    await vi.advanceTimersByTimeAsync(30000);
+    expect(registry.getRemote('recovered')).toBeDefined();
+
+    await vi.advanceTimersByTimeAsync(15000);
+    expect(registry.getRemote('recovered')).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it('ignores stale checks after a remote id is re-registered', async () => {
+    const firstStaleCheck = deferredResponse();
+    const secondStaleCheck = deferredResponse();
+    fetchMock
+      .mockReturnValueOnce(firstStaleCheck.promise)
+      .mockReturnValueOnce(secondStaleCheck.promise)
+      .mockResolvedValueOnce({ ok: true } as Response)
+      .mockRejectedValueOnce(new Error('replacement failure'));
+
+    const original = registerRemote('reused');
+    await vi.advanceTimersByTimeAsync(15000);
+
+    expect(registry.unregister(original.id)).toBe(true);
+    const replacement = registerRemote('reused');
+    await vi.advanceTimersByTimeAsync(0);
+
+    firstStaleCheck.reject(new Error('stale failure one'));
+    secondStaleCheck.reject(new Error('stale failure two'));
+    await vi.advanceTimersByTimeAsync(0);
+
+    await vi.advanceTimersByTimeAsync(15000);
+    expect(registry.getRemote(replacement.id)).toBe(replacement);
+  });
+});

--- a/web/src/server/services/remote-registry.ts
+++ b/web/src/server/services/remote-registry.ts
@@ -12,19 +12,16 @@ export interface RemoteServer {
   registeredAt: Date;
   lastHeartbeat: Date;
   sessionIds: Set<string>; // Track which sessions belong to this remote
-  consecutiveFailures: number; // Track consecutive health check failures
 }
 
 export class RemoteRegistry {
   private remotes: Map<string, RemoteServer> = new Map();
   private remotesByName: Map<string, RemoteServer> = new Map();
   private sessionToRemote: Map<string, string> = new Map(); // sessionId -> remoteId
+  private healthCheckFailures: WeakMap<RemoteServer, number> = new WeakMap();
   private healthCheckInterval: NodeJS.Timeout | null = null;
   private readonly HEALTH_CHECK_INTERVAL = 15000; // Check every 15 seconds
   private readonly HEALTH_CHECK_TIMEOUT = 5000; // 5 second timeout per check
-  // Number of consecutive failures before removing a remote.
-  // This provides tolerance for temporary network issues or server restarts.
-  // With 15s intervals, 3 failures = 45s of downtime tolerance.
   private readonly MAX_CONSECUTIVE_FAILURES = 3;
 
   constructor() {
@@ -49,7 +46,6 @@ export class RemoteRegistry {
       registeredAt: now,
       lastHeartbeat: now,
       sessionIds: new Set<string>(),
-      consecutiveFailures: 0,
     };
 
     this.remotes.set(remote.id, registeredRemote);
@@ -72,6 +68,7 @@ export class RemoteRegistry {
         this.sessionToRemote.delete(sessionId);
       }
 
+      this.healthCheckFailures.delete(remote);
       this.remotesByName.delete(remote.name);
       return this.remotes.delete(remoteId);
     }
@@ -160,9 +157,6 @@ export class RemoteRegistry {
     }
 
     try {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), this.HEALTH_CHECK_TIMEOUT);
-
       // Use the token provided by the remote for authentication
       const headers: Record<string, string> = {
         Authorization: `Bearer ${remote.token}`,
@@ -171,19 +165,21 @@ export class RemoteRegistry {
       // Only check health endpoint - all remotes MUST have it
       const response = await fetch(`${remote.url}/api/health`, {
         headers,
-        signal: controller.signal,
+        signal: AbortSignal.timeout(this.HEALTH_CHECK_TIMEOUT),
       });
 
-      clearTimeout(timeoutId);
-
       if (response.ok) {
-        // Reset failure count on successful health check
-        if (remote.consecutiveFailures > 0) {
+        if (this.remotes.get(remote.id) !== remote) {
+          return;
+        }
+
+        const failedChecks = this.healthCheckFailures.get(remote) ?? 0;
+        if (failedChecks > 0) {
           logger.debug(
-            `remote ${remote.name} recovered after ${remote.consecutiveFailures} failed checks`
+            `remote ${remote.name} recovered after ${failedChecks} failed health checks`
           );
         }
-        remote.consecutiveFailures = 0;
+        this.healthCheckFailures.delete(remote);
         remote.lastHeartbeat = new Date();
         logger.debug(`health check passed for ${remote.name}`);
       } else {
@@ -195,21 +191,23 @@ export class RemoteRegistry {
         return;
       }
 
-      remote.consecutiveFailures++;
-      const failureCount = remote.consecutiveFailures;
+      if (this.remotes.get(remote.id) !== remote) {
+        return;
+      }
+
+      const failureCount = (this.healthCheckFailures.get(remote) ?? 0) + 1;
       const maxFailures = this.MAX_CONSECUTIVE_FAILURES;
+      this.healthCheckFailures.set(remote, failureCount);
 
       if (failureCount >= maxFailures) {
-        // Only remove after consecutive failures to tolerate temporary issues
         logger.warn(
           `remote ${remote.name} (${remote.id}) failed ${failureCount}/${maxFailures} health checks, removing`,
           error
         );
         this.unregister(remote.id);
       } else {
-        // Log warning but keep the remote registered
         logger.warn(
-          `remote ${remote.name} failed health check (${failureCount}/${maxFailures}):`,
+          `remote ${remote.name} (${remote.id}) failed health check ${failureCount}/${maxFailures}`,
           error instanceof Error ? error.message : String(error)
         );
       }

--- a/web/src/server/services/remote-registry.ts
+++ b/web/src/server/services/remote-registry.ts
@@ -12,6 +12,7 @@ export interface RemoteServer {
   registeredAt: Date;
   lastHeartbeat: Date;
   sessionIds: Set<string>; // Track which sessions belong to this remote
+  consecutiveFailures: number; // Track consecutive health check failures
 }
 
 export class RemoteRegistry {
@@ -21,6 +22,10 @@ export class RemoteRegistry {
   private healthCheckInterval: NodeJS.Timeout | null = null;
   private readonly HEALTH_CHECK_INTERVAL = 15000; // Check every 15 seconds
   private readonly HEALTH_CHECK_TIMEOUT = 5000; // 5 second timeout per check
+  // Number of consecutive failures before removing a remote.
+  // This provides tolerance for temporary network issues or server restarts.
+  // With 15s intervals, 3 failures = 45s of downtime tolerance.
+  private readonly MAX_CONSECUTIVE_FAILURES = 3;
 
   constructor() {
     this.startHealthChecker();
@@ -44,6 +49,7 @@ export class RemoteRegistry {
       registeredAt: now,
       lastHeartbeat: now,
       sessionIds: new Set<string>(),
+      consecutiveFailures: 0,
     };
 
     this.remotes.set(remote.id, registeredRemote);
@@ -171,6 +177,13 @@ export class RemoteRegistry {
       clearTimeout(timeoutId);
 
       if (response.ok) {
+        // Reset failure count on successful health check
+        if (remote.consecutiveFailures > 0) {
+          logger.debug(
+            `remote ${remote.name} recovered after ${remote.consecutiveFailures} failed checks`
+          );
+        }
+        remote.consecutiveFailures = 0;
         remote.lastHeartbeat = new Date();
         logger.debug(`health check passed for ${remote.name}`);
       } else {
@@ -178,10 +191,27 @@ export class RemoteRegistry {
       }
     } catch (error) {
       // During shutdown, don't log errors or unregister remotes
-      if (!isShuttingDown()) {
-        logger.warn(`remote failed health check: ${remote.name} (${remote.id})`, error);
-        // Remove the remote if it fails health check
+      if (isShuttingDown()) {
+        return;
+      }
+
+      remote.consecutiveFailures++;
+      const failureCount = remote.consecutiveFailures;
+      const maxFailures = this.MAX_CONSECUTIVE_FAILURES;
+
+      if (failureCount >= maxFailures) {
+        // Only remove after consecutive failures to tolerate temporary issues
+        logger.warn(
+          `remote ${remote.name} (${remote.id}) failed ${failureCount}/${maxFailures} health checks, removing`,
+          error
+        );
         this.unregister(remote.id);
+      } else {
+        // Log warning but keep the remote registered
+        logger.warn(
+          `remote ${remote.name} failed health check (${failureCount}/${maxFailures}):`,
+          error instanceof Error ? error.message : String(error)
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary

- Keep HQ remotes registered through transient health-check failures.
- Unregister only after three consecutive failed checks; reset the threshold after recovery.
- Keep failure state private in a `WeakMap` instead of changing the public `RemoteServer` shape.
- Ignore stale in-flight checks after unregistering or re-registering the same remote ID.
- Use `AbortSignal.timeout()` so completed requests do not leave timeout timers behind.

## Regression coverage

- One transient failure keeps the remote registered.
- Three consecutive failures unregister it.
- A successful check resets the failure threshold.
- Stale checks cannot affect a replacement remote with the same ID.

This incorporates and extends the unit coverage proposed by @nikolasdehor in #604.

## Validation

- `pnpm exec vitest run --mode=server --maxWorkers=1`: 53 files passed, 572 tests passed, 75 skipped.
- `pnpm exec vitest run --mode=server src/server/services/remote-registry.test.ts`: 4 tests passed.
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`
- Branch autoreview: no actionable findings.

## Local environment notes

- The aggregate `pnpm run check` reaches the known type-aware lint incompatibility between local TypeScript 6 and the repository's `moduleResolution=node10`; standard typecheck passes.
- The native forwarder build reaches the known local Zig 0.16 incompatibility; CI uses the repository-pinned Zig 0.15.2 toolchain.
