### PR TITLE
feat(ios): support Tailscale Serve discovery and identity auth

### DIFF
--- a/ios/VibeTunnel/Services/AuthenticationService.swift
+++ b/ios/VibeTunnel/Services/AuthenticationService.swift
@@ -50,6 +50,8 @@ final class AuthenticationService: ObservableObject {
         let noAuth: Bool
         let enableSSHKeys: Bool
         let disallowUserPassword: Bool
+        let tailscaleAuth: Bool?
+        let authenticatedUser: String?
     }
 
     /// Authentication response from the server.
@@ -169,6 +171,27 @@ final class AuthenticationService: ObservableObject {
         } else {
             throw APIError.authenticationFailed(authResponse.error ?? "Authentication failed")
         }
+    }
+
+    /// Authenticate via Tailscale identity (Tailscale Serve auto-auth).
+    /// Tailscale Serve injects identity headers on every request, so no JWT token is needed.
+    /// We just mark the session as authenticated using the user info from /api/auth/config.
+    func authenticateWithTailscale(user: String) async throws {
+        // Verify Tailscale auth actually works by calling a protected endpoint
+        let url = self.serverConfig.apiURL(path: "/api/sessions")
+        let (_, response) = try await URLSession.shared.data(from: url)
+
+        guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw AuthenticationError.serverError("Tailscale identity auth failed - server rejected request")
+        }
+
+        // Tailscale Serve injects identity headers on every request,
+        // so no JWT token is needed - every request is auto-authenticated.
+        self.currentUser = user
+        self.authMethod = .noAuth
+        self.isAuthenticated = true
+
+        self.logger.info("Authenticated via Tailscale identity: \(user)")
     }
 
     /// Verify if current token is still valid

--- a/ios/VibeTunnel/Services/TailscaleDiscoveryService.swift
+++ b/ios/VibeTunnel/Services/TailscaleDiscoveryService.swift
@@ -297,6 +297,32 @@ final class TailscaleDiscoveryService {
             await resolveHostname(hostname)
         }
 
+        // First, try direct HTTP probe on the standard port
+        if let server = await probeHTTP(
+            hostname: hostname,
+            resolvedIP: resolvedIP,
+            port: port
+        ) {
+            return server
+        }
+
+        // If direct probe failed, try HTTPS on port 443 via the hostname.
+        // This handles the case where Tailscale Serve is active — the server
+        // binds to localhost only, and Tailscale Serve proxies HTTPS 443 → localhost:4020.
+        logger.info("HTTP probe failed for \(hostname):\(port), trying HTTPS via Tailscale Serve on port 443")
+        if let server = await probeHTTPS(hostname: hostname, resolvedIP: resolvedIP) {
+            return server
+        }
+
+        return nil
+    }
+
+    /// Probes a server via plain HTTP on the given port
+    private func probeHTTP(
+        hostname: String,
+        resolvedIP: String?,
+        port: Int
+    ) async -> TailscaleServer? {
         // Construct URL for health check - VibeTunnel uses /api/health endpoint
         let urlString: String = if let resolvedIP {
             "http://\(resolvedIP):\(port)/api/health"
@@ -308,7 +334,44 @@ final class TailscaleDiscoveryService {
             return nil
         }
 
-        // Perform health check
+        return await performHealthProbe(
+            url: url,
+            hostname: hostname,
+            resolvedIP: resolvedIP,
+            port: port,
+            isHTTPS: false
+        )
+    }
+
+    /// Probes a server via HTTPS on port 443 (Tailscale Serve)
+    private func probeHTTPS(
+        hostname: String,
+        resolvedIP: String?
+    ) async -> TailscaleServer? {
+        // Tailscale Serve uses the MagicDNS hostname with HTTPS on port 443
+        let httpsUrlString = "https://\(hostname)/api/health"
+        guard let url = URL(string: httpsUrlString) else {
+            logger.debug("Invalid HTTPS URL for \(hostname)")
+            return nil
+        }
+
+        return await performHealthProbe(
+            url: url,
+            hostname: hostname,
+            resolvedIP: resolvedIP,
+            port: 443,
+            isHTTPS: true
+        )
+    }
+
+    /// Performs the actual health probe request and parses the response
+    private func performHealthProbe(
+        url: URL,
+        hostname: String,
+        resolvedIP: String?,
+        port: Int,
+        isHTTPS: Bool
+    ) async -> TailscaleServer? {
         do {
             let configuration = URLSessionConfiguration.default
             configuration.timeoutIntervalForRequest = Constants.probeTimeout
@@ -345,6 +408,12 @@ final class TailscaleDiscoveryService {
                         }
                     }
 
+                    // If we reached the server via HTTPS, use that as the httpsUrl
+                    if isHTTPS && httpsUrl == nil {
+                        httpsUrl = "https://\(hostname)"
+                        logger.info("Server reachable via Tailscale Serve HTTPS: \(httpsUrl!)")
+                    }
+
                     // Extract device name from hostname
                     let deviceName = hostname
                         .replacingOccurrences(of: ".ts.net", with: "")
@@ -356,7 +425,7 @@ final class TailscaleDiscoveryService {
                     return TailscaleServer(
                         hostname: hostname,
                         ip: resolvedIP,
-                        port: port,
+                        port: isHTTPS ? Constants.defaultPort : port,
                         deviceName: deviceName,
                         isReachable: true,
                         lastSeen: Date(),
@@ -366,7 +435,7 @@ final class TailscaleDiscoveryService {
                 }
             }
         } catch {
-            logger.debug("Failed to probe \(hostname): \(error.localizedDescription)")
+            logger.debug("Failed to probe \(hostname) (\(isHTTPS ? "HTTPS" : "HTTP")): \(error.localizedDescription)")
         }
 
         return nil

--- a/ios/VibeTunnel/ViewModels/ServerListViewModel.swift
+++ b/ios/VibeTunnel/ViewModels/ServerListViewModel.swift
@@ -178,7 +178,7 @@ class ServerListViewModel: ServerListViewModelProtocol {
 
             // Check if server requires authentication
             let authConfig = try await authService.getAuthConfig()
-            connectionLogger.debug("🔗 Auth config: noAuth=\(authConfig.noAuth)")
+            connectionLogger.debug("🔗 Auth config: noAuth=\(authConfig.noAuth), tailscaleAuth=\(authConfig.tailscaleAuth ?? false)")
 
             if authConfig.noAuth {
                 // No auth required, test connection directly
@@ -191,9 +191,15 @@ class ServerListViewModel: ServerListViewModelProtocol {
                 return
             }
 
-            // Authentication required - attempt auto-login
-            // connectionLogger.info("🔗 Authentication required, attempting auto-login")
-            try await authService.attemptAutoLogin(profile: profile)
+            // Check for Tailscale identity authentication (via Tailscale Serve headers)
+            if authConfig.tailscaleAuth == true, let user = authConfig.authenticatedUser {
+                connectionLogger.info("🔗 Tailscale identity auth available for user: \(user)")
+                try await authService.authenticateWithTailscale(user: user)
+                connectionLogger.info("🔗 ✅ Tailscale auth successful")
+            } else {
+                // Standard authentication - attempt auto-login with stored credentials
+                try await authService.attemptAutoLogin(profile: profile)
+            }
             // connectionLogger.info("🔗 ✅ Auto-login successful")
 
             // Auto-login successful, test connection


### PR DESCRIPTION
## Summary

- **HTTPS fallback probe**: When HTTP probe on port 4020 fails (server bound to localhost with Tailscale Serve), falls back to probing HTTPS on port 443 via the Tailscale hostname
- **Tailscale identity auth**: Detects `tailscaleAuth` in server auth config and authenticates via Tailscale Serve identity headers (no JWT token needed)
- **Connection flow routing**: Checks for Tailscale auth before falling through to password-based auto-login

## Problem

When Tailscale Serve is enabled, the VibeTunnel server binds to `127.0.0.1:4020` (localhost only) for security. Tailscale Serve then proxies `https://<hostname>.ts.net:443` → `localhost:4020`. The iOS discovery service only probed `http://<IP>:4020`, which is unreachable from remote devices.

## Solution

Three-layer fix:
1. **Discovery** (`TailscaleDiscoveryService`): Refactored `probeServer()` into `probeHTTP()`/`probeHTTPS()`/`performHealthProbe()`. After HTTP fails, tries HTTPS on port 443.
2. **Auth** (`AuthenticationService`): Added `tailscaleAuth`/`authenticatedUser` fields to `AuthConfig`. Added `authenticateWithTailscale(user:)` that verifies auth works without a JWT token.
3. **Connection** (`ServerListViewModel`): Routes to Tailscale identity auth when `authConfig.tailscaleAuth == true`.

## Test plan

- [x] Tested with Tailscale Serve enabled on macOS — iOS discovers and connects via HTTPS
- [x] Verified Tailscale identity authentication works (no credentials needed)
- [x] Build succeeds on iOS simulator (iPhone 17 Pro)
- [ ] Verify standard HTTP discovery still works when Tailscale Serve is disabled
- [ ] Verify fallback paths work when HTTPS fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)