### PR TITLE
feat(ios): Tailscale Serve discovery with identity auth and connection fixes

### DIFF
--- a/ios/VibeTunnel/Models/FileEntry.swift
+++ b/ios/VibeTunnel/Models/FileEntry.swift
@@ -24,20 +24,13 @@ struct FileEntry: Codable, Identifiable {
     let modTime: Date
     let isGitTracked: Bool?
     let gitStatus: GitFileStatus?
+    let isSymlink: Bool?
 
-    var id: String { self.path }
+    var id: String {
+        self.path
+    }
 
     /// Creates a new FileEntry with the given parameters.
-    ///
-    /// - Parameters:
-    ///   - name: The file name
-    ///   - path: The full path to the file
-    ///   - isDir: Whether this entry represents a directory
-    ///   - size: The file size in bytes
-    ///   - mode: The file permissions mode string
-    ///   - modTime: The modification time
-    ///   - isGitTracked: Whether the file is in a git repository
-    ///   - gitStatus: The git status of the file
     init(
         name: String,
         path: String,
@@ -46,7 +39,8 @@ struct FileEntry: Codable, Identifiable {
         mode: String,
         modTime: Date,
         isGitTracked: Bool? = nil,
-        gitStatus: GitFileStatus? = nil)
+        gitStatus: GitFileStatus? = nil,
+        isSymlink: Bool? = nil)
     {
         self.name = name
         self.path = path
@@ -56,37 +50,45 @@ struct FileEntry: Codable, Identifiable {
         self.modTime = modTime
         self.isGitTracked = isGitTracked
         self.gitStatus = gitStatus
+        self.isSymlink = isSymlink
     }
 
     enum CodingKeys: String, CodingKey {
         case name
         case path
-        case isDir = "is_dir"
+        case type
         case size
-        case mode
-        case modTime = "mod_time"
+        case modified
+        case permissions
         case isGitTracked
         case gitStatus
+        case isSymlink
     }
 
     /// Creates a FileEntry from a decoder.
     ///
-    /// - Parameter decoder: The decoder to read data from.
-    ///
-    /// This custom initializer handles the special parsing of the modification
-    /// time from ISO8601 format, supporting both fractional and non-fractional seconds.
+    /// Handles mapping from server's JSON format:
+    /// - `type: "file"|"directory"` → `isDir: Bool`
+    /// - `modified: "ISO8601 string"` → `modTime: Date`
+    /// - `permissions: "644"` → `mode: String`
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.name = try container.decode(String.self, forKey: .name)
         self.path = try container.decode(String.self, forKey: .path)
-        self.isDir = try container.decode(Bool.self, forKey: .isDir)
         self.size = try container.decode(Int64.self, forKey: .size)
-        self.mode = try container.decode(String.self, forKey: .mode)
         self.isGitTracked = try container.decodeIfPresent(Bool.self, forKey: .isGitTracked)
         self.gitStatus = try container.decodeIfPresent(GitFileStatus.self, forKey: .gitStatus)
+        self.isSymlink = try container.decodeIfPresent(Bool.self, forKey: .isSymlink)
 
-        // Decode mod_time string as Date
-        let modTimeString = try container.decode(String.self, forKey: .modTime)
+        // Server sends "type": "file" | "directory" — convert to Bool
+        let typeString = try container.decode(String.self, forKey: .type)
+        self.isDir = typeString == "directory"
+
+        // Server sends "permissions": "644" — map to mode
+        self.mode = try container.decodeIfPresent(String.self, forKey: .permissions) ?? "000"
+
+        // Server sends "modified": ISO8601 string — parse to Date
+        let modTimeString = try container.decode(String.self, forKey: .modified)
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         if let date = formatter.date(from: modTimeString) {
@@ -98,11 +100,24 @@ struct FileEntry: Codable, Identifiable {
                 self.modTime = date
             } else {
                 throw DecodingError.dataCorruptedError(
-                    forKey: .modTime,
+                    forKey: .modified,
                     in: container,
                     debugDescription: "Invalid date format")
             }
         }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.name, forKey: .name)
+        try container.encode(self.path, forKey: .path)
+        try container.encode(self.isDir ? "directory" : "file", forKey: .type)
+        try container.encode(self.size, forKey: .size)
+        try container.encode(ISO8601DateFormatter().string(from: self.modTime), forKey: .modified)
+        try container.encodeIfPresent(self.mode, forKey: .permissions)
+        try container.encodeIfPresent(self.isGitTracked, forKey: .isGitTracked)
+        try container.encodeIfPresent(self.gitStatus, forKey: .gitStatus)
+        try container.encodeIfPresent(self.isSymlink, forKey: .isSymlink)
     }
 
     /// Returns a human-readable file size string.

--- a/ios/VibeTunnel/Models/ServerConfig.swift
+++ b/ios/VibeTunnel/Models/ServerConfig.swift
@@ -31,8 +31,8 @@ struct ServerConfig: Codable, Equatable {
         preferTailscale: Bool = false,
         httpsAvailable: Bool = false,
         isPublic: Bool = false,
-        preferSSL: Bool = true
-    ) {
+        preferSSL: Bool = true)
+    {
         self.host = host
         self.port = port
         self.name = name
@@ -54,10 +54,10 @@ struct ServerConfig: Codable, Equatable {
     /// a file URL as fallback to ensure non-nil return.
     var baseURL: URL {
         // Handle IPv6 addresses by wrapping in brackets
-        var formattedHost = host
+        var formattedHost = self.host
 
         // First, strip any existing brackets to normalize
-        if formattedHost.hasPrefix("[") && formattedHost.hasSuffix("]") {
+        if formattedHost.hasPrefix("["), formattedHost.hasSuffix("]") {
             formattedHost = String(formattedHost.dropFirst().dropLast())
         }
 
@@ -77,7 +77,7 @@ struct ServerConfig: Codable, Equatable {
 
         // This should always succeed with valid host and port
         // Fallback ensures we always have a valid URL
-        return URL(string: "http://\(formattedHost):\(port)") ?? URL(fileURLWithPath: "/")
+        return URL(string: "http://\(formattedHost):\(self.port)") ?? URL(fileURLWithPath: "/")
     }
 
     /// User-friendly display name for the server.
@@ -85,7 +85,7 @@ struct ServerConfig: Codable, Equatable {
     /// Returns the custom name if set, otherwise formats
     /// the host and port as "host:port".
     var displayName: String {
-        name ?? "\(host):\(port)"
+        self.name ?? "\(self.host):\(self.port)"
     }
 
     /// Creates a URL for an API endpoint path.
@@ -93,14 +93,14 @@ struct ServerConfig: Codable, Equatable {
     /// - Parameter path: The API path (e.g., "/api/sessions")
     /// - Returns: A complete URL for the API endpoint
     func apiURL(path: String) -> URL {
-        connectionURL().appendingPathComponent(path)
+        self.connectionURL().appendingPathComponent(path)
     }
 
     /// Unique identifier for this server configuration.
     ///
     /// Used for keychain storage and identifying server instances.
     var id: String {
-        "\(host):\(port)"
+        "\(self.host):\(self.port)"
     }
 
     /// Connection type available for this server
@@ -112,9 +112,9 @@ struct ServerConfig: Codable, Equatable {
 
     /// Determines available connection types based on configuration
     var availableConnectionTypes: ConnectionType {
-        if isTailscaleEnabled && tailscaleHostname != nil {
+        if self.isTailscaleEnabled, self.tailscaleHostname != nil {
             .both
-        } else if tailscaleHostname != nil {
+        } else if self.tailscaleHostname != nil {
             .tailscale
         } else {
             .local
@@ -125,11 +125,11 @@ struct ServerConfig: Codable, Equatable {
     /// - Parameter useTailscale: Force use of Tailscale connection if available
     /// - Returns: The best URL for connecting to the server
     func connectionURL(useTailscale: Bool? = nil) -> URL {
-        let shouldUseTailscale = useTailscale ?? preferTailscale
+        let shouldUseTailscale = useTailscale ?? self.preferTailscale
 
-        if shouldUseTailscale && isTailscaleEnabled {
+        if shouldUseTailscale, self.isTailscaleEnabled {
             // For Tailscale connections with HTTPS available
-            if httpsAvailable && preferSSL && tailscaleHostname != nil {
+            if self.httpsAvailable, self.preferSSL, tailscaleHostname != nil {
                 // Use HTTPS via Tailscale hostname (port 443 is implicit)
                 if let tailscaleHostname,
                    let url = URL(string: "https://\(tailscaleHostname)")
@@ -152,26 +152,26 @@ struct ServerConfig: Codable, Equatable {
         }
 
         // Fall back to regular connection
-        return baseURL
+        return self.baseURL
     }
 
     /// Display name with connection type indicator
     var displayNameWithConnectionType: String {
-        let baseName = displayName
+        let baseName = self.displayName
         var indicators: [String] = []
 
         // Add connection security indicator
-        if httpsAvailable && preferSSL {
+        if self.httpsAvailable, self.preferSSL {
             indicators.append("🔒") // HTTPS/SSL connection
         }
 
         // Add public/private indicator
-        if isPublic {
+        if self.isPublic {
             indicators.append("🌐") // Public (Funnel)
         }
 
         // Add Tailscale indicator if using Tailscale but not HTTPS
-        if isTailscaleEnabled && !(httpsAvailable && preferSSL) {
+        if self.isTailscaleEnabled, !(self.httpsAvailable && self.preferSSL) {
             indicators.append("🔗") // Tailscale network
         }
 

--- a/ios/VibeTunnel/Models/ServerProfile.swift
+++ b/ios/VibeTunnel/Models/ServerProfile.swift
@@ -44,8 +44,8 @@ struct ServerProfile: Identifiable, Codable, Equatable {
         preferTailscale: Bool = false,
         httpsAvailable: Bool = false,
         isPublic: Bool = false,
-        preferSSL: Bool = true
-    ) {
+        preferSSL: Bool = true)
+    {
         self.id = id
         self.name = name
 
@@ -56,17 +56,17 @@ struct ServerProfile: Identifiable, Codable, Equatable {
             if host == nil || port == nil {
                 if let urlComponents = URLComponents(string: url) {
                     self.host = host ?? urlComponents.host
-                    self.port = port ?? (urlComponents.port ?? 4_020)
+                    self.port = port ?? (urlComponents.port ?? 4020)
                 } else {
                     self.host = host
-                    self.port = port ?? 4_020
+                    self.port = port ?? 4020
                 }
             } else {
                 self.host = host
                 self.port = port
             }
         } else if let host {
-            let port = port ?? 4_020
+            let port = port ?? 4020
             self.host = host
             self.port = port
             self.url = "http://\(host):\(port)"
@@ -74,7 +74,7 @@ struct ServerProfile: Identifiable, Codable, Equatable {
             // Fallback to localhost
             self.url = "http://localhost:4020"
             self.host = "localhost"
-            self.port = 4_020
+            self.port = 4020
         }
 
         self.requiresAuth = requiresAuth
@@ -103,31 +103,28 @@ struct ServerProfile: Identifiable, Codable, Equatable {
         // Clean up the host - remove brackets from IPv6 addresses
         // URLComponents includes brackets in the host for IPv6, but we want clean IPs
         var cleanHost = host
-        if cleanHost.hasPrefix("[") && cleanHost.hasSuffix("]") {
+        if cleanHost.hasPrefix("["), cleanHost.hasSuffix("]") {
             cleanHost = String(cleanHost.dropFirst().dropLast())
         }
 
-        // Determine default port based on scheme
-        let defaultPort: Int = if let scheme = urlComponents.scheme?.lowercased() {
-            scheme == "https" ? 443 : 80
-        } else {
-            80
-        }
-
-        let port = urlComponents.port ?? defaultPort
+        // Use the stored port (set during profile creation/discovery) which reflects
+        // the actual VibeTunnel server port (typically 4020). Fall back to explicit URL
+        // port, then 4020. Do NOT derive from URL scheme — an HTTPS URL like
+        // https://hostname.ts.net uses Tailscale Serve on 443 but the underlying
+        // server port is still 4020.
+        let port = self.port ?? urlComponents.port ?? 4020
 
         return ServerConfig(
             host: cleanHost,
             port: port,
-            name: name,
-            tailscaleHostname: tailscaleHostname,
-            tailscaleIP: tailscaleIP,
-            isTailscaleEnabled: isTailscaleEnabled,
-            preferTailscale: preferTailscale,
-            httpsAvailable: httpsAvailable,
-            isPublic: isPublic,
-            preferSSL: preferSSL
-        )
+            name: self.name,
+            tailscaleHostname: self.tailscaleHostname,
+            tailscaleIP: self.tailscaleIP,
+            isTailscaleEnabled: self.isTailscaleEnabled,
+            preferTailscale: self.preferTailscale,
+            httpsAvailable: self.httpsAvailable,
+            isPublic: self.isPublic,
+            preferSSL: self.preferSSL)
     }
 }
 
@@ -139,45 +136,59 @@ extension ServerProfile {
     /// Load all saved profiles from UserDefaults
     static func loadAll(from userDefaults: UserDefaults = .standard) -> [ServerProfile] {
         guard let data = userDefaults.data(forKey: storageKey),
-              let profiles = try? JSONDecoder().decode([ServerProfile].self, from: data)
+              var profiles = try? JSONDecoder().decode([ServerProfile].self, from: data)
         else {
             return []
         }
+
+        // Migration: fix Tailscale profiles that have port 443 or 80 from old URL-scheme
+        // derivation bug. The actual VibeTunnel server port is always 4020.
+        var needsSave = false
+        for i in profiles.indices where profiles[i].isTailscaleEnabled {
+            if profiles[i].port == 443 || profiles[i].port == 80 || profiles[i].port == nil {
+                profiles[i].port = 4020
+                needsSave = true
+            }
+        }
+        if needsSave {
+            self.saveAll(profiles, to: userDefaults)
+        }
+
         return profiles
     }
 
     /// Save profiles to UserDefaults
     static func saveAll(_ profiles: [ServerProfile], to userDefaults: UserDefaults = .standard) {
         if let data = try? JSONEncoder().encode(profiles) {
-            userDefaults.set(data, forKey: storageKey)
+            userDefaults.set(data, forKey: self.storageKey)
         }
     }
 
     /// Add or update a profile
     static func save(_ profile: ServerProfile, to userDefaults: UserDefaults = .standard) {
-        var profiles = loadAll(from: userDefaults)
+        var profiles = self.loadAll(from: userDefaults)
         if let index = profiles.firstIndex(where: { $0.id == profile.id }) {
             profiles[index] = profile
         } else {
             profiles.append(profile)
         }
-        saveAll(profiles, to: userDefaults)
+        self.saveAll(profiles, to: userDefaults)
     }
 
     /// Delete a profile
     static func delete(_ profile: ServerProfile, from userDefaults: UserDefaults = .standard) {
-        var profiles = loadAll(from: userDefaults)
+        var profiles = self.loadAll(from: userDefaults)
         profiles.removeAll { $0.id == profile.id }
-        saveAll(profiles, to: userDefaults)
+        self.saveAll(profiles, to: userDefaults)
     }
 
     /// Update last connected time
     static func updateLastConnected(for profileId: UUID, in userDefaults: UserDefaults = .standard) {
-        var profiles = loadAll(from: userDefaults)
+        var profiles = self.loadAll(from: userDefaults)
         if let index = profiles.firstIndex(where: { $0.id == profileId }) {
             profiles[index].lastConnected = Date()
             profiles[index].updatedAt = Date()
-            saveAll(profiles, to: userDefaults)
+            self.saveAll(profiles, to: userDefaults)
         }
     }
 }

--- a/ios/VibeTunnel/Models/TerminalSnapshot.swift
+++ b/ios/VibeTunnel/Models/TerminalSnapshot.swift
@@ -76,7 +76,6 @@ extension TerminalSnapshot {
         let pattern = "\\x1B\\[[0-9;]*[mGKHf]"
         let regex = try? NSRegularExpression(pattern: pattern, options: [])
         let range = NSRange(location: 0, length: output.utf16.count)
-        let cleaned = regex?.stringByReplacingMatches(in: output, options: [], range: range, withTemplate: "") ?? output
-        return cleaned
+        return regex?.stringByReplacingMatches(in: output, options: [], range: range, withTemplate: "") ?? output
     }
 }

--- a/ios/VibeTunnel/Services/APIClient.swift
+++ b/ios/VibeTunnel/Services/APIClient.swift
@@ -121,7 +121,7 @@ class APIClient: APIClientProtocol {
 
     /// Updates the base URL for API requests (used for Tailscale connections)
     func updateBaseURL(_ url: URL) {
-        overrideBaseURL = url
+        self.overrideBaseURL = url
     }
 
     // MARK: - Session Management

--- a/ios/VibeTunnel/Services/AuthenticationService.swift
+++ b/ios/VibeTunnel/Services/AuthenticationService.swift
@@ -42,6 +42,7 @@ final class AuthenticationService: ObservableObject {
         case password
         case sshKey = "ssh-key"
         case noAuth = "no-auth"
+        case tailscale
     }
 
     /// Server authentication configuration.
@@ -50,6 +51,8 @@ final class AuthenticationService: ObservableObject {
         let noAuth: Bool
         let enableSSHKeys: Bool
         let disallowUserPassword: Bool
+        let tailscaleAuth: Bool?
+        let authenticatedUser: String?
     }
 
     /// Authentication response from the server.
@@ -168,6 +171,51 @@ final class AuthenticationService: ObservableObject {
             self.logger.info("Successfully authenticated user: \(username)")
         } else {
             throw APIError.authenticationFailed(authResponse.error ?? "Authentication failed")
+        }
+    }
+
+    /// Authenticate via Tailscale identity (Tailscale Serve auto-auth).
+    /// Tailscale Serve injects identity headers on every proxied request, so HTTP API calls
+    /// are automatically authenticated. However, WebSocket connections need a JWT token
+    /// (passed as a query parameter) since header injection may not work for upgrades.
+    /// This method verifies Tailscale auth works, then requests a JWT token for WebSocket use.
+    func authenticateWithTailscale(user: String) async throws {
+        // Verify Tailscale auth actually works by calling a protected endpoint
+        let verifyURL = self.serverConfig.apiURL(path: "/api/sessions")
+        let (_, verifyResponse) = try await URLSession.shared.data(from: verifyURL)
+
+        guard let httpResponse = verifyResponse as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            throw AuthenticationError.serverError("Tailscale identity auth failed - server rejected request")
+        }
+
+        self.currentUser = user
+        self.authMethod = .tailscale
+        self.isAuthenticated = true
+
+        self.logger.info("Authenticated via Tailscale identity: \(user)")
+
+        // Request a JWT token for WebSocket authentication.
+        // The server's /api/auth/tailscale-token endpoint issues JWTs to Tailscale-authed users.
+        // Older servers may not have this endpoint (404) — WebSocket will rely on Tailscale headers.
+        do {
+            let tokenURL = self.serverConfig.apiURL(path: "/api/auth/tailscale-token")
+            var tokenRequest = URLRequest(url: tokenURL)
+            tokenRequest.httpMethod = "POST"
+            tokenRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+            let (tokenData, tokenResponse) = try await URLSession.shared.data(for: tokenRequest)
+
+            if let tokenHTTP = tokenResponse as? HTTPURLResponse, tokenHTTP.statusCode == 200 {
+                let authResponse = try JSONDecoder().decode(AuthResponse.self, from: tokenData)
+                if authResponse.success, let token = authResponse.token {
+                    self.authToken = token
+                    self.logger.info("Obtained JWT token for WebSocket auth")
+                }
+            } else {
+                self.logger.info("Server does not support tailscale-token endpoint, WebSocket will use header auth")
+            }
+        } catch {
+            self.logger.warning("Failed to obtain JWT token for WebSocket: \(error.localizedDescription)")
         }
     }
 

--- a/ios/VibeTunnel/Services/BonjourDiscoveryService.swift
+++ b/ios/VibeTunnel/Services/BonjourDiscoveryService.swift
@@ -36,8 +36,8 @@ struct DiscoveredServer: Identifiable, Equatable {
         port: Int,
         type: String = "_vibetunnel._tcp",
         domain: String = "local",
-        metadata: [String: String]
-    ) {
+        metadata: [String: String])
+    {
         self.id = UUID()
         self.name = name
         self.host = host

--- a/ios/VibeTunnel/Services/BufferWebSocketClient.swift
+++ b/ios/VibeTunnel/Services/BufferWebSocketClient.swift
@@ -686,7 +686,8 @@ class BufferWebSocketClient: NSObject {
     }
 
     private func sendV3Subscribe(sessionId: String) async throws {
-        let flags: UInt32 = V3SubscribeFlags.snapshots.rawValue | V3SubscribeFlags.events.rawValue
+        let flags: UInt32 = V3SubscribeFlags.stdout.rawValue | V3SubscribeFlags.snapshots.rawValue | V3SubscribeFlags
+            .events.rawValue
         var payload = Data(count: 12)
         payload.withUnsafeMutableBytes { bytes in
             bytes.storeBytes(of: flags.littleEndian, toByteOffset: 0, as: UInt32.self)

--- a/ios/VibeTunnel/Services/ConnectionManager.swift
+++ b/ios/VibeTunnel/Services/ConnectionManager.swift
@@ -14,7 +14,7 @@ final class ConnectionManager {
     // MARK: - Constants
 
     private enum Constants {
-        static let connectionRestorationWindow: TimeInterval = 3_600 // 1 hour
+        static let connectionRestorationWindow: TimeInterval = 3600 // 1 hour
         static let savedServerConfigKey = "savedServerConfig"
         static let connectionStateKey = "connectionState"
         static let lastConnectionTimeKey = "lastConnectionTime"
@@ -31,8 +31,8 @@ final class ConnectionManager {
 
     var isConnected: Bool = false {
         didSet {
-            guard oldValue != isConnected else { return }
-            storage.set(isConnected, forKey: Constants.connectionStateKey)
+            guard oldValue != self.isConnected else { return }
+            self.storage.set(self.isConnected, forKey: Constants.connectionStateKey)
         }
     }
 
@@ -45,17 +45,17 @@ final class ConnectionManager {
 
     private init(storage: PersistentStorage = UserDefaultsStorage()) {
         self.storage = storage
-        loadSavedConnection()
-        restoreConnectionState()
+        self.loadSavedConnection()
+        self.restoreConnectionState()
     }
 
     #if DEBUG
-        /// Test-only factory method for creating instances with mock storage
-        /// - Parameter storage: Mock storage for testing
-        /// - Returns: A new ConnectionManager instance for testing
-        static func createForTesting(storage: PersistentStorage) -> ConnectionManager {
-            ConnectionManager(storage: storage)
-        }
+    /// Test-only factory method for creating instances with mock storage
+    /// - Parameter storage: Mock storage for testing
+    /// - Returns: A new ConnectionManager instance for testing
+    static func createForTesting(storage: PersistentStorage) -> ConnectionManager {
+        ConnectionManager(storage: storage)
+    }
     #endif
 
     private func loadSavedConnection() {
@@ -65,10 +65,9 @@ final class ConnectionManager {
             self.serverConfig = config
 
             // Set up authentication service for restored connection
-            authenticationService = AuthenticationService(
+            self.authenticationService = AuthenticationService(
                 apiClient: APIClient.shared,
-                serverConfig: config
-            )
+                serverConfig: config)
 
             // Configure API client and WebSocket client with auth service
             if let authService = authenticationService {
@@ -80,18 +79,18 @@ final class ConnectionManager {
 
     private func restoreConnectionState() {
         // Restore connection state if app was terminated while connected
-        let wasConnected = storage.bool(forKey: Constants.connectionStateKey)
+        let wasConnected = self.storage.bool(forKey: Constants.connectionStateKey)
         if let lastConnectionData = storage.object(forKey: Constants.lastConnectionTimeKey) as? Date {
-            lastConnectionTime = lastConnectionData
+            self.lastConnectionTime = lastConnectionData
 
             // Only restore connection if it was within the last hour
             let timeSinceLastConnection = Date().timeIntervalSince(lastConnectionData)
-            if wasConnected && timeSinceLastConnection < Constants.connectionRestorationWindow && serverConfig != nil {
+            if wasConnected, timeSinceLastConnection < Constants.connectionRestorationWindow, self.serverConfig != nil {
                 // Attempt to restore connection
-                isConnected = true
+                self.isConnected = true
             } else {
                 // Clear stale connection state
-                isConnected = false
+                self.isConnected = false
             }
         }
     }
@@ -105,10 +104,9 @@ final class ConnectionManager {
             // Create and configure authentication service BEFORE saving config
             // This prevents race conditions where other components try to use
             // the API client before authentication is properly configured
-            authenticationService = AuthenticationService(
+            self.authenticationService = AuthenticationService(
                 apiClient: APIClient.shared,
-                serverConfig: config
-            )
+                serverConfig: config)
 
             // Configure API client and WebSocket client with auth service
             if let authService = authenticationService {
@@ -117,32 +115,32 @@ final class ConnectionManager {
             }
 
             // Now save the config and timestamp after auth is set up
-            storage.set(data, forKey: Constants.savedServerConfigKey)
+            self.storage.set(data, forKey: Constants.savedServerConfigKey)
             self.serverConfig = config
 
             // Save connection timestamp
-            lastConnectionTime = Date()
-            storage.set(lastConnectionTime, forKey: Constants.lastConnectionTimeKey)
+            self.lastConnectionTime = Date()
+            self.storage.set(self.lastConnectionTime, forKey: Constants.lastConnectionTimeKey)
 
             // Determine and save connection type
-            activeConnectionType = determineConnectionType(for: config)
-            storage.set(activeConnectionType.rawValue, forKey: Constants.connectionTypeKey)
+            self.activeConnectionType = self.determineConnectionType(for: config)
+            self.storage.set(self.activeConnectionType.rawValue, forKey: Constants.connectionTypeKey)
         }
     }
 
     func disconnect() async {
-        isConnected = false
-        activeConnectionType = .unknown
-        storage.removeObject(forKey: Constants.connectionStateKey)
-        storage.removeObject(forKey: Constants.lastConnectionTimeKey)
-        storage.removeObject(forKey: Constants.connectionTypeKey)
+        self.isConnected = false
+        self.activeConnectionType = .unknown
+        self.storage.removeObject(forKey: Constants.connectionStateKey)
+        self.storage.removeObject(forKey: Constants.lastConnectionTimeKey)
+        self.storage.removeObject(forKey: Constants.connectionTypeKey)
 
-        await authenticationService?.logout()
-        authenticationService = nil
+        await self.authenticationService?.logout()
+        self.authenticationService = nil
     }
 
     var currentServerConfig: ServerConfig? {
-        serverConfig
+        self.serverConfig
     }
 
     // MARK: - Tailscale Support
@@ -150,12 +148,12 @@ final class ConnectionManager {
     /// Determines the best connection type for a server config
     private func determineConnectionType(for config: ServerConfig) -> ActiveConnectionType {
         // Check if we're on the same local network
-        if isOnSameLocalNetwork(config: config) {
+        if self.isOnSameLocalNetwork(config: config) {
             return .local
         }
 
         // Check if Tailscale is available and configured
-        if config.isTailscaleEnabled && tailscaleService.isRunning {
+        if config.isTailscaleEnabled, self.tailscaleService.isRunning {
             return .tailscale
         }
 
@@ -180,7 +178,7 @@ final class ConnectionManager {
         var optimized = config
 
         // If Tailscale is available and we're not on local network, prefer it
-        if !isOnSameLocalNetwork(config: config) && tailscaleService.isRunning {
+        if !self.isOnSameLocalNetwork(config: config), self.tailscaleService.isRunning {
             optimized.preferTailscale = true
 
             // Try to get Tailscale details if not already set
@@ -200,12 +198,12 @@ final class ConnectionManager {
         // Re-evaluate the best connection method
         let optimized = await optimizeServerConfig(config)
         if optimized != config {
-            serverConfig = optimized
-            activeConnectionType = determineConnectionType(for: optimized)
+            self.serverConfig = optimized
+            self.activeConnectionType = self.determineConnectionType(for: optimized)
 
             // Update stored config
             if let data = try? JSONEncoder().encode(optimized) {
-                storage.set(data, forKey: Constants.savedServerConfigKey)
+                self.storage.set(data, forKey: Constants.savedServerConfigKey)
             }
 
             // Update API client base URL if needed

--- a/ios/VibeTunnel/Services/LivePreviewManager.swift
+++ b/ios/VibeTunnel/Services/LivePreviewManager.swift
@@ -170,17 +170,8 @@ struct LivePreviewModifier: ViewModifier {
     }
 }
 
-/// Environment key for passing subscription down the view hierarchy.
-/// Enables child views to access the live preview subscription.
-private struct LivePreviewSubscriptionKey: EnvironmentKey {
-    static let defaultValue: LivePreviewSubscription? = nil
-}
-
 extension EnvironmentValues {
-    var livePreviewSubscription: LivePreviewSubscription? {
-        get { self[LivePreviewSubscriptionKey.self] }
-        set { self[LivePreviewSubscriptionKey.self] = newValue }
-    }
+    @Entry var livePreviewSubscription: LivePreviewSubscription?
 }
 
 extension View {

--- a/ios/VibeTunnel/Services/TailscaleDiscoveryService.swift
+++ b/ios/VibeTunnel/Services/TailscaleDiscoveryService.swift
@@ -22,10 +22,10 @@ final class TailscaleDiscoveryService {
         let isPublic: Bool
 
         var displayName: String {
-            deviceName.replacingOccurrences(of: "-", with: " ")
+            self.deviceName.replacingOccurrences(of: "-", with: " ")
                 .split(separator: ".")
                 .first
-                .map(String.init) ?? deviceName
+                .map(String.init) ?? self.deviceName
         }
     }
 
@@ -66,7 +66,7 @@ final class TailscaleDiscoveryService {
     // MARK: - Constants
 
     private enum Constants {
-        static let defaultPort = 4_020
+        static let defaultPort = 4020
         static let probeTimeout: TimeInterval = 3.0
         static let discoveryInterval: TimeInterval = 30.0
     }
@@ -79,56 +79,56 @@ final class TailscaleDiscoveryService {
 
     /// Starts discovering Tailscale servers
     func startDiscovery() {
-        guard !isDiscovering else {
-            logger.debug("Discovery already in progress")
+        guard !self.isDiscovering else {
+            self.logger.debug("Discovery already in progress")
             return
         }
 
-        guard tailscaleService.isRunning else {
-            logger.info("Tailscale not running, skipping discovery")
-            lastError = "Tailscale is not running"
+        guard self.tailscaleService.isRunning else {
+            self.logger.info("Tailscale not running, skipping discovery")
+            self.lastError = "Tailscale is not running"
             return
         }
 
-        isDiscovering = true
-        lastError = nil
+        self.isDiscovering = true
+        self.lastError = nil
 
-        discoveryTask = Task {
-            await discoverServers()
+        self.discoveryTask = Task {
+            await self.discoverServers()
         }
     }
 
     /// Stops the discovery process
     func stopDiscovery() {
-        discoveryTask?.cancel()
-        discoveryTask = nil
-        isDiscovering = false
+        self.discoveryTask?.cancel()
+        self.discoveryTask = nil
+        self.isDiscovering = false
     }
 
     /// Starts the auto-refresh timer for periodic discovery
     func startAutoRefresh() {
         // Check if auto-refresh is enabled in settings
         guard UserDefaults.standard.bool(forKey: "tailscaleAutoRefresh") else {
-            logger.debug("Auto-refresh is disabled in settings")
+            self.logger.debug("Auto-refresh is disabled in settings")
             return
         }
 
         // Don't start if already running
-        guard refreshTimer == nil else {
-            logger.debug("Auto-refresh timer already running")
+        guard self.refreshTimer == nil else {
+            self.logger.debug("Auto-refresh timer already running")
             return
         }
 
         // Must have discovery enabled and Tailscale running
         guard UserDefaults.standard.bool(forKey: "enableTailscaleDiscovery"),
-              tailscaleService.isRunning
+              self.tailscaleService.isRunning
         else {
-            logger.info("Cannot start auto-refresh: discovery disabled or Tailscale not running")
+            self.logger.info("Cannot start auto-refresh: discovery disabled or Tailscale not running")
             return
         }
 
-        logger.info("Starting auto-refresh timer with \(Constants.discoveryInterval)s interval")
-        isAutoRefreshing = true
+        self.logger.info("Starting auto-refresh timer with \(Constants.discoveryInterval)s interval")
+        self.isAutoRefreshing = true
 
         // Schedule the timer on the main run loop
         DispatchQueue.main.async { [weak self] in
@@ -159,24 +159,24 @@ final class TailscaleDiscoveryService {
 
     /// Stops the auto-refresh timer
     func stopAutoRefresh() {
-        refreshTimer?.invalidate()
-        refreshTimer = nil
-        isAutoRefreshing = false
-        nextRefreshTime = nil
-        logger.info("Stopped auto-refresh timer")
+        self.refreshTimer?.invalidate()
+        self.refreshTimer = nil
+        self.isAutoRefreshing = false
+        self.nextRefreshTime = nil
+        self.logger.info("Stopped auto-refresh timer")
     }
 
     /// Adds a known server hostname for future discovery
     func addKnownServer(hostname: String) {
-        var known = knownHostnames
+        var known = self.knownHostnames
         known.insert(hostname)
-        knownHostnames = known
+        self.knownHostnames = known
 
         // Immediately probe this server
         Task {
             if let server = await probeServer(hostname: hostname) {
-                if !discoveredServers.contains(where: { $0.hostname == hostname }) {
-                    discoveredServers.append(server)
+                if !self.discoveredServers.contains(where: { $0.hostname == hostname }) {
+                    self.discoveredServers.append(server)
                 }
             }
         }
@@ -184,141 +184,202 @@ final class TailscaleDiscoveryService {
 
     /// Removes a server from known servers
     func removeKnownServer(hostname: String) {
-        var known = knownHostnames
+        var known = self.knownHostnames
         known.remove(hostname)
-        knownHostnames = known
+        self.knownHostnames = known
 
-        discoveredServers.removeAll { $0.hostname == hostname }
+        self.discoveredServers.removeAll { $0.hostname == hostname }
     }
 
     /// Manually refreshes the server list
     func refresh() async {
-        guard !isDiscovering else { return }
+        guard !self.isDiscovering else { return }
 
-        isDiscovering = true
+        self.isDiscovering = true
         defer { isDiscovering = false }
 
-        await discoverServers()
+        await self.discoverServers()
     }
 
     /// Resets the entire discovery environment, clearing all state
     func resetEnvironment() {
         // Stop any ongoing discovery
-        stopDiscovery()
-        stopAutoRefresh()
+        self.stopDiscovery()
+        self.stopAutoRefresh()
 
         // Clear discovered servers
-        discoveredServers = []
+        self.discoveredServers = []
 
         // Clear known hostnames from UserDefaults
-        knownHostnames = []
+        self.knownHostnames = []
 
         // Reset error states
-        lastError = nil
-        isDiscovering = false
+        self.lastError = nil
+        self.isDiscovering = false
 
-        logger.info("Tailscale discovery environment reset")
+        self.logger.info("Tailscale discovery environment reset")
     }
 
     // MARK: - Private Methods
 
     private func discoverServers() async {
-        logger.info("Starting Tailscale server discovery using API")
+        self.logger.info("Starting Tailscale server discovery using API")
 
         // Check if Tailscale is configured and running
-        guard tailscaleService.isConfigured else {
-            logger.warning("Tailscale OAuth token not configured")
-            lastError = "No OAuth token configured"
-            isDiscovering = false
+        guard self.tailscaleService.isConfigured else {
+            self.logger.warning("Tailscale OAuth token not configured")
+            self.lastError = "No OAuth token configured"
+            self.isDiscovering = false
             return
         }
 
         // Refresh device list from API
-        await tailscaleService.refreshStatus()
+        await self.tailscaleService.refreshStatus()
 
-        guard tailscaleService.isRunning else {
-            logger.warning("Tailscale API not accessible")
-            lastError = tailscaleService.statusError ?? "API not accessible"
-            isDiscovering = false
+        guard self.tailscaleService.isRunning else {
+            self.logger.warning("Tailscale API not accessible")
+            self.lastError = self.tailscaleService.statusError ?? "API not accessible"
+            self.isDiscovering = false
             return
         }
 
-        logger.info("Processing \(tailscaleService.devices.count) devices from Tailscale API")
+        self.logger.info("Processing \(self.tailscaleService.devices.count) devices from Tailscale API")
 
         // Filter devices that could be VibeTunnel servers
         var newServers: [TailscaleServer] = []
 
-        for device in tailscaleService.devices {
-            logger
+        for device in self.tailscaleService.devices {
+            self.logger
                 .info(
-                    "Checking device: \(device.name), OS: '\(device.os ?? "nil")', isOnline: \(device.isOnline), isVibeTunnelServer: \(device.isVibeTunnelServer), lastSeen: \(device.lastSeen ?? "nil")"
-                )
+                    "Checking device: \(device.name), OS: '\(device.os ?? "nil")', isOnline: \(device.isOnline), isVibeTunnelServer: \(device.isVibeTunnelServer), lastSeen: \(device.lastSeen ?? "nil")")
 
             // Only check online devices that could be servers
-            guard device.isOnline && device.isVibeTunnelServer else {
-                logger
+            guard device.isOnline, device.isVibeTunnelServer else {
+                self.logger
                     .info(
-                        "Skipping device \(device.name): online=\(device.isOnline), server=\(device.isVibeTunnelServer), OS='\(device.os ?? "nil")'"
-                    )
+                        "Skipping device \(device.name): online=\(device.isOnline), server=\(device.isVibeTunnelServer), OS='\(device.os ?? "nil")'")
                 continue
             }
 
-            logger.info("Probing VibeTunnel on \(device.name) (\(device.ipv4Address ?? "no IP"))")
+            self.logger.info("Probing VibeTunnel on \(device.name) (\(device.ipv4Address ?? "no IP"))")
 
             // Check if this device has VibeTunnel running on port 4020
             if let server = await probeServer(hostname: device.name, ip: device.ipv4Address) {
                 newServers.append(server)
-                logger.info("Found VibeTunnel server: \(device.name)")
+                self.logger.info("Found VibeTunnel server: \(device.name)")
             } else {
-                logger.info("No VibeTunnel response from \(device.name)")
+                self.logger.info("No VibeTunnel response from \(device.name)")
             }
         }
 
         // Update discovered servers
-        discoveredServers = newServers.sorted { $0.deviceName < $1.deviceName }
+        self.discoveredServers = newServers.sorted { $0.deviceName < $1.deviceName }
 
-        logger.info("Discovery complete. Found \(discoveredServers.count) VibeTunnel servers")
-        isDiscovering = false
+        self.logger.info("Discovery complete. Found \(self.discoveredServers.count) VibeTunnel servers")
+        self.isDiscovering = false
     }
 
     private func probeServer(
         hostname: String,
         ip: String? = nil,
-        port: Int = Constants.defaultPort
-    )
+        port: Int = Constants.defaultPort)
         async -> TailscaleServer?
     {
-        logger.debug("Probing server: \(hostname):\(port)")
+        self.logger.debug("Probing server: \(hostname):\(port)")
 
         // Use provided IP or try to resolve the hostname
         let resolvedIP: String? = if let providedIP = ip {
             providedIP
         } else {
-            await resolveHostname(hostname)
+            await self.resolveHostname(hostname)
         }
 
+        // Probe both HTTP and HTTPS in parallel. Prefer HTTPS when available
+        // because Tailscale Serve injects identity headers for automatic auth.
+        // Without HTTPS, connections go direct and require password login.
+        async let httpResult = self.probeHTTP(hostname: hostname, resolvedIP: resolvedIP, port: port)
+        async let httpsResult = self.probeHTTPS(hostname: hostname, resolvedIP: resolvedIP)
+
+        let http = await httpResult
+        let https = await httpsResult
+
+        if let https {
+            self.logger.info("HTTPS probe succeeded for \(hostname) — using Tailscale Serve")
+            return https
+        }
+
+        if let http {
+            self.logger.info("HTTP probe succeeded for \(hostname) on port \(port)")
+            return http
+        }
+
+        self.logger.info("No VibeTunnel response from \(hostname) on HTTP or HTTPS")
+        return nil
+    }
+
+    /// Probes a server via plain HTTP on the given port
+    private func probeHTTP(
+        hostname: String,
+        resolvedIP: String?,
+        port: Int) async -> TailscaleServer?
+    {
         // Construct URL for health check - VibeTunnel uses /api/health endpoint
-        let urlString: String = if let resolvedIP {
+        let urlString = if let resolvedIP {
             "http://\(resolvedIP):\(port)/api/health"
         } else {
             "http://\(hostname):\(port)/api/health"
         }
         guard let url = URL(string: urlString) else {
-            logger.debug("Invalid URL for \(hostname)")
+            self.logger.debug("Invalid URL for \(hostname)")
             return nil
         }
 
-        // Perform health check
+        return await self.performHealthProbe(
+            url: url,
+            hostname: hostname,
+            resolvedIP: resolvedIP,
+            port: port,
+            isHTTPS: false)
+    }
+
+    /// Probes a server via HTTPS on port 443 (Tailscale Serve)
+    private func probeHTTPS(
+        hostname: String,
+        resolvedIP: String?) async -> TailscaleServer?
+    {
+        // Tailscale Serve uses the MagicDNS hostname with HTTPS on port 443
+        let httpsUrlString = "https://\(hostname)/api/health"
+        guard let url = URL(string: httpsUrlString) else {
+            self.logger.debug("Invalid HTTPS URL for \(hostname)")
+            return nil
+        }
+
+        return await self.performHealthProbe(
+            url: url,
+            hostname: hostname,
+            resolvedIP: resolvedIP,
+            port: 443,
+            isHTTPS: true)
+    }
+
+    /// Performs the actual health probe request and parses the response
+    private func performHealthProbe(
+        url: URL,
+        hostname: String,
+        resolvedIP: String?,
+        port: Int,
+        isHTTPS: Bool) async -> TailscaleServer?
+    {
         do {
             let configuration = URLSessionConfiguration.default
             configuration.timeoutIntervalForRequest = Constants.probeTimeout
             let session = URLSession(configuration: configuration)
 
-            logger.debug("Probing URL: \(url.absoluteString)")
+            self.logger.debug("Probing URL: \(url.absoluteString)")
             let (data, response) = try await session.data(from: url)
 
             if let httpResponse = response as? HTTPURLResponse {
-                logger.debug("Probe response from \(hostname): HTTP \(httpResponse.statusCode)")
+                self.logger.debug("Probe response from \(hostname): HTTP \(httpResponse.statusCode)")
                 if httpResponse.statusCode == 200 {
                     // Parse the health response to get Tailscale information
                     var httpsUrl: String?
@@ -328,7 +389,7 @@ final class TailscaleDiscoveryService {
                         // Check for Tailscale HTTPS URL
                         if let tailscaleUrl = health.tailscaleUrl {
                             httpsUrl = tailscaleUrl
-                            logger.info("Found Tailscale HTTPS URL: \(tailscaleUrl)")
+                            self.logger.info("Found Tailscale HTTPS URL: \(tailscaleUrl)")
                         }
 
                         // Check connections object for more details
@@ -340,9 +401,15 @@ final class TailscaleDiscoveryService {
                             // Check if Funnel (public access) is enabled
                             if let funnel = tailscale.funnel {
                                 isPublic = funnel
-                                logger.info("Tailscale Funnel enabled: \(funnel)")
+                                self.logger.info("Tailscale Funnel enabled: \(funnel)")
                             }
                         }
+                    }
+
+                    // If we reached the server via HTTPS, use that as the httpsUrl
+                    if isHTTPS, httpsUrl == nil {
+                        httpsUrl = "https://\(hostname)"
+                        self.logger.info("Server reachable via Tailscale Serve HTTPS: \(httpsUrl!)")
                     }
 
                     // Extract device name from hostname
@@ -356,17 +423,17 @@ final class TailscaleDiscoveryService {
                     return TailscaleServer(
                         hostname: hostname,
                         ip: resolvedIP,
-                        port: port,
+                        port: isHTTPS ? Constants.defaultPort : port,
                         deviceName: deviceName,
                         isReachable: true,
                         lastSeen: Date(),
                         httpsUrl: httpsUrl,
-                        isPublic: isPublic
-                    )
+                        isPublic: isPublic)
                 }
             }
         } catch {
-            logger.debug("Failed to probe \(hostname): \(error.localizedDescription)")
+            self.logger
+                .debug("Failed to probe \(hostname) (\(isHTTPS ? "HTTPS" : "HTTP")): \(error.localizedDescription)")
         }
 
         return nil
@@ -405,8 +472,8 @@ final class TailscaleDiscoveryService {
                     socklen_t(hostname.count),
                     nil,
                     0,
-                    NI_NUMERICHOST
-                ) == 0 {
+                    NI_NUMERICHOST) == 0
+                {
                     // Use the recommended String initializer to avoid deprecation warning
                     let hostnameData = hostname.withUnsafeBufferPointer { buffer in
                         guard let baseAddress = buffer.baseAddress else { return Data() }
@@ -434,7 +501,6 @@ final class TailscaleDiscoveryService {
             preferTailscale: true,
             httpsAvailable: tailscaleServer.httpsUrl != nil,
             isPublic: tailscaleServer.isPublic,
-            preferSSL: tailscaleServer.httpsUrl != nil
-        )
+            preferSSL: tailscaleServer.httpsUrl != nil)
     }
 }

--- a/ios/VibeTunnel/Services/TailscaleService.swift
+++ b/ios/VibeTunnel/Services/TailscaleService.swift
@@ -40,26 +40,26 @@ final class TailscaleService {
     var clientId: String? {
         get {
             do {
-                return try keychainService.loadPassword(for: Self.clientIdKey.uuidString)
+                return try self.keychainService.loadPassword(for: Self.clientIdKey.uuidString)
             } catch {
-                logger.debug("No client ID found in Keychain")
+                self.logger.debug("No client ID found in Keychain")
                 return nil
             }
         }
         set {
             do {
                 if let id = newValue {
-                    try keychainService.savePassword(id, for: Self.clientIdKey.uuidString)
+                    try self.keychainService.savePassword(id, for: Self.clientIdKey.uuidString)
                 } else {
-                    try keychainService.deletePassword(for: Self.clientIdKey.uuidString)
+                    try self.keychainService.deletePassword(for: Self.clientIdKey.uuidString)
                 }
                 // Clear cached token when credentials change
-                clearCachedToken()
+                self.clearCachedToken()
                 Task {
-                    await refreshStatus()
+                    await self.refreshStatus()
                 }
             } catch {
-                logger.error("Failed to save client ID to Keychain: \(error)")
+                self.logger.error("Failed to save client ID to Keychain: \(error)")
             }
         }
     }
@@ -68,26 +68,26 @@ final class TailscaleService {
     var clientSecret: String? {
         get {
             do {
-                return try keychainService.loadPassword(for: Self.clientSecretKey.uuidString)
+                return try self.keychainService.loadPassword(for: Self.clientSecretKey.uuidString)
             } catch {
-                logger.debug("No client secret found in Keychain")
+                self.logger.debug("No client secret found in Keychain")
                 return nil
             }
         }
         set {
             do {
                 if let secret = newValue {
-                    try keychainService.savePassword(secret, for: Self.clientSecretKey.uuidString)
+                    try self.keychainService.savePassword(secret, for: Self.clientSecretKey.uuidString)
                 } else {
-                    try keychainService.deletePassword(for: Self.clientSecretKey.uuidString)
+                    try self.keychainService.deletePassword(for: Self.clientSecretKey.uuidString)
                 }
                 // Clear cached token when credentials change
-                clearCachedToken()
+                self.clearCachedToken()
                 Task {
-                    await refreshStatus()
+                    await self.refreshStatus()
                 }
             } catch {
-                logger.error("Failed to save client secret to Keychain: \(error)")
+                self.logger.error("Failed to save client secret to Keychain: \(error)")
             }
         }
     }
@@ -96,7 +96,7 @@ final class TailscaleService {
     private var accessToken: String? {
         get {
             do {
-                return try keychainService.loadPassword(for: Self.accessTokenKey.uuidString)
+                return try self.keychainService.loadPassword(for: Self.accessTokenKey.uuidString)
             } catch {
                 return nil
             }
@@ -104,12 +104,12 @@ final class TailscaleService {
         set {
             do {
                 if let token = newValue {
-                    try keychainService.savePassword(token, for: Self.accessTokenKey.uuidString)
+                    try self.keychainService.savePassword(token, for: Self.accessTokenKey.uuidString)
                 } else {
-                    try keychainService.deletePassword(for: Self.accessTokenKey.uuidString)
+                    try self.keychainService.deletePassword(for: Self.accessTokenKey.uuidString)
                 }
             } catch {
-                logger.error("Failed to save access token to Keychain: \(error)")
+                self.logger.error("Failed to save access token to Keychain: \(error)")
             }
         }
     }
@@ -136,7 +136,7 @@ final class TailscaleService {
 
     /// Indicates if we have a valid OAuth token (for backward compatibility)
     var isInstalled: Bool {
-        isConfigured
+        self.isConfigured
     }
 
     /// Indicates if Tailscale API is accessible
@@ -176,7 +176,7 @@ final class TailscaleService {
         let clientVersion: String?
 
         var ipv4Address: String? {
-            addresses.first { $0.contains(".") && !$0.contains(":") }
+            self.addresses.first { $0.contains(".") && !$0.contains(":") }
         }
 
         var isOnline: Bool {
@@ -192,7 +192,7 @@ final class TailscaleService {
         var isVibeTunnelServer: Bool {
             // Check if device has VibeTunnel tag or is a macOS/Darwin device
             // The API might return "darwin", "macOS", "Darwin", etc.
-            if tags?.contains("vibetunnel") ?? false {
+            if self.tags?.contains("vibetunnel") ?? false {
                 return true
             }
             if let deviceOS = os?.lowercased() {
@@ -205,38 +205,38 @@ final class TailscaleService {
     // MARK: - Initialization
 
     private init() {
-        setupNotifications()
+        self.setupNotifications()
         Task {
-            await refreshStatus()
+            await self.refreshStatus()
         }
     }
 
     /// Sets up notification observers for app lifecycle
     private func setupNotifications() {
         #if os(iOS)
-            NotificationCenter.default.addObserver(
-                forName: UIApplication.willEnterForegroundNotification,
-                object: nil,
-                queue: .main
-            ) { _ in
-                Task { @MainActor in
-                    // Refresh token when app comes to foreground
-                    await self.refreshStatus()
-                }
+        NotificationCenter.default.addObserver(
+            forName: UIApplication.willEnterForegroundNotification,
+            object: nil,
+            queue: .main)
+        { _ in
+            Task { @MainActor in
+                // Refresh token when app comes to foreground
+                await self.refreshStatus()
             }
+        }
 
-            NotificationCenter.default.addObserver(
-                forName: UIApplication.didBecomeActiveNotification,
-                object: nil,
-                queue: .main
-            ) { _ in
-                Task { @MainActor in
-                    // Check token validity when app becomes active
-                    if self.isConfigured {
-                        _ = await self.ensureValidAccessToken()
-                    }
+        NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main)
+        { _ in
+            Task { @MainActor in
+                // Check token validity when app becomes active
+                if self.isConfigured {
+                    _ = await self.ensureValidAccessToken()
                 }
             }
+        }
         #endif
     }
 
@@ -246,58 +246,58 @@ final class TailscaleService {
     func clearCredentials() {
         // Clear from Keychain
         do {
-            try keychainService.deletePassword(for: Self.clientIdKey.uuidString)
-            try keychainService.deletePassword(for: Self.clientSecretKey.uuidString)
-            try keychainService.deletePassword(for: Self.accessTokenKey.uuidString)
+            try self.keychainService.deletePassword(for: Self.clientIdKey.uuidString)
+            try self.keychainService.deletePassword(for: Self.clientSecretKey.uuidString)
+            try self.keychainService.deletePassword(for: Self.accessTokenKey.uuidString)
         } catch {
-            logger.error("Failed to delete credentials from Keychain: \(error)")
+            self.logger.error("Failed to delete credentials from Keychain: \(error)")
         }
 
         // Clear token expiry from UserDefaults
         UserDefaults.standard.removeObject(forKey: Self.tokenExpiryKey)
 
         // Clear in-memory values (will be cleared via property setters)
-        clientId = nil
-        clientSecret = nil
-        clearCachedToken()
+        self.clientId = nil
+        self.clientSecret = nil
+        self.clearCachedToken()
 
         // Clear discovered state
-        devices = []
-        tailnetName = nil
-        isRunning = false
-        statusError = nil
-        lastStatusCheck = nil
+        self.devices = []
+        self.tailnetName = nil
+        self.isRunning = false
+        self.statusError = nil
+        self.lastStatusCheck = nil
 
         // Post notification to update all views
         NotificationCenter.default.post(name: Notification.Name("TailscaleCredentialsCleared"), object: nil)
 
-        logger.info("Tailscale credentials and state cleared")
+        self.logger.info("Tailscale credentials and state cleared")
     }
 
     /// Clears the cached OAuth token
     private func clearCachedToken() {
-        accessToken = nil
-        tokenExpiry = nil
+        self.accessToken = nil
+        self.tokenExpiry = nil
     }
 
     /// Refreshes the Tailscale status by querying the API
     func refreshStatus() async {
-        guard isConfigured else {
-            isRunning = false
-            devices = []
-            tailnetName = nil
-            statusError = "No credentials configured"
-            logger.info("Tailscale credentials not configured")
+        guard self.isConfigured else {
+            self.isRunning = false
+            self.devices = []
+            self.tailnetName = nil
+            self.statusError = "No credentials configured"
+            self.logger.info("Tailscale credentials not configured")
             return
         }
 
         // Ensure we have a valid access token
-        if await ensureValidAccessToken() {
-            await fetchDevices()
+        if await self.ensureValidAccessToken() {
+            await self.fetchDevices()
         } else {
-            isRunning = false
-            devices = []
-            tailnetName = nil
+            self.isRunning = false
+            self.devices = []
+            self.tailnetName = nil
             // statusError is set by ensureValidAccessToken
         }
     }
@@ -305,17 +305,17 @@ final class TailscaleService {
     /// Ensures we have a valid access token, fetching a new one if needed
     private func ensureValidAccessToken() async -> Bool {
         // Check if we have a valid cached token
-        if accessToken != nil,
+        if self.accessToken != nil,
            let expiry = tokenExpiry,
            expiry > Date().addingTimeInterval(60)
         { // Still valid for at least 1 minute
-            logger.debug("Using cached token, expires at \(expiry)")
+            self.logger.debug("Using cached token, expires at \(expiry)")
             return true
         }
 
-        logger.info("Token expired or missing, fetching new token")
+        self.logger.info("Token expired or missing, fetching new token")
         // Fetch new token
-        return await fetchAccessToken()
+        return await self.fetchAccessToken()
     }
 
     /// Fetches a new OAuth access token using client credentials
@@ -323,23 +323,23 @@ final class TailscaleService {
         guard let clientId,
               let clientSecret
         else {
-            statusError = "Missing credentials"
+            self.statusError = "Missing credentials"
             return false
         }
 
         // Validate client ID and secret format
         if !clientId.hasPrefix("k") {
-            statusError = "Invalid Client ID format - should start with 'k'"
+            self.statusError = "Invalid Client ID format - should start with 'k'"
             return false
         }
 
         if !clientSecret.hasPrefix("tskey-client-") {
-            statusError = "Invalid Client Secret format - must start with 'tskey-client-'"
+            self.statusError = "Invalid Client Secret format - must start with 'tskey-client-'"
             return false
         }
 
         guard let url = URL(string: Self.oauthTokenEndpoint) else {
-            statusError = "Invalid OAuth endpoint"
+            self.statusError = "Invalid OAuth endpoint"
             return false
         }
 
@@ -353,7 +353,7 @@ final class TailscaleService {
             URLQueryItem(name: "client_id", value: clientId),
             URLQueryItem(name: "client_secret", value: clientSecret),
             URLQueryItem(name: "grant_type", value: "client_credentials"),
-            URLQueryItem(name: "scope", value: "devices:core:read")
+            URLQueryItem(name: "scope", value: "devices:core:read"),
         ]
         request.httpBody = components.percentEncodedQuery?.data(using: .utf8)
         request.timeoutInterval = Self.apiTimeoutInterval
@@ -362,19 +362,19 @@ final class TailscaleService {
             let (data, response) = try await URLSession.shared.data(for: request)
 
             guard let httpResponse = response as? HTTPURLResponse else {
-                statusError = "Invalid response from OAuth endpoint"
+                self.statusError = "Invalid response from OAuth endpoint"
                 return false
             }
 
             if httpResponse.statusCode == 401 {
-                statusError = "Invalid client credentials"
-                logger.error("OAuth client credentials rejected with 401")
+                self.statusError = "Invalid client credentials"
+                self.logger.error("OAuth client credentials rejected with 401")
                 return false
             }
 
             guard httpResponse.statusCode == 200 else {
-                statusError = "OAuth error: HTTP \(httpResponse.statusCode)"
-                logger.error("OAuth endpoint returned status code: \(httpResponse.statusCode)")
+                self.statusError = "OAuth error: HTTP \(httpResponse.statusCode)"
+                self.logger.error("OAuth endpoint returned status code: \(httpResponse.statusCode)")
                 return false
             }
 
@@ -397,8 +397,8 @@ final class TailscaleService {
 
             // Validate the returned token
             if !tokenResponse.accessToken.hasPrefix("tskey-api-") {
-                logger.error("Invalid access token format returned: \(tokenResponse.accessToken.prefix(10))")
-                statusError = "Invalid access token format"
+                self.logger.error("Invalid access token format returned: \(tokenResponse.accessToken.prefix(10))")
+                self.statusError = "Invalid access token format"
                 return false
             }
 
@@ -406,11 +406,11 @@ final class TailscaleService {
             self.accessToken = tokenResponse.accessToken
             self.tokenExpiry = Date().addingTimeInterval(TimeInterval(tokenResponse.expiresIn))
 
-            logger.info("Successfully obtained OAuth access token, expires in \(tokenResponse.expiresIn) seconds")
+            self.logger.info("Successfully obtained OAuth access token, expires in \(tokenResponse.expiresIn) seconds")
             return true
         } catch {
-            logger.error("Failed to fetch OAuth access token: \(error)")
-            statusError = "Failed to get access token: \(error.localizedDescription)"
+            self.logger.error("Failed to fetch OAuth access token: \(error)")
+            self.statusError = "Failed to get access token: \(error.localizedDescription)"
             return false
         }
     }
@@ -418,7 +418,7 @@ final class TailscaleService {
     /// Fetches the list of devices from Tailscale API
     private func fetchDevices() async {
         guard let token = accessToken else {
-            statusError = "No access token available"
+            self.statusError = "No access token available"
             return
         }
 
@@ -428,9 +428,9 @@ final class TailscaleService {
         // Construct URL with - in the path (OAuth uses - instead of explicit tailnet)
         let urlString = "\(Self.tailscaleAPIEndpoint)/tailnet/\(tailnetIdentifier)/devices"
         guard let url = URL(string: urlString) else {
-            logger.error("Invalid Tailscale API URL: \(urlString)")
-            statusError = "Invalid API URL"
-            isRunning = false
+            self.logger.error("Invalid Tailscale API URL: \(urlString)")
+            self.statusError = "Invalid API URL"
+            self.isRunning = false
             return
         }
 
@@ -442,8 +442,8 @@ final class TailscaleService {
         request.timeoutInterval = Self.apiTimeoutInterval
 
         // Log complete request details
-        logger.debug("Tailscale API Request to: \(url.absoluteString)")
-        logger.debug("Using OAuth token: \(String(token.prefix(15)))...\(String(token.suffix(10)))")
+        self.logger.debug("Tailscale API Request to: \(url.absoluteString)")
+        self.logger.debug("Using OAuth token: \(String(token.prefix(15)))...\(String(token.suffix(10)))")
 
         do {
             let (data, response) = try await URLSession.shared.data(for: request)
@@ -453,47 +453,47 @@ final class TailscaleService {
             }
 
             if httpResponse.statusCode == 401 {
-                statusError = "Invalid token - refreshing credentials"
-                isRunning = false
-                logger.error("OAuth token rejected with 401, clearing token")
-                clearCachedToken()
+                self.statusError = "Invalid token - refreshing credentials"
+                self.isRunning = false
+                self.logger.error("OAuth token rejected with 401, clearing token")
+                self.clearCachedToken()
                 // Try to refresh token once
-                if await fetchAccessToken() {
+                if await self.fetchAccessToken() {
                     // Retry with new token
-                    await fetchDevices()
+                    await self.fetchDevices()
                 }
                 return
             }
 
             if httpResponse.statusCode == 403 {
-                statusError = "Access denied - refreshing token"
-                isRunning = false
-                logger.error("403 Forbidden - attempting token refresh")
-                clearCachedToken()
+                self.statusError = "Access denied - refreshing token"
+                self.isRunning = false
+                self.logger.error("403 Forbidden - attempting token refresh")
+                self.clearCachedToken()
                 // Try to refresh token once
-                if await fetchAccessToken() {
+                if await self.fetchAccessToken() {
                     // Retry with new token
-                    await fetchDevices()
+                    await self.fetchDevices()
                 } else {
-                    statusError = "Access denied - check client credentials"
-                    logger.error("Failed to refresh token after 403")
+                    self.statusError = "Access denied - check client credentials"
+                    self.logger.error("Failed to refresh token after 403")
                 }
                 return
             }
 
             if httpResponse.statusCode == 500 {
-                statusError = "Tailscale API server error"
-                isRunning = false
-                logger.error("Tailscale API returned 500 error")
+                self.statusError = "Tailscale API server error"
+                self.isRunning = false
+                self.logger.error("Tailscale API returned 500 error")
                 return
             }
 
             guard httpResponse.statusCode == 200 else {
-                statusError = "API error: HTTP \(httpResponse.statusCode)"
-                isRunning = false
-                logger.error("Tailscale API returned status code: \(httpResponse.statusCode)")
+                self.statusError = "API error: HTTP \(httpResponse.statusCode)"
+                self.isRunning = false
+                self.logger.error("Tailscale API returned status code: \(httpResponse.statusCode)")
                 if let errorString = String(data: data, encoding: .utf8) {
-                    logger.error("Error response: \(errorString)")
+                    self.logger.error("Error response: \(errorString)")
                 }
                 return
             }
@@ -504,7 +504,7 @@ final class TailscaleService {
 
             // First log the raw response to debug JSON issues
             if let jsonString = String(data: data, encoding: .utf8) {
-                logger.info("Raw API response: \(jsonString)")
+                self.logger.info("Raw API response: \(jsonString)")
             }
 
             let decoder = JSONDecoder()
@@ -525,49 +525,49 @@ final class TailscaleService {
                     self.tailnetName = "Tailscale"
                 }
 
-                logger.info("Successfully fetched \(devices.count) devices from Tailscale")
+                self.logger.info("Successfully fetched \(self.devices.count) devices from Tailscale")
             } catch {
-                logger.error("Failed to decode devices response: \(error)")
+                self.logger.error("Failed to decode devices response: \(error)")
                 if let decodingError = error as? DecodingError {
                     switch decodingError {
-                    case .keyNotFound(let key, let context):
-                        logger.error("Missing key: \(key.stringValue) - \(context.debugDescription)")
-                    case .typeMismatch(let type, let context):
-                        logger.error("Type mismatch for type \(type) - \(context.debugDescription)")
-                    case .valueNotFound(let type, let context):
-                        logger.error("Value not found for type \(type) - \(context.debugDescription)")
-                    case .dataCorrupted(let context):
-                        logger.error("Data corrupted - \(context.debugDescription)")
+                    case let .keyNotFound(key, context):
+                        self.logger.error("Missing key: \(key.stringValue) - \(context.debugDescription)")
+                    case let .typeMismatch(type, context):
+                        self.logger.error("Type mismatch for type \(type) - \(context.debugDescription)")
+                    case let .valueNotFound(type, context):
+                        self.logger.error("Value not found for type \(type) - \(context.debugDescription)")
+                    case let .dataCorrupted(context):
+                        self.logger.error("Data corrupted - \(context.debugDescription)")
                     @unknown default:
-                        logger.error("Unknown decoding error")
+                        self.logger.error("Unknown decoding error")
                     }
                 }
-                statusError = "The data couldn't be read because it is missing."
-                isRunning = false
+                self.statusError = "The data couldn't be read because it is missing."
+                self.isRunning = false
             }
         } catch {
-            logger.error("Failed to fetch Tailscale devices: \(error)")
+            self.logger.error("Failed to fetch Tailscale devices: \(error)")
 
             // Provide more specific error messages
             if let urlError = error as? URLError {
                 switch urlError.code {
                 case .timedOut:
-                    statusError = "Request timed out"
+                    self.statusError = "Request timed out"
                 case .notConnectedToInternet:
-                    statusError = "No internet connection"
+                    self.statusError = "No internet connection"
                 case .cannotFindHost:
-                    statusError = "Cannot reach Tailscale API"
+                    self.statusError = "Cannot reach Tailscale API"
                 case .badServerResponse:
-                    statusError = "Invalid response from server"
+                    self.statusError = "Invalid response from server"
                 default:
-                    statusError = "Network error: \(urlError.code.rawValue)"
+                    self.statusError = "Network error: \(urlError.code.rawValue)"
                 }
             } else {
-                statusError = error.localizedDescription
+                self.statusError = error.localizedDescription
             }
 
-            isRunning = false
-            lastStatusCheck = Date()
+            self.isRunning = false
+            self.lastStatusCheck = Date()
         }
     }
 
@@ -575,7 +575,7 @@ final class TailscaleService {
     private func extractTailnetName(from hostname: String) -> String? {
         // Hostname format: device-name.tailnet-name.ts.net
         let components = hostname.split(separator: ".")
-        if components.count >= 3 && components.suffix(2).joined(separator: ".") == "ts.net" {
+        if components.count >= 3, components.suffix(2).joined(separator: ".") == "ts.net" {
             return String(components[components.count - 3])
         }
         return nil
@@ -585,14 +585,14 @@ final class TailscaleService {
 
     /// Legacy property for organization - maps to clientId
     var organization: String? {
-        get { clientId }
-        set { clientId = newValue }
+        get { self.clientId }
+        set { self.clientId = newValue }
     }
 
     /// Legacy property for API key - maps to clientSecret
     var apiKey: String? {
-        get { clientSecret }
-        set { clientSecret = newValue }
+        get { self.clientSecret }
+        set { self.clientSecret = newValue }
     }
 
     // MARK: - Compatibility Methods (for UI that expects these)
@@ -600,11 +600,11 @@ final class TailscaleService {
     /// Opens Tailscale configuration in settings
     func openTailscaleApp() {
         // This now opens our settings view instead
-        logger.info("Opening Tailscale configuration")
+        self.logger.info("Opening Tailscale configuration")
     }
 
     /// Opens App Store (no longer needed, but kept for compatibility)
     func openAppStore() {
-        logger.info("OAuth token configuration needed - no app required")
+        self.logger.info("OAuth token configuration needed - no app required")
     }
 }

--- a/ios/VibeTunnel/Utils/JSONValue.swift
+++ b/ios/VibeTunnel/Utils/JSONValue.swift
@@ -34,15 +34,15 @@ enum JSONValue: Codable, Equatable {
         var container = encoder.singleValueContainer()
 
         switch self {
-        case .string(let value):
+        case let .string(value):
             try container.encode(value)
-        case .number(let value):
+        case let .number(value):
             try container.encode(value)
-        case .bool(let value):
+        case let .bool(value):
             try container.encode(value)
-        case .array(let value):
+        case let .array(value):
             try container.encode(value)
-        case .object(let value):
+        case let .object(value):
             try container.encode(value)
         case .null:
             try container.encodeNil()

--- a/ios/VibeTunnel/ViewModels/ServerListViewModel.swift
+++ b/ios/VibeTunnel/ViewModels/ServerListViewModel.swift
@@ -47,17 +47,17 @@ class ServerListViewModel: ServerListViewModelProtocol {
         connectionManager: ConnectionManager = ConnectionManager.shared,
         networkMonitor: NetworkMonitoring = NetworkMonitor.shared,
         keychainService: KeychainServiceProtocol = KeychainService(),
-        userDefaults: UserDefaults = .standard
-    ) {
+        userDefaults: UserDefaults = .standard)
+    {
         self.connectionManager = connectionManager
         self.networkMonitor = networkMonitor
         self.keychainService = keychainService
         self.userDefaults = userDefaults
-        loadProfiles()
+        self.loadProfiles()
     }
 
     func loadProfiles() {
-        profiles = ServerProfile.loadAll(from: userDefaults).sorted { profile1, profile2 in
+        self.profiles = ServerProfile.loadAll(from: self.userDefaults).sorted { profile1, profile2 in
             // Sort by last connected (most recent first), then by name
             if let date1 = profile1.lastConnected, let date2 = profile2.lastConnected {
                 date1 > date2
@@ -72,60 +72,60 @@ class ServerListViewModel: ServerListViewModelProtocol {
     }
 
     func loadProfilesAndCheckHealth() {
-        loadProfiles()
+        self.loadProfiles()
 
         // Check health of all profiles in background
         Task {
-            await checkAndUpdateAllProfiles()
+            await self.checkAndUpdateAllProfiles()
         }
     }
 
     func addProfile(_ profile: ServerProfile, password: String? = nil) async throws {
-        ServerProfile.save(profile, to: userDefaults)
+        ServerProfile.save(profile, to: self.userDefaults)
 
         // Save password to keychain if provided
         if let password, !password.isEmpty {
-            try keychainService.savePassword(password, for: profile.id)
+            try self.keychainService.savePassword(password, for: profile.id)
         }
 
-        loadProfiles()
+        self.loadProfiles()
     }
 
     func updateProfile(_ profile: ServerProfile, password: String? = nil) async throws {
         var updatedProfile = profile
         updatedProfile.updatedAt = Date()
-        ServerProfile.save(updatedProfile, to: userDefaults)
+        ServerProfile.save(updatedProfile, to: self.userDefaults)
 
         // Handle password updates based on auth requirement
         if !profile.requiresAuth {
             // If profile doesn't require auth, remove any stored password
-            try? keychainService.deletePassword(for: profile.id)
+            try? self.keychainService.deletePassword(for: profile.id)
         } else if let password {
             if password.isEmpty {
                 // Delete password if empty string provided
-                try keychainService.deletePassword(for: profile.id)
+                try self.keychainService.deletePassword(for: profile.id)
             } else {
                 // Save new password
-                try keychainService.savePassword(password, for: profile.id)
+                try self.keychainService.savePassword(password, for: profile.id)
             }
         }
         // If password is nil and profile requires auth, leave existing password unchanged
 
-        loadProfiles()
+        self.loadProfiles()
     }
 
     func deleteProfile(_ profile: ServerProfile) async throws {
-        ServerProfile.delete(profile, from: userDefaults)
+        ServerProfile.delete(profile, from: self.userDefaults)
 
         // Delete password from keychain
-        try keychainService.deletePassword(for: profile.id)
+        try self.keychainService.deletePassword(for: profile.id)
 
-        loadProfiles()
+        self.loadProfiles()
     }
 
     func getPassword(for profile: ServerProfile) -> String? {
         do {
-            return try keychainService.getPassword(for: profile.id)
+            return try self.keychainService.getPassword(for: profile.id)
         } catch {
             // Password not found or error occurred
             return nil
@@ -134,7 +134,7 @@ class ServerListViewModel: ServerListViewModelProtocol {
 
     func connectToProfile(_ profile: ServerProfile) async throws {
         // connectionLogger.info("🔗 Starting connection to profile: \(profile.name) (id: \(profile.id))")
-        connectionLogger
+        self.connectionLogger
             .debug("🔗 Profile details: requiresAuth=\(profile.requiresAuth), username=\(profile.username ?? "nil")")
 
         // Log profile URL and connection details
@@ -142,14 +142,14 @@ class ServerListViewModel: ServerListViewModelProtocol {
         // connectionLogger.info("🔗 HTTPS Available: \(profile.httpsAvailable), Prefer SSL: \(profile.preferSSL)")
         // connectionLogger.info("🔗 Tailscale Hostname: \(profile.tailscaleHostname ?? "nil")")
 
-        isLoading = true
-        errorMessage = nil
-        showLoginView = false
+        self.isLoading = true
+        self.errorMessage = nil
+        self.showLoginView = false
         defer { isLoading = false }
 
         // Create server config
         guard var config = profile.toServerConfig() else {
-            connectionLogger.error("🔗 ❌ Failed to create server config")
+            self.connectionLogger.error("🔗 ❌ Failed to create server config")
             throw APIError.invalidURL
         }
         // connectionLogger.info("🔗 ✅ Created server config:")
@@ -166,45 +166,51 @@ class ServerListViewModel: ServerListViewModelProtocol {
 
         do {
             // Save connection - this sets up the AuthenticationService
-            connectionManager.saveConnection(config)
-            connectionLogger.debug("🔗 ✅ Saved connection to manager")
+            self.connectionManager.saveConnection(config)
+            self.connectionLogger.debug("🔗 ✅ Saved connection to manager")
 
             // Get auth service
             guard let authService = connectionManager.authenticationService else {
-                connectionLogger.error("🔗 ❌ No authentication service available")
+                self.connectionLogger.error("🔗 ❌ No authentication service available")
                 throw APIError.noServerConfigured
             }
-            connectionLogger.debug("🔗 ✅ Got authentication service")
+            self.connectionLogger.debug("🔗 ✅ Got authentication service")
 
             // Check if server requires authentication
             let authConfig = try await authService.getAuthConfig()
-            connectionLogger.debug("🔗 Auth config: noAuth=\(authConfig.noAuth)")
+            self.connectionLogger
+                .debug("🔗 Auth config: noAuth=\(authConfig.noAuth), tailscaleAuth=\(authConfig.tailscaleAuth ?? false)")
 
             if authConfig.noAuth {
                 // No auth required, test connection directly
                 // connectionLogger.info("🔗 No auth required, testing connection directly")
                 _ = try await APIClient.shared.getSessions()
-                connectionManager.isConnected = true
-                ServerProfile.updateLastConnected(for: profile.id, in: userDefaults)
-                loadProfiles()
+                self.connectionManager.isConnected = true
+                ServerProfile.updateLastConnected(for: profile.id, in: self.userDefaults)
+                self.loadProfiles()
                 // connectionLogger.info("🔗 ✅ Connection successful (no auth)")
                 return
             }
 
-            // Authentication required - attempt auto-login
-            // connectionLogger.info("🔗 Authentication required, attempting auto-login")
-            try await authService.attemptAutoLogin(profile: profile)
+            // Check for Tailscale identity authentication (via Tailscale Serve headers)
+            if authConfig.tailscaleAuth == true, let user = authConfig.authenticatedUser {
+                self.connectionLogger.info("🔗 Tailscale identity auth available for user: \(user)")
+                try await authService.authenticateWithTailscale(user: user)
+                self.connectionLogger.info("🔗 ✅ Tailscale auth successful")
+            } else {
+                // Standard authentication - attempt auto-login with stored credentials
+                try await authService.attemptAutoLogin(profile: profile)
+            }
             // connectionLogger.info("🔗 ✅ Auto-login successful")
 
             // Auto-login successful, test connection
             _ = try await APIClient.shared.getSessions()
-            connectionManager.isConnected = true
-            ServerProfile.updateLastConnected(for: profile.id, in: userDefaults)
-            loadProfiles()
+            self.connectionManager.isConnected = true
+            ServerProfile.updateLastConnected(for: profile.id, in: self.userDefaults)
+            self.loadProfiles()
             // connectionLogger.info("🔗 ✅ Connection fully established")
-            connectionLogger.debug(
-                "🔗 📊 ConnectionManager state: isConnected=\(connectionManager.isConnected), serverConfig=\(connectionManager.serverConfig != nil ? "✅" : "❌")"
-            )
+            self.connectionLogger.debug(
+                "🔗 📊 ConnectionManager state: isConnected=\(self.connectionManager.isConnected), serverConfig=\(self.connectionManager.serverConfig != nil ? "✅" : "❌")")
         } catch let authError as AuthenticationError {
             // Handle authentication errors first
             connectionLogger.error("🔗 ❌ Authentication error: \(authError)")
@@ -235,175 +241,91 @@ class ServerListViewModel: ServerListViewModelProtocol {
             // Throw the error to be caught in initiateConnectionToProfile
             throw authError
         } catch {
-            connectionLogger.error("🔗 ❌ Initial connection failed: \(error)")
+            self.connectionLogger.error("🔗 ❌ Initial connection failed: \(error)")
             // connectionLogger.info("🔗 Error type: \(String(describing: type(of: error)))")
 
             // Only attempt fallback for Tailscale servers that were using HTTPS
-            if profile.isTailscaleEnabled && config.httpsAvailable && config.preferSSL && !fallbackAttempted {
-                connectionLogger.warning("🔗 ⚠️ HTTPS connection failed, trying HTTP fallback")
-                // connectionLogger.info("🔗 Error type: \(String(describing: type(of: error)))")
+            if profile.isTailscaleEnabled, config.httpsAvailable, config.preferSSL, !fallbackAttempted {
+                self.connectionLogger
+                    .warning("🔗 ⚠️ HTTPS connection failed, trying HTTP fallback on port \(profile.port ?? 4020)")
 
-                connectionStatusMessage = "HTTPS unavailable, switching to HTTP..."
+                self.connectionStatusMessage = "HTTPS unavailable, switching to HTTP..."
                 fallbackAttempted = true
 
-                // First, do a health check to get current server state
-                if let healthProfile = await checkServerHealth(for: profile) {
-                    connectionLogger
-                        .info(
-                            "🔗 Health check result - HTTPS: \(healthProfile.httpsAvailable), Public: \(healthProfile.isPublic)"
-                        )
+                // Build an HTTP fallback config directly — do NOT save profile changes
+                // during fallback. The profile's stored flags (from discovery) remain authoritative.
+                var httpConfig = ServerConfig(
+                    host: config.tailscaleIP ?? config.tailscaleHostname ?? config.host,
+                    port: profile.port ?? 4020,
+                    name: config.name,
+                    tailscaleHostname: config.tailscaleHostname,
+                    tailscaleIP: config.tailscaleIP,
+                    isTailscaleEnabled: true,
+                    preferTailscale: true,
+                    httpsAvailable: false,
+                    isPublic: false,
+                    preferSSL: false)
 
-                    // Save the updated profile from health check
-                    ServerProfile.save(healthProfile, to: userDefaults)
+                self.connectionManager.saveConnection(httpConfig)
 
-                    // Create new config from health check results
-                    guard var newConfig = healthProfile.toServerConfig() else {
-                        connectionLogger.error("🔗 ❌ Failed to create config from health check")
-                        throw APIError.invalidURL
+                do {
+                    guard let authService = connectionManager.authenticationService else {
+                        throw APIError.noServerConfigured
                     }
 
-                    // Force HTTP for this attempt
-                    newConfig.httpsAvailable = false
-                    newConfig.preferSSL = false
+                    let authConfig = try await authService.getAuthConfig()
 
-                    // connectionLogger.info("🔗 Retrying with HTTP: \(newConfig.connectionURL())")
-
-                    // Save and retry with HTTP config
-                    connectionManager.saveConnection(newConfig)
-
-                    // Try connection again with updated config
-                    do {
-                        guard let authService = connectionManager.authenticationService else {
-                            throw APIError.noServerConfigured
-                        }
-
-                        let authConfig = try await authService.getAuthConfig()
-
-                        if authConfig.noAuth {
-                            _ = try await APIClient.shared.getSessions()
-                            connectionManager.isConnected = true
-                            ServerProfile.updateLastConnected(for: healthProfile.id, in: userDefaults)
-                            loadProfiles()
-                            // connectionLogger.info("🔗 ✅ HTTP fallback successful (no auth)")
-                            connectionStatusMessage = nil
-                            return
-                        } else {
-                            try await authService.attemptAutoLogin(profile: healthProfile)
-                            _ = try await APIClient.shared.getSessions()
-                            connectionManager.isConnected = true
-                            ServerProfile.updateLastConnected(for: healthProfile.id, in: userDefaults)
-                            loadProfiles()
-                            // connectionLogger.info("🔗 ✅ HTTP fallback successful (with auth)")
-                            connectionStatusMessage = nil
-                            return
-                        }
-                    } catch {
-                        connectionLogger.error("🔗 ❌ HTTP fallback also failed: \(error)")
+                    if authConfig.noAuth {
+                        _ = try await APIClient.shared.getSessions()
+                        self.connectionManager.isConnected = true
+                        ServerProfile.updateLastConnected(for: profile.id, in: self.userDefaults)
+                        self.loadProfiles()
+                        self.connectionStatusMessage = nil
+                        return
+                    } else if authConfig.tailscaleAuth == true, let user = authConfig.authenticatedUser {
+                        try await authService.authenticateWithTailscale(user: user)
+                        _ = try await APIClient.shared.getSessions()
+                        self.connectionManager.isConnected = true
+                        ServerProfile.updateLastConnected(for: profile.id, in: self.userDefaults)
+                        self.loadProfiles()
+                        self.connectionStatusMessage = nil
+                        return
+                    } else {
+                        try await authService.attemptAutoLogin(profile: profile)
+                        _ = try await APIClient.shared.getSessions()
+                        self.connectionManager.isConnected = true
+                        ServerProfile.updateLastConnected(for: profile.id, in: self.userDefaults)
+                        self.loadProfiles()
+                        self.connectionStatusMessage = nil
+                        return
                     }
-                } else {
-                    connectionLogger.warning("🔗 ⚠️ Health check failed, trying blind HTTP fallback")
-
-                    // Blind fallback without health check
-                    config.httpsAvailable = false
-                    config.preferSSL = false
-                    config.isPublic = false
-
-                    var updatedProfile = profile
-                    updatedProfile.httpsAvailable = false
-                    updatedProfile.preferSSL = false
-                    updatedProfile.isPublic = false
-                    ServerProfile.save(updatedProfile, to: userDefaults)
-
-                    connectionManager.saveConnection(config)
-
-                    // Try one more time with HTTP
-                    do {
-                        guard let authService = connectionManager.authenticationService else {
-                            throw APIError.noServerConfigured
-                        }
-
-                        let authConfig = try await authService.getAuthConfig()
-
-                        if authConfig.noAuth {
-                            _ = try await APIClient.shared.getSessions()
-                            connectionManager.isConnected = true
-                            ServerProfile.updateLastConnected(for: updatedProfile.id, in: userDefaults)
-                            loadProfiles()
-                            // connectionLogger.info("🔗 ✅ Blind HTTP fallback successful")
-                            connectionStatusMessage = nil
-                            return
-                        } else {
-                            try await authService.attemptAutoLogin(profile: updatedProfile)
-                            _ = try await APIClient.shared.getSessions()
-                            connectionManager.isConnected = true
-                            ServerProfile.updateLastConnected(for: updatedProfile.id, in: userDefaults)
-                            loadProfiles()
-                            // connectionLogger.info("🔗 ✅ Blind HTTP fallback successful (with auth)")
-                            connectionStatusMessage = nil
-                            return
-                        }
-                    } catch {
-                        connectionLogger.error("🔗 ❌ Blind HTTP fallback also failed: \(error)")
-                    }
-                }
-            }
-
-            // Only update Tailscale servers after failure (they might have switched modes)
-            if profile.isTailscaleEnabled {
-                // connectionLogger.info("🔗 📊 Updating Tailscale server UI after connection failure")
-                if let healthProfile = await checkServerHealth(for: profile) {
-                    connectionLogger
-                        .info(
-                            "🔗 📊 Server actual state - HTTPS: \(healthProfile.httpsAvailable), Public: \(healthProfile.isPublic)"
-                        )
-                    connectionLogger
-                        .info("🔗 📊 Profile was - HTTPS: \(profile.httpsAvailable), Public: \(profile.isPublic)")
-
-                    // Save the actual server state to update UI
-                    ServerProfile.save(healthProfile, to: userDefaults)
-
-                    // Force UI refresh to show correct lock/unlock icons
-                    await MainActor.run {
-                        loadProfiles()
-                    }
-
-                    // connectionLogger.info("🔗 ✅ UI updated to reflect server state change")
-                } else {
-                    connectionLogger.warning("🔗 ⚠️ Could not determine server state, updating profile to HTTP-only")
-                    // If we can't reach the server, assume HTTP only
-                    var fallbackProfile = profile
-                    fallbackProfile.httpsAvailable = false
-                    fallbackProfile.preferSSL = false
-                    fallbackProfile.isPublic = false
-                    ServerProfile.save(fallbackProfile, to: userDefaults)
-                    await MainActor.run {
-                        loadProfiles()
-                    }
+                } catch {
+                    self.connectionLogger.error("🔗 ❌ HTTP fallback also failed: \(error)")
                 }
             }
 
             // Clear status message
-            connectionStatusMessage = nil
+            self.connectionStatusMessage = nil
 
             // Handle specific error types for user feedback
             if let apiError = error as? APIError {
                 switch apiError {
                 case .serverError(401, _):
                     // Authentication required but no auto-login available
-                    showLoginView = true
+                    self.showLoginView = true
                     return
                 case .networkError:
-                    errorMessage = "Cannot connect to server. Please check the server is running and accessible."
-                    connectionLogger.error("🔗 ❌ Network error: Server not accessible")
+                    self.errorMessage = "Cannot connect to server. Please check the server is running and accessible."
+                    self.connectionLogger.error("🔗 ❌ Network error: Server not accessible")
                     // Don't throw - let user see error but don't block UI
                     return
                 default:
-                    errorMessage = "Connection failed. The server may have switched between public and private mode. Please tap refresh and try again."
+                    self.errorMessage = "Connection failed. The server may have switched between public and private mode. Please tap refresh and try again."
                     // Don't throw - let user see error but don't block UI
                     return
                 }
             } else {
-                errorMessage = "Connection failed: \(error.localizedDescription)"
+                self.errorMessage = "Connection failed: \(error.localizedDescription)"
                 // Don't throw - let user see error but don't block UI
                 return
             }
@@ -411,13 +333,13 @@ class ServerListViewModel: ServerListViewModelProtocol {
     }
 
     func testConnection(for profile: ServerProfile) async -> Bool {
-        let password = profile.requiresAuth ? getPassword(for: profile) : nil
+        let password = profile.requiresAuth ? self.getPassword(for: profile) : nil
         guard let config = profile.toServerConfig(password: password) else {
             return false
         }
 
         // Save the config temporarily to test using injected connection manager
-        connectionManager.saveConnection(config)
+        self.connectionManager.saveConnection(config)
 
         do {
             _ = try await APIClient.shared.getSessions()
@@ -434,7 +356,7 @@ class ServerListViewModel: ServerListViewModelProtocol {
         var updatedProfiles: [ServerProfile] = []
         var hasChanges = false
 
-        for profile in profiles {
+        for profile in self.profiles {
             // Only check health for Tailscale-enabled servers
             guard profile.isTailscaleEnabled else {
                 // connectionLogger.info("🔍 Skipping non-Tailscale profile: \(profile.name)")
@@ -442,27 +364,24 @@ class ServerListViewModel: ServerListViewModelProtocol {
                 continue
             }
 
-            connectionLogger
+            self.connectionLogger
                 .info(
-                    "🔍 Checking Tailscale profile: \(profile.name), current HTTPS: \(profile.httpsAvailable), Public: \(profile.isPublic)"
-                )
+                    "🔍 Checking Tailscale profile: \(profile.name), current HTTPS: \(profile.httpsAvailable), Public: \(profile.isPublic)")
 
             // Check each Tailscale profile's server health
             if let updatedProfile = await checkServerHealth(for: profile) {
-                connectionLogger
+                self.connectionLogger
                     .info(
-                        "🔍 Health check result for \(profile.name): HTTPS: \(updatedProfile.httpsAvailable), Public: \(updatedProfile.isPublic)"
-                    )
+                        "🔍 Health check result for \(profile.name): HTTPS: \(updatedProfile.httpsAvailable), Public: \(updatedProfile.isPublic)")
 
                 if updatedProfile.httpsAvailable != profile.httpsAvailable ||
                     updatedProfile.isPublic != profile.isPublic ||
                     updatedProfile.preferSSL != profile.preferSSL
                 {
                     hasChanges = true
-                    connectionLogger
+                    self.connectionLogger
                         .info(
-                            "🔍 Profile \(profile.name) updated - HTTPS: \(updatedProfile.httpsAvailable), Public: \(updatedProfile.isPublic), PreferSSL: \(updatedProfile.preferSSL)"
-                        )
+                            "🔍 Profile \(profile.name) updated - HTTPS: \(updatedProfile.httpsAvailable), Public: \(updatedProfile.isPublic), PreferSSL: \(updatedProfile.preferSSL)")
                 } else {
                     // connectionLogger.info("🔍 Profile \(profile.name) unchanged")
                 }
@@ -478,12 +397,12 @@ class ServerListViewModel: ServerListViewModelProtocol {
         if hasChanges {
             // connectionLogger.info("🔍 Saving \(updatedProfiles.count) updated profiles")
             for profile in updatedProfiles {
-                ServerProfile.save(profile, to: userDefaults)
+                ServerProfile.save(profile, to: self.userDefaults)
             }
             // Reload to refresh UI
             await MainActor.run {
                 // connectionLogger.info("🔍 Reloading profiles to refresh UI")
-                loadProfiles()
+                self.loadProfiles()
             }
         } else {
             // connectionLogger.info("🔍 No changes detected in any profiles")
@@ -494,11 +413,11 @@ class ServerListViewModel: ServerListViewModelProtocol {
     private func checkServerHealth(for profile: ServerProfile) async -> ServerProfile? {
         let probeHost = profile.host ?? URL(string: profile.url)?.host
         guard let probeHost else {
-            connectionLogger.error("🔍 No host found for profile \(profile.name)")
+            self.connectionLogger.error("🔍 No host found for profile \(profile.name)")
             return nil
         }
 
-        let httpUrl = "http://\(probeHost):\(profile.port ?? 4_020)/api/health"
+        let httpUrl = "http://\(probeHost):\(profile.port ?? 4020)/api/health"
         var updatedProfile = profile
 
         // connectionLogger.info("🔍 Probing health at: \(httpUrl)")
@@ -518,27 +437,38 @@ class ServerListViewModel: ServerListViewModelProtocol {
                     if let health = try? JSONDecoder().decode(HealthResponse.self, from: data),
                        let connections = health.connections
                     {
-                        // connectionLogger.info("🔍 Health data connections: \(connections)")
-
                         // Check for Tailscale info
                         if let tailscale = connections.tailscale {
-                            let httpsAvailable = tailscale.httpsAvailable ?? false
-                            let isPublic = tailscale.isPublic ?? false
+                            let healthHTTPS = tailscale.httpsAvailable ?? false
+                            let healthPublic = tailscale.isPublic ?? false
 
-                            // connectionLogger.info("🔍 Tailscale data - HTTPS: \(httpsAvailable), Public: \(isPublic)")
-
-                            updatedProfile.httpsAvailable = httpsAvailable
-                            updatedProfile.isPublic = isPublic
-                            updatedProfile.preferSSL = httpsAvailable
+                            // For Tailscale profiles: the health endpoint (HTTP on port 4020)
+                            // may not know about Tailscale Serve proxying HTTPS on 443.
+                            // Only upgrade HTTPS flags (false→true), never downgrade flags
+                            // that were set by discovery (which actually probed HTTPS).
+                            if healthHTTPS || !profile.isTailscaleEnabled {
+                                updatedProfile.httpsAvailable = healthHTTPS
+                                updatedProfile.preferSSL = healthHTTPS
+                            }
+                            // Always update public/funnel status — server knows about this
+                            updatedProfile.isPublic = healthPublic
 
                             return updatedProfile
                         }
 
-                        // Fallback to general connection info
+                        // No Tailscale section in health response — for Tailscale profiles,
+                        // preserve existing HTTPS flags (discovery is authoritative)
+                        if profile.isTailscaleEnabled {
+                            // Only update isPublic from general info if available
+                            updatedProfile.isPublic = connections.isPublic ?? profile.isPublic
+                            return updatedProfile
+                        }
+
+                        // For non-Tailscale profiles, use general connection info
                         let httpsAvailable = connections.sslAvailable ?? false
                         let isPublic = connections.isPublic ?? false
 
-                        connectionLogger
+                        self.connectionLogger
                             .info("🔍 General connection data - HTTPS: \(httpsAvailable), Public: \(isPublic)")
 
                         updatedProfile.httpsAvailable = httpsAvailable
@@ -550,7 +480,7 @@ class ServerListViewModel: ServerListViewModelProtocol {
                 }
             }
         } catch {
-            connectionLogger.debug("🔍 Health check failed for \(profile.name): \(error.localizedDescription)")
+            self.connectionLogger.debug("🔍 Health check failed for \(profile.name): \(error.localizedDescription)")
         }
 
         return nil
@@ -563,12 +493,12 @@ class ServerListViewModel: ServerListViewModelProtocol {
         // Try to probe using the stored Tailscale hostname if available
         let probeHost = profile.tailscaleHostname ?? profile.host ?? URL(string: profile.url)?.host
         guard let probeHost else {
-            connectionLogger.error("🔍 ❌ Cannot determine host for probing")
+            self.connectionLogger.error("🔍 ❌ Cannot determine host for probing")
             return nil
         }
 
         // First try HTTP health check (always available)
-        let httpUrl = "http://\(probeHost):\(profile.port ?? 4_020)/api/health"
+        let httpUrl = "http://\(probeHost):\(profile.port ?? 4020)/api/health"
         var updatedProfile = profile
         var httpsAvailable = false
         var isPublic = false
@@ -588,7 +518,7 @@ class ServerListViewModel: ServerListViewModelProtocol {
                 let session = URLSession(configuration: configuration)
 
                 if let url = URL(string: httpUrl) {
-                    connectionLogger.debug("🔍 Probing HTTP: \(url.absoluteString)")
+                    self.connectionLogger.debug("🔍 Probing HTTP: \(url.absoluteString)")
                     let (data, response) = try await session.data(from: url)
 
                     if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
@@ -614,44 +544,55 @@ class ServerListViewModel: ServerListViewModelProtocol {
                     }
                 }
             } catch {
-                connectionLogger.warning("🔍 ⚠️ Probe attempt \(attempt) failed: \(error.localizedDescription)")
+                self.connectionLogger.warning("🔍 ⚠️ Probe attempt \(attempt) failed: \(error.localizedDescription)")
                 // Continue to next attempt
             }
         }
 
         // After all attempts, handle failure case
         if !probeSuccess {
-            connectionLogger.warning("🔍 ⚠️ All probe attempts failed")
-            // If probe fails, assume server is offline or unreachable
-            // ALWAYS clear HTTPS/public flags when probe fails
+            self.connectionLogger.warning("🔍 ⚠️ All probe attempts failed")
+
+            // For Tailscale profiles, preserve HTTPS flags from discovery even if
+            // the HTTP health probe fails (server may only be reachable via Tailscale Serve)
+            if profile.isTailscaleEnabled {
+                self.connectionLogger.info("🔍 Probe failed but preserving Tailscale profile flags")
+                return profile
+            }
+
+            // For non-Tailscale profiles, clear flags when probe fails
             httpsAvailable = false
             isPublic = false
 
-            // Force update when probe fails - server might be transitioning
             if updatedProfile.httpsAvailable || updatedProfile.isPublic {
-                // connectionLogger.info("🔍 Probe failed - clearing HTTPS/public flags")
                 updatedProfile.httpsAvailable = false
                 updatedProfile.isPublic = false
                 updatedProfile.preferSSL = false
 
-                // Save updated profile
-                ServerProfile.save(updatedProfile, to: userDefaults)
-                loadProfiles()
+                ServerProfile.save(updatedProfile, to: self.userDefaults)
+                self.loadProfiles()
 
                 return updatedProfile
             }
         }
 
         // Update profile if capabilities changed
-        if updatedProfile.httpsAvailable != httpsAvailable || updatedProfile.isPublic != isPublic {
-            // connectionLogger.info("🔍 Server capabilities changed - updating profile")
-            updatedProfile.httpsAvailable = httpsAvailable
-            updatedProfile.isPublic = isPublic
-            updatedProfile.preferSSL = httpsAvailable // Prefer SSL if available
+        // For Tailscale profiles, only upgrade HTTPS flags (never downgrade)
+        let shouldUpdateHTTPS = if profile.isTailscaleEnabled {
+            httpsAvailable && !updatedProfile.httpsAvailable // only false→true
+        } else {
+            updatedProfile.httpsAvailable != httpsAvailable
+        }
 
-            // Save updated profile
-            ServerProfile.save(updatedProfile, to: userDefaults)
-            loadProfiles()
+        if shouldUpdateHTTPS || updatedProfile.isPublic != isPublic {
+            if shouldUpdateHTTPS {
+                updatedProfile.httpsAvailable = httpsAvailable
+                updatedProfile.preferSSL = httpsAvailable
+            }
+            updatedProfile.isPublic = isPublic
+
+            ServerProfile.save(updatedProfile, to: self.userDefaults)
+            self.loadProfiles()
 
             return updatedProfile
         }
@@ -662,40 +603,40 @@ class ServerListViewModel: ServerListViewModelProtocol {
     /// Initiate connection to a profile (replaces View logic)
     func initiateConnectionToProfile(_ profile: ServerProfile) async {
         // connectionLogger.info("🔗 initiateConnectionToProfile called for: \(profile.name)")
-        connectionLogger
-            .info("🔗 Profile details - URL: \(profile.url), HTTPS: \(profile.httpsAvailable), SSL: \(profile.preferSSL)"
-            )
+        self.connectionLogger
+            .info(
+                "🔗 Profile details - URL: \(profile.url), HTTPS: \(profile.httpsAvailable), SSL: \(profile.preferSSL)")
 
-        guard networkMonitor.isConnected else {
-            connectionLogger.error("🔗 ❌ No network connection")
-            errorMessage = "No internet connection available"
+        guard self.networkMonitor.isConnected else {
+            self.connectionLogger.error("🔗 ❌ No network connection")
+            self.errorMessage = "No internet connection available"
             return
         }
         // connectionLogger.info("🔗 Network connection available")
 
         // Store the current profile for potential login callback
-        currentConnectingProfile = profile
+        self.currentConnectingProfile = profile
 
         // Try to connect with the current profile settings
         // connectionLogger.info("🔗 Attempting connection with current profile settings")
 
         do {
             // connectionLogger.info("🔗 Calling connectToProfile...")
-            try await connectToProfile(profile)
+            try await self.connectToProfile(profile)
             // connectionLogger.info("🔗 ✅ Connection successful")
             // Connection successful - clear any error
-            errorMessage = nil
+            self.errorMessage = nil
         } catch {
-            connectionLogger.error("🔗 ❌ Connection failed: \(error)")
+            self.connectionLogger.error("🔗 ❌ Connection failed: \(error)")
 
             // If it was an auth error, show login view
             // Otherwise, show error to user
             if error is AuthenticationError {
                 // connectionLogger.info("🔗 🔐 Authentication error detected, showing login view")
-                showLoginView = true
-                currentConnectingProfile = profile
+                self.showLoginView = true
+                self.currentConnectingProfile = profile
             } else {
-                errorMessage = "Failed to connect to \(profile.name). The server may have changed its connection mode. Please tap the refresh button and try again."
+                self.errorMessage = "Failed to connect to \(profile.name). The server may have changed its connection mode. Please tap the refresh button and try again."
             }
         }
     }
@@ -703,58 +644,58 @@ class ServerListViewModel: ServerListViewModelProtocol {
     /// Handle successful login and save credentials
     func handleLoginSuccess(username: String, password: String) async throws {
         guard let profile = currentConnectingProfile else {
-            credentialsLogger.warning("⚠️ No current connecting profile found")
+            self.credentialsLogger.warning("⚠️ No current connecting profile found")
             throw AuthenticationError.invalidCredentials
         }
 
-        credentialsLogger.info("💾 Saving credentials after successful login for profile: \(profile.name)")
-        credentialsLogger.debug("💾 Username: \(username), Password length: \(password.count)")
+        self.credentialsLogger.info("💾 Saving credentials after successful login for profile: \(profile.name)")
+        self.credentialsLogger.debug("💾 Username: \(username), Password length: \(password.count)")
 
         // Save password to keychain with profile ID
         if !password.isEmpty {
-            try keychainService.savePassword(password, for: profile.id)
-            credentialsLogger.info("💾 Password saved to keychain successfully")
+            try self.keychainService.savePassword(password, for: profile.id)
+            self.credentialsLogger.info("💾 Password saved to keychain successfully")
         }
 
         // Update profile with correct username and auth requirement
         var updatedProfile = profile
         updatedProfile.requiresAuth = true
         updatedProfile.username = username
-        ServerProfile.save(updatedProfile, to: userDefaults)
-        credentialsLogger.info("💾 Profile updated with username: \(username)")
+        ServerProfile.save(updatedProfile, to: self.userDefaults)
+        self.credentialsLogger.info("💾 Profile updated with username: \(username)")
 
         // Mark connection as successful
-        connectionManager.isConnected = true
+        self.connectionManager.isConnected = true
 
         // Reload profiles to reflect changes
-        loadProfiles()
+        self.loadProfiles()
     }
 
     func connectToServer(config: ServerConfig) async {
-        guard networkMonitor.isConnected else {
-            errorMessage = "No internet connection available"
+        guard self.networkMonitor.isConnected else {
+            self.errorMessage = "No internet connection available"
             return
         }
 
-        isLoading = true
+        self.isLoading = true
         defer { isLoading = false }
 
         // Save connection temporarily
-        connectionManager.saveConnection(config)
+        self.connectionManager.saveConnection(config)
 
         do {
             // Try to get sessions to check if auth is required
             _ = try await APIClient.shared.getSessions()
             // Success - no auth required
-            connectionManager.isConnected = true
+            self.connectionManager.isConnected = true
         } catch {
             if case APIError.serverError(401, _) = error {
                 // Authentication required
                 // Authentication service is already set by saveConnection
-                showLoginView = true
+                self.showLoginView = true
             } else {
                 // Other error
-                errorMessage = "Failed to connect: \(error.localizedDescription)"
+                self.errorMessage = "Failed to connect: \(error.localizedDescription)"
             }
         }
     }
@@ -785,7 +726,6 @@ extension ServerListViewModel {
         return ServerProfile(
             name: suggestedName,
             url: cleanURL,
-            requiresAuth: false
-        )
+            requiresAuth: false)
     }
 }

--- a/ios/VibeTunnel/Views/Connection/ServerListView.swift
+++ b/ios/VibeTunnel/Views/Connection/ServerListView.swift
@@ -25,7 +25,7 @@ struct ServerListView: View {
     }
 
     #if targetEnvironment(macCatalyst)
-        @State private var windowManager = MacCatalystWindowManager.shared
+    @State private var windowManager = MacCatalystWindowManager.shared
     #endif
 
     var body: some View {
@@ -36,8 +36,8 @@ struct ServerListView: View {
                     HStack {
                         Spacer()
                         Button {
-                            settingsInitialTab = .general
-                            showingSettings = true
+                            self.settingsInitialTab = .general
+                            self.showingSettings = true
                         } label: {
                             Image(systemName: "gearshape.fill")
                                 .font(.system(size: 22))
@@ -52,42 +52,42 @@ struct ServerListView: View {
                 ScrollView {
                     VStack(spacing: Theme.Spacing.extraLarge) {
                         // Logo and Title
-                        headerView
+                        self.headerView
                             .padding(.top, {
                                 #if targetEnvironment(macCatalyst)
-                                    return windowManager.windowStyle == .inline ? 60 : 40
+                                return self.windowManager.windowStyle == .inline ? 60 : 40
                                 #else
-                                    return 40
+                                return 40
                                 #endif
                             }())
 
                         // Server List Section
-                        if !viewModel.profiles.isEmpty {
-                            serverListSection
-                                .opacity(contentOpacity)
+                        if !self.viewModel.profiles.isEmpty {
+                            self.serverListSection
+                                .opacity(self.contentOpacity)
                                 .onAppear {
                                     withAnimation(Theme.Animation.smooth.delay(0.3)) {
-                                        contentOpacity = 1.0
+                                        self.contentOpacity = 1.0
                                     }
                                 }
                         } else {
-                            emptyStateView
-                                .opacity(contentOpacity)
+                            self.emptyStateView
+                                .opacity(self.contentOpacity)
                                 .onAppear {
                                     withAnimation(Theme.Animation.smooth.delay(0.3)) {
-                                        contentOpacity = 1.0
+                                        self.contentOpacity = 1.0
                                     }
                                 }
                         }
 
                         // Discovered servers section
-                        if discoveryService.isDiscovering || !filteredDiscoveredServers.isEmpty {
-                            discoveredServersSection
+                        if self.discoveryService.isDiscovering || !self.filteredDiscoveredServers.isEmpty {
+                            self.discoveredServersSection
                                 .padding(.top, Theme.Spacing.large)
                         }
 
                         // Tailscale servers section - Always show for demo
-                        tailscaleServersSection
+                        self.tailscaleServersSection
                             .padding(.top, Theme.Spacing.large)
 
                         Spacer(minLength: 50)
@@ -100,160 +100,157 @@ struct ServerListView: View {
             .background(Theme.Colors.terminalBackground.ignoresSafeArea())
             .task {
                 // Refresh Tailscale status first
-                await tailscaleService.refreshStatus()
+                await self.tailscaleService.refreshStatus()
 
                 // Now start discovery if Tailscale is running
-                if tailscaleService.isRunning {
-                    tailscaleDiscovery.startDiscovery()
+                if self.tailscaleService.isRunning {
+                    self.tailscaleDiscovery.startDiscovery()
                 }
             }
-            .onReceive(NotificationCenter.default
-                .publisher(for: Notification.Name("TailscaleCredentialsCleared"))
-            ) { _ in
+            .onReceive(
+                NotificationCenter.default
+                    .publisher(for: Notification.Name("TailscaleCredentialsCleared")))
+            { _ in
                 // When Tailscale is reset, clear the discovered servers from view
                 // Force refresh the service references to get cleared state
                 Task { @MainActor in
-                    tailscaleDiscovery = TailscaleDiscoveryService.shared
-                    tailscaleService = TailscaleService.shared
+                    self.tailscaleDiscovery = TailscaleDiscoveryService.shared
+                    self.tailscaleService = TailscaleService.shared
 
                     // Remove any saved servers that are Tailscale-based
-                    let tailscaleProfiles = viewModel.profiles
+                    let tailscaleProfiles = self.viewModel.profiles
                         .filter { $0.isTailscaleEnabled || $0.tailscaleHostname != nil }
                     for profile in tailscaleProfiles {
-                        try? await viewModel.deleteProfile(profile)
+                        try? await self.viewModel.deleteProfile(profile)
                     }
                 }
             }
-            .sheet(item: $selectedProfile) { profile in
-                ServerProfileEditView(
-                    profile: profile,
-                    onSave: { updatedProfile, password in
-                        Task {
-                            try await viewModel.updateProfile(updatedProfile, password: password)
-                            selectedProfile = nil
-                        }
+            .sheet(item: self.$selectedProfile) { profile in
+                    ServerProfileEditView(
+                        profile: profile,
+                        onSave: { updatedProfile, password in
+                            Task {
+                                try await self.viewModel.updateProfile(updatedProfile, password: password)
+                                self.selectedProfile = nil
+                            }
+                        },
+                        onDelete: {
+                            Task {
+                                try await self.viewModel.deleteProfile(profile)
+                                self.selectedProfile = nil
+                            }
+                        })
+                }
+                .sheet(
+                    isPresented: self.$showingAddServer,
+                    onDismiss: {
+                        // Clear the selected discovered server when sheet is dismissed
+                        self.selectedDiscoveredServer = nil
                     },
-                    onDelete: {
-                        Task {
-                            try await viewModel.deleteProfile(profile)
-                            selectedProfile = nil
+                    content: {
+                        AddServerView(
+                            initialHost: self.selectedDiscoveredServer?.host,
+                            initialPort: self.selectedDiscoveredServer.map { String($0.port) },
+                            initialName: self.selectedDiscoveredServer?.displayName)
+                        { _ in
+                            self.viewModel.loadProfiles()
                         }
-                    }
-                )
-            }
-            .sheet(
-                isPresented: $showingAddServer,
-                onDismiss: {
-                    // Clear the selected discovered server when sheet is dismissed
-                    selectedDiscoveredServer = nil
-                },
-                content: {
+                    })
+                .sheet(item: self.$serverToAdd) { server in
                     AddServerView(
-                        initialHost: selectedDiscoveredServer?.host,
-                        initialPort: selectedDiscoveredServer.map { String($0.port) },
-                        initialName: selectedDiscoveredServer?.displayName
-                    ) { _ in
-                        viewModel.loadProfiles()
+                        initialHost: server.host,
+                        initialPort: String(server.port),
+                        initialName: server.displayName)
+                    { _ in
+                        self.viewModel.loadProfiles()
+                        self.serverToAdd = nil
                     }
                 }
-            )
-            .sheet(item: $serverToAdd) { server in
-                AddServerView(
-                    initialHost: server.host,
-                    initialPort: String(server.port),
-                    initialName: server.displayName
-                ) { _ in
-                    viewModel.loadProfiles()
-                    serverToAdd = nil
-                }
-            }
-            .sheet(isPresented: $viewModel.showLoginView) {
-                if let config = viewModel.connectionManager.serverConfig,
-                   let authService = viewModel.connectionManager.authenticationService
-                {
-                    LoginView(
-                        isPresented: $viewModel.showLoginView,
-                        serverConfig: config,
-                        authenticationService: authService
-                    ) { username, password in
-                        // Delegate to ViewModel to handle login success
-                        Task { @MainActor in
-                            do {
-                                try await viewModel.handleLoginSuccess(username: username, password: password)
-                            } catch {
-                                viewModel.errorMessage = "Failed to save credentials: \(error.localizedDescription)"
+                .sheet(isPresented: self.$viewModel.showLoginView) {
+                    if let config = viewModel.connectionManager.serverConfig,
+                       let authService = viewModel.connectionManager.authenticationService
+                    {
+                        LoginView(
+                            isPresented: self.$viewModel.showLoginView,
+                            serverConfig: config,
+                            authenticationService: authService)
+                        { username, password in
+                            // Delegate to ViewModel to handle login success
+                            Task { @MainActor in
+                                do {
+                                    try await self.viewModel.handleLoginSuccess(username: username, password: password)
+                                } catch {
+                                    self.viewModel.errorMessage = "Failed to save credentials: \(error.localizedDescription)"
+                                }
                             }
                         }
                     }
                 }
-            }
-            .sheet(
-                isPresented: $showingSettings,
-                onDismiss: {
-                    // Reset to general tab after dismissal
-                    settingsInitialTab = .general
+                .sheet(
+                    isPresented: self.$showingSettings,
+                    onDismiss: {
+                        // Reset to general tab after dismissal
+                        self.settingsInitialTab = .general
 
-                    // Reload profiles immediately to show newly added servers
-                    viewModel.loadProfiles()
+                        // Reload profiles immediately to show newly added servers
+                        self.viewModel.loadProfiles()
 
-                    // Refresh Tailscale discovery after settings close
-                    // in case user configured Tailscale
-                    Task {
-                        await tailscaleService.refreshStatus()
-                        if tailscaleService.isConfigured && tailscaleService.isRunning {
-                            tailscaleDiscovery.startDiscovery()
+                        // Refresh Tailscale discovery after settings close
+                        // in case user configured Tailscale
+                        Task {
+                            await self.tailscaleService.refreshStatus()
+                            if self.tailscaleService.isConfigured, self.tailscaleService.isRunning {
+                                self.tailscaleDiscovery.startDiscovery()
+                            }
                         }
+                    },
+                    content: {
+                        SettingsView(selectedTab: self.$settingsInitialTab)
+                    })
+                .overlay(alignment: .top) {
+                    if let statusMessage = viewModel.connectionStatusMessage {
+                        HStack {
+                            Image(systemName: "info.circle.fill")
+                                .foregroundColor(.orange)
+                            Text(statusMessage)
+                                .font(.system(size: 14))
+                        }
+                        .padding()
+                        .background(Theme.Colors.terminalBackground.opacity(0.95))
+                        .cornerRadius(8)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(Color.orange.opacity(0.3), lineWidth: 1))
+                        .padding(.top, 50)
+                        .transition(.move(edge: .top).combined(with: .opacity))
                     }
-                },
-                content: {
-                    SettingsView(selectedTab: $settingsInitialTab)
                 }
-            )
-            .overlay(alignment: .top) {
-                if let statusMessage = viewModel.connectionStatusMessage {
-                    HStack {
-                        Image(systemName: "info.circle.fill")
-                            .foregroundColor(.orange)
-                        Text(statusMessage)
-                            .font(.system(size: 14))
-                    }
-                    .padding()
-                    .background(Theme.Colors.terminalBackground.opacity(0.95))
-                    .cornerRadius(8)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8)
-                            .stroke(Color.orange.opacity(0.3), lineWidth: 1)
-                    )
-                    .padding(.top, 50)
-                    .transition(.move(edge: .top).combined(with: .opacity))
-                }
-            }
         }
         .navigationViewStyle(StackNavigationViewStyle())
         .onAppear {
-            viewModel.loadProfilesAndCheckHealth()
-            discoveryService.startDiscovery()
+            self.viewModel.loadProfilesAndCheckHealth()
+            self.discoveryService.startDiscovery()
 
             // Also reload profiles in case they were added from settings
-            viewModel.loadProfiles()
+            self.viewModel.loadProfiles()
         }
-        .alert("Connection Failed", isPresented: .constant(viewModel.errorMessage != nil)) {
+        .alert("Connection Failed", isPresented: .constant(self.viewModel.errorMessage != nil)) {
             Button("OK") {
-                viewModel.errorMessage = nil
+                self.viewModel.errorMessage = nil
             }
         } message: {
-            Text(viewModel.errorMessage ?? "")
+            Text(self.viewModel.errorMessage ?? "")
         }
         .onDisappear {
-            discoveryService.stopDiscovery()
+            self.discoveryService.stopDiscovery()
         }
-        .sheet(isPresented: $showingDiscoverySheet) {
+        .sheet(isPresented: self.$showingDiscoverySheet) {
             DiscoveryDetailSheet(
-                discoveredServers: filteredDiscoveredServers
-            ) { _ in
-                showingDiscoverySheet = false
+                discoveredServers: self.filteredDiscoveredServers)
+            { _ in
+                self.showingDiscoverySheet = false
                 // Auto-fill add server form with discovered server
-                showingAddServer = true
+                self.showingAddServer = true
             }
         }
     }
@@ -276,10 +273,10 @@ struct ServerListView: View {
                     .foregroundColor(Theme.Colors.primaryAccent)
                     .glowEffect()
             }
-            .scaleEffect(logoScale)
+            .scaleEffect(self.logoScale)
             .onAppear {
                 withAnimation(Theme.Animation.smooth.delay(0.1)) {
-                    logoScale = 1.0
+                    self.logoScale = 1.0
                 }
             }
 
@@ -314,7 +311,7 @@ struct ServerListView: View {
                 // Refresh button
                 Button {
                     Task {
-                        await viewModel.checkAndUpdateAllProfiles()
+                        await self.viewModel.checkAndUpdateAllProfiles()
                     }
                 } label: {
                     Image(systemName: "arrow.clockwise")
@@ -323,8 +320,8 @@ struct ServerListView: View {
                 }
 
                 Button {
-                    selectedDiscoveredServer = nil // Clear any discovered server
-                    showingAddServer = true
+                    self.selectedDiscoveredServer = nil // Clear any discovered server
+                    self.showingAddServer = true
                 } label: {
                     Image(systemName: "plus.circle")
                         .font(.system(size: 20))
@@ -333,17 +330,16 @@ struct ServerListView: View {
             }
 
             VStack(spacing: Theme.Spacing.small) {
-                ForEach(viewModel.profiles) { profile in
+                ForEach(self.viewModel.profiles) { profile in
                     ServerProfileCard(
                         profile: profile,
-                        isLoading: viewModel.isLoading,
+                        isLoading: self.viewModel.isLoading,
                         onConnect: {
-                            connectToProfile(profile)
+                            self.connectToProfile(profile)
                         },
                         onEdit: {
-                            selectedProfile = profile
-                        }
-                    )
+                            self.selectedProfile = profile
+                        })
                 }
             }
         }
@@ -370,8 +366,8 @@ struct ServerListView: View {
             }
 
             Button {
-                selectedDiscoveredServer = nil // Clear any discovered server
-                showingAddServer = true
+                self.selectedDiscoveredServer = nil // Clear any discovered server
+                self.showingAddServer = true
             } label: {
                 HStack(spacing: Theme.Spacing.small) {
                     Image(systemName: "plus.circle.fill")
@@ -384,12 +380,10 @@ struct ServerListView: View {
                 .padding(.horizontal, Theme.Spacing.large)
                 .background(
                     RoundedRectangle(cornerRadius: Theme.CornerRadius.medium)
-                        .fill(Theme.Colors.terminalBackground)
-                )
+                        .fill(Theme.Colors.terminalBackground))
                 .overlay(
                     RoundedRectangle(cornerRadius: Theme.CornerRadius.medium)
-                        .stroke(Theme.Colors.primaryAccent, lineWidth: 2)
-                )
+                        .stroke(Theme.Colors.primaryAccent, lineWidth: 2))
             }
         }
         .padding(.horizontal)
@@ -398,8 +392,8 @@ struct ServerListView: View {
     // MARK: - Discovered Servers Section
 
     private var filteredDiscoveredServers: [DiscoveredServer] {
-        let profiles = viewModel.profiles
-        let discovered = discoveryService.discoveredServers
+        let profiles = self.viewModel.profiles
+        let discovered = self.discoveryService.discoveredServers
 
         var filtered: [DiscoveredServer] = []
         for server in discovered {
@@ -413,7 +407,7 @@ struct ServerListView: View {
                     let defaultPort = urlComponents.scheme?.lowercased() == "https" ? 443 : 80
                     let profilePort = urlComponents.port ?? defaultPort
 
-                    if profileHost == server.host && profilePort == server.port {
+                    if profileHost == server.host, profilePort == server.port {
                         isAlreadySaved = true
                         break
                     }
@@ -426,16 +420,16 @@ struct ServerListView: View {
         return filtered
     }
 
-    @ViewBuilder private var discoveredServersSection: some View {
+    private var discoveredServersSection: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.medium) {
             // Header
-            discoveryHeader
+            self.discoveryHeader
 
             // Content
-            if filteredDiscoveredServers.isEmpty && discoveryService.isDiscovering {
-                searchingView
-            } else if !filteredDiscoveredServers.isEmpty {
-                discoveredServersList
+            if self.filteredDiscoveredServers.isEmpty, self.discoveryService.isDiscovering {
+                self.searchingView
+            } else if !self.filteredDiscoveredServers.isEmpty {
+                self.discoveredServersList
             }
         }
     }
@@ -448,7 +442,7 @@ struct ServerListView: View {
 
             Spacer()
 
-            if discoveryService.isDiscovering {
+            if self.discoveryService.isDiscovering {
                 ProgressView()
                     .scaleEffect(0.7)
             }
@@ -469,26 +463,26 @@ struct ServerListView: View {
 
     private var discoveredServersList: some View {
         VStack(spacing: Theme.Spacing.small) {
-            ForEach(Array(filteredDiscoveredServers.prefix(3))) { server in
+            ForEach(Array(self.filteredDiscoveredServers.prefix(3))) { server in
                 DiscoveredServerCard(
-                    server: server
-                ) {
-                    connectToDiscoveredServer(server)
+                    server: server)
+                {
+                    self.connectToDiscoveredServer(server)
                 }
             }
 
-            if filteredDiscoveredServers.count > 3 {
-                viewMoreButton
+            if self.filteredDiscoveredServers.count > 3 {
+                self.viewMoreButton
             }
         }
     }
 
     private var viewMoreButton: some View {
         Button {
-            showingDiscoverySheet = true
+            self.showingDiscoverySheet = true
         } label: {
             HStack {
-                Text("View \(filteredDiscoveredServers.count - 3) more...")
+                Text("View \(self.filteredDiscoveredServers.count - 3) more...")
                     .font(Theme.Typography.terminalSystem(size: 14))
                 Image(systemName: "chevron.right")
                     .font(.system(size: 12))
@@ -500,7 +494,7 @@ struct ServerListView: View {
 
     // MARK: - Tailscale Servers Section
 
-    @ViewBuilder private var tailscaleServersSection: some View {
+    private var tailscaleServersSection: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.medium) {
             // Header
             HStack {
@@ -510,13 +504,13 @@ struct ServerListView: View {
 
                 Spacer()
 
-                if tailscaleDiscovery.isDiscovering {
+                if self.tailscaleDiscovery.isDiscovering {
                     ProgressView()
                         .scaleEffect(0.7)
                 } else {
                     Button {
                         Task {
-                            await tailscaleDiscovery.refresh()
+                            await self.tailscaleDiscovery.refresh()
                         }
                     } label: {
                         Image(systemName: "arrow.clockwise")
@@ -527,14 +521,14 @@ struct ServerListView: View {
             }
 
             // Content
-            if !tailscaleService.isInstalled {
+            if !self.tailscaleService.isInstalled {
                 VStack(alignment: .leading, spacing: Theme.Spacing.small) {
                     Text("Tailscale not installed")
                         .font(Theme.Typography.terminalSystem(size: 14))
                         .foregroundColor(Theme.Colors.secondaryText)
                     Button {
-                        settingsInitialTab = .tailscale
-                        showingSettings = true
+                        self.settingsInitialTab = .tailscale
+                        self.showingSettings = true
                     } label: {
                         Text("Configure Tailscale →")
                             .font(Theme.Typography.terminalSystem(size: 14))
@@ -542,14 +536,14 @@ struct ServerListView: View {
                     }
                 }
                 .padding(Theme.Spacing.medium)
-            } else if !tailscaleService.isRunning {
+            } else if !self.tailscaleService.isRunning {
                 VStack(alignment: .leading, spacing: Theme.Spacing.small) {
                     Text("Tailscale not running")
                         .font(Theme.Typography.terminalSystem(size: 14))
                         .foregroundColor(Theme.Colors.secondaryText)
                     Button {
-                        settingsInitialTab = .tailscale
-                        showingSettings = true
+                        self.settingsInitialTab = .tailscale
+                        self.showingSettings = true
                     } label: {
                         Text("Open Tailscale Settings →")
                             .font(Theme.Typography.terminalSystem(size: 14))
@@ -557,7 +551,7 @@ struct ServerListView: View {
                     }
                 }
                 .padding(Theme.Spacing.medium)
-            } else if tailscaleDiscovery.discoveredServers.isEmpty && tailscaleDiscovery.isDiscovering {
+            } else if self.tailscaleDiscovery.discoveredServers.isEmpty, self.tailscaleDiscovery.isDiscovering {
                 HStack {
                     Text("Searching for Tailscale servers...")
                         .font(Theme.Typography.terminalSystem(size: 14))
@@ -565,10 +559,10 @@ struct ServerListView: View {
                     Spacer()
                 }
                 .padding(Theme.Spacing.medium)
-            } else if !tailscaleDiscovery.discoveredServers.isEmpty {
-                let filteredServers = tailscaleDiscovery.discoveredServers.filter { server in
+            } else if !self.tailscaleDiscovery.discoveredServers.isEmpty {
+                let filteredServers = self.tailscaleDiscovery.discoveredServers.filter { server in
                     // Check if this server is already saved
-                    !viewModel.profiles.contains { profile in
+                    !self.viewModel.profiles.contains { profile in
                         // Match by Tailscale hostname
                         if let profileTailscaleHostname = profile.tailscaleHostname,
                            profileTailscaleHostname == server.hostname
@@ -585,7 +579,7 @@ struct ServerListView: View {
                         }
 
                         // Match by regular host/port combination
-                        if profile.host == (server.ip ?? server.hostname) && profile.port == server.port {
+                        if profile.host == (server.ip ?? server.hostname), profile.port == server.port {
                             return true
                         }
 
@@ -597,9 +591,9 @@ struct ServerListView: View {
                     VStack(spacing: Theme.Spacing.small) {
                         ForEach(filteredServers) { server in
                             TailscaleServerCard(
-                                server: server
-                            ) {
-                                addTailscaleServer(server)
+                                server: server)
+                            {
+                                self.addTailscaleServer(server)
                             }
                         }
                     }
@@ -616,27 +610,47 @@ struct ServerListView: View {
             "http://\(server.ip ?? server.hostname):\(server.port)"
         }
 
-        let profile = ServerProfile(
-            id: UUID(),
-            name: server.displayName,
-            url: url,
-            host: server.ip ?? server.hostname,
-            port: server.port,
-            tailscaleHostname: server.hostname,
-            tailscaleIP: server.ip,
-            isTailscaleEnabled: true,
-            preferTailscale: true,
-            httpsAvailable: server.httpsUrl != nil,
-            isPublic: server.isPublic,
-            preferSSL: server.httpsUrl != nil
-        )
+        // Check for existing profile with the same Tailscale hostname — update it
+        // instead of creating a duplicate.
+        let existingProfile = self.viewModel.profiles.first { $0.tailscaleHostname == server.hostname }
+
+        var profile: ServerProfile
+        if var existing = existingProfile {
+            existing.url = url
+            existing.host = server.ip ?? server.hostname
+            existing.port = server.port
+            existing.tailscaleIP = server.ip
+            existing.httpsAvailable = server.httpsUrl != nil
+            existing.isPublic = server.isPublic
+            existing.preferSSL = server.httpsUrl != nil
+            existing.updatedAt = Date()
+            profile = existing
+        } else {
+            profile = ServerProfile(
+                id: UUID(),
+                name: server.displayName,
+                url: url,
+                host: server.ip ?? server.hostname,
+                port: server.port,
+                tailscaleHostname: server.hostname,
+                tailscaleIP: server.ip,
+                isTailscaleEnabled: true,
+                preferTailscale: true,
+                httpsAvailable: server.httpsUrl != nil,
+                isPublic: server.isPublic,
+                preferSSL: server.httpsUrl != nil)
+        }
 
         Task {
             do {
-                try await viewModel.addProfile(profile, password: nil)
-                tailscaleDiscovery.addKnownServer(hostname: server.hostname)
+                if existingProfile != nil {
+                    try await self.viewModel.updateProfile(profile)
+                } else {
+                    try await self.viewModel.addProfile(profile, password: nil)
+                }
+                self.tailscaleDiscovery.addKnownServer(hostname: server.hostname)
             } catch {
-                logger.error("Failed to save Tailscale server: \(error)")
+                self.logger.error("Failed to save Tailscale server: \(error)")
             }
         }
     }
@@ -645,13 +659,13 @@ struct ServerListView: View {
 
     private func connectToProfile(_ profile: ServerProfile) {
         Task {
-            await viewModel.initiateConnectionToProfile(profile)
+            await self.viewModel.initiateConnectionToProfile(profile)
         }
     }
 
     private func connectToDiscoveredServer(_ server: DiscoveredServer) {
         // Use item binding to ensure server data is available when sheet opens
-        serverToAdd = server
+        self.serverToAdd = server
     }
 }
 
@@ -670,7 +684,7 @@ struct ServerProfileCard: View {
     var body: some View {
         HStack(spacing: Theme.Spacing.medium) {
             // Icon
-            Image(systemName: profile.iconSymbol)
+            Image(systemName: self.profile.iconSymbol)
                 .font(.system(size: 24))
                 .foregroundColor(Theme.Colors.primaryAccent)
                 .frame(width: 40, height: 40)
@@ -680,18 +694,18 @@ struct ServerProfileCard: View {
             // Server Info
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 4) {
-                    Text(profile.name)
+                    Text(self.profile.name)
                         .font(Theme.Typography.terminalSystem(size: 16, weight: .medium))
                         .foregroundColor(Theme.Colors.terminalForeground)
 
-                    if profile.isPublic {
+                    if self.profile.isPublic {
                         // Public (Funnel) indicator
                         Text("🌐")
                             .font(.system(size: 12))
                     }
 
                     // Tailscale indicator
-                    if profile.isTailscaleEnabled {
+                    if self.profile.isTailscaleEnabled {
                         Text("🔗")
                             .font(.system(size: 12))
                     }
@@ -700,7 +714,7 @@ struct ServerProfileCard: View {
                 // Show appropriate URL with security indicator
                 HStack(spacing: 4) {
                     // Security indicators next to URL
-                    if profile.httpsAvailable && profile.preferSSL {
+                    if self.profile.httpsAvailable, self.profile.preferSSL {
                         // HTTPS/SSL indicator - locked
                         Image(systemName: "lock.fill")
                             .font(.system(size: 10))
@@ -713,12 +727,12 @@ struct ServerProfileCard: View {
                     }
 
                     // Show appropriate URL based on Tailscale status
-                    if profile.preferTailscale && profile.tailscaleHostname != nil {
-                        Text(profile.tailscaleHostname ?? profile.url)
+                    if self.profile.preferTailscale, self.profile.tailscaleHostname != nil {
+                        Text(self.profile.tailscaleHostname ?? self.profile.url)
                             .font(Theme.Typography.terminalSystem(size: 12))
                             .foregroundColor(Theme.Colors.secondaryText)
                     } else {
-                        Text(profile.url)
+                        Text(self.profile.url)
                             .font(Theme.Typography.terminalSystem(size: 12))
                             .foregroundColor(Theme.Colors.secondaryText)
                     }
@@ -735,16 +749,16 @@ struct ServerProfileCard: View {
 
             // Action Buttons
             HStack(spacing: Theme.Spacing.small) {
-                Button(action: onEdit) {
+                Button(action: self.onEdit) {
                     Image(systemName: "ellipsis.circle")
                         .font(.system(size: 20))
                         .foregroundColor(Theme.Colors.secondaryText)
                 }
                 .buttonStyle(.plain)
 
-                Button(action: onConnect) {
+                Button(action: self.onConnect) {
                     HStack(spacing: 4) {
-                        if isLoading {
+                        if self.isLoading {
                             ProgressView()
                                 .scaleEffect(0.8)
                         } else {
@@ -757,7 +771,7 @@ struct ServerProfileCard: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.borderless)
-                .disabled(isLoading)
+                .disabled(self.isLoading)
             }
         }
         .padding(Theme.Spacing.medium)
@@ -765,13 +779,12 @@ struct ServerProfileCard: View {
         .cornerRadius(Theme.CornerRadius.card)
         .overlay(
             RoundedRectangle(cornerRadius: Theme.CornerRadius.card)
-                .stroke(Theme.Colors.cardBorder, lineWidth: 1)
-        )
-        .scaleEffect(isPressed ? 0.98 : 1.0)
-        .animation(.easeInOut(duration: 0.1), value: isPressed)
+                .stroke(Theme.Colors.cardBorder, lineWidth: 1))
+        .scaleEffect(self.isPressed ? 0.98 : 1.0)
+        .animation(.easeInOut(duration: 0.1), value: self.isPressed)
         .contentShape(Rectangle())
         .onTapGesture {
-            onConnect()
+            self.onConnect()
         }
     }
 }
@@ -786,22 +799,22 @@ struct TailscaleServerCard: View {
     var body: some View {
         HStack(spacing: Theme.Spacing.medium) {
             // Icon
-            Image(systemName: server.isPublic ? "globe.badge.chevron.backward" : "lock.shield.fill")
+            Image(systemName: self.server.isPublic ? "globe.badge.chevron.backward" : "lock.shield.fill")
                 .font(.system(size: 24))
-                .foregroundColor(server.isPublic ? .purple : .blue)
+                .foregroundColor(self.server.isPublic ? .purple : .blue)
                 .frame(width: 40, height: 40)
-                .background((server.isPublic ? Color.purple : Color.blue).opacity(0.1))
+                .background((self.server.isPublic ? Color.purple : Color.blue).opacity(0.1))
                 .cornerRadius(Theme.CornerRadius.small)
 
             // Server Info
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 4) {
-                    Text(server.displayName)
+                    Text(self.server.displayName)
                         .font(Theme.Typography.terminalSystem(size: 16, weight: .medium))
                         .foregroundColor(Theme.Colors.terminalForeground)
 
                     // Show public/private indicator
-                    if server.isPublic {
+                    if self.server.isPublic {
                         Text("Public")
                             .font(Theme.Typography.terminalSystem(size: 10))
                             .fontWeight(.semibold)
@@ -831,16 +844,18 @@ struct TailscaleServerCard: View {
                     // Always show HTTP connection info
                     HStack(spacing: 8) {
                         if let ip = server.ip {
-                            Text("\(ip):\(String(server.port))")
+                            Text("\(ip):\(String(self.server.port))")
                                 .font(Theme.Typography.terminalSystem(size: 12))
-                                .foregroundColor(Theme.Colors.secondaryText.opacity(server.httpsUrl != nil ? 0.7 : 1.0))
+                                .foregroundColor(Theme.Colors.secondaryText
+                                    .opacity(self.server.httpsUrl != nil ? 0.7 : 1.0))
                         } else {
-                            Text("\(server.hostname):\(String(server.port))")
+                            Text("\(self.server.hostname):\(String(self.server.port))")
                                 .font(Theme.Typography.terminalSystem(size: 12))
-                                .foregroundColor(Theme.Colors.secondaryText.opacity(server.httpsUrl != nil ? 0.7 : 1.0))
+                                .foregroundColor(Theme.Colors.secondaryText
+                                    .opacity(self.server.httpsUrl != nil ? 0.7 : 1.0))
                         }
 
-                        if server.isReachable {
+                        if self.server.isReachable {
                             Circle()
                                 .fill(Color.green)
                                 .frame(width: 6, height: 6)
@@ -856,15 +871,15 @@ struct TailscaleServerCard: View {
             Spacer()
 
             // Add Button
-            if isAdded {
+            if self.isAdded {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.system(size: 20))
                     .foregroundColor(.green)
             } else {
                 Button {
                     withAnimation {
-                        isAdded = true
-                        onAdd()
+                        self.isAdded = true
+                        self.onAdd()
                     }
                 } label: {
                     Text("Add")
@@ -883,8 +898,7 @@ struct TailscaleServerCard: View {
         .cornerRadius(Theme.CornerRadius.medium)
         .overlay(
             RoundedRectangle(cornerRadius: Theme.CornerRadius.medium)
-                .stroke(server.isPublic ? Color.purple.opacity(0.3) : Color.blue.opacity(0.3), lineWidth: 1)
-        )
+                .stroke(self.server.isPublic ? Color.purple.opacity(0.3) : Color.blue.opacity(0.3), lineWidth: 1))
     }
 }
 

--- a/ios/VibeTunnel/Views/Sessions/SessionCardView.swift
+++ b/ios/VibeTunnel/Views/Sessions/SessionCardView.swift
@@ -231,7 +231,7 @@ struct SessionCardView: View {
 
     // MARK: - View Components
 
-    @ViewBuilder private var commandInfoView: some View {
+    private var commandInfoView: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 4) {
                 Text("$")

--- a/ios/VibeTunnel/Views/Sessions/SessionListView.swift
+++ b/ios/VibeTunnel/Views/Sessions/SessionListView.swift
@@ -510,8 +510,13 @@ struct SessionHeaderView: View {
     let onKillAll: () -> Void
     let onCleanupAll: () -> Void
 
-    private var runningCount: Int { self.sessions.count { $0.isRunning } }
-    private var exitedCount: Int { self.sessions.count { !$0.isRunning } }
+    private var runningCount: Int {
+        self.sessions.count { $0.isRunning }
+    }
+
+    private var exitedCount: Int {
+        self.sessions.count { !$0.isRunning }
+    }
 
     var body: some View {
         VStack(spacing: Theme.Spacing.medium) {

--- a/ios/VibeTunnel/Views/Settings/SettingsView.swift
+++ b/ios/VibeTunnel/Views/Settings/SettingsView.swift
@@ -26,7 +26,9 @@ struct SettingsView: View {
         case advanced = "Advanced"
         case about = "About"
 
-        var id: String { self.rawValue }
+        var id: String {
+            self.rawValue
+        }
 
         var icon: String {
             switch self {
@@ -61,7 +63,8 @@ struct SettingsView: View {
                                 self.selectedTab.wrappedValue == tab ? Theme.Colors.primaryAccent : Theme.Colors
                                     .terminalForeground.opacity(0.5))
                             .background(
-                                self.selectedTab.wrappedValue == tab ? Theme.Colors.primaryAccent.opacity(0.1) : Color.clear)
+                                self.selectedTab.wrappedValue == tab ? Theme.Colors.primaryAccent.opacity(0.1) : Color
+                                    .clear)
                         }
                         .buttonStyle(PlainButtonStyle())
                     }
@@ -115,7 +118,9 @@ struct SettingsView: View {
 
 #if DEBUG
 extension SettingsView {
-    var test_selectedTab: Binding<SettingsTab> { self.selectedTab }
+    var test_selectedTab: Binding<SettingsTab> {
+        self.selectedTab
+    }
 }
 #endif
 

--- a/ios/VibeTunnel/Views/Settings/TailscaleSettingsView.swift
+++ b/ios/VibeTunnel/Views/Settings/TailscaleSettingsView.swift
@@ -20,20 +20,20 @@ struct TailscaleSettingsContent: View {
 
     var body: some View {
         VStack(spacing: Theme.Spacing.large) {
-            statusSection
-            settingsSection
-            discoverySection
-            aboutSection
-            if tailscaleService.isConfigured {
-                resetSection
+            self.statusSection
+            self.settingsSection
+            self.discoverySection
+            self.aboutSection
+            if self.tailscaleService.isConfigured {
+                self.resetSection
             }
             Spacer()
         }
         .task {
-            await refreshStatus()
+            await self.refreshStatus()
             // Start auto-refresh if enabled
-            if enableDiscovery && autoRefresh && tailscaleService.isRunning {
-                discoveryService.startAutoRefresh()
+            if self.enableDiscovery, self.autoRefresh, self.tailscaleService.isRunning {
+                self.discoveryService.startAutoRefresh()
             }
         }
         .onDisappear {
@@ -41,19 +41,18 @@ struct TailscaleSettingsContent: View {
             // because it should continue running in the background
         }
         .refreshable {
-            await refreshStatus()
+            await self.refreshStatus()
         }
-        .alert("Reset Tailscale Configuration", isPresented: $showingResetConfirmation) {
+        .alert("Reset Tailscale Configuration", isPresented: self.$showingResetConfirmation) {
             Button("Cancel", role: .cancel) {}
             Button("Reset", role: .destructive) {
-                resetConfiguration()
+                self.resetConfiguration()
             }
         } message: {
             Text(
-                "This will remove your API credentials and clear all discovered servers. You'll need to reconfigure Tailscale to use it again."
-            )
+                "This will remove your API credentials and clear all discovered servers. You'll need to reconfigure Tailscale to use it again.")
         }
-        .sheet(isPresented: $showingCredentialsInput) {
+        .sheet(isPresented: self.$showingCredentialsInput) {
             NavigationStack {
                 Form {
                     Section {
@@ -100,7 +99,7 @@ struct TailscaleSettingsContent: View {
                     }
 
                     Section {
-                        TextField("k4cdcxxxxxxxx", text: $clientIdInput)
+                        TextField("k4cdcxxxxxxxx", text: self.$clientIdInput)
                             .textFieldStyle(.roundedBorder)
                             .autocapitalization(.none)
                             .disableAutocorrection(true)
@@ -113,7 +112,7 @@ struct TailscaleSettingsContent: View {
                     }
 
                     Section {
-                        SecureField("tskey-client-...", text: $clientSecretInput)
+                        SecureField("tskey-client-...", text: self.$clientSecretInput)
                             .textFieldStyle(.roundedBorder)
                             .autocapitalization(.none)
                             .disableAutocorrection(true)
@@ -136,7 +135,7 @@ struct TailscaleSettingsContent: View {
                     }
 
                     // Show loading state when saving
-                    if isSavingCredentials {
+                    if self.isSavingCredentials {
                         Section {
                             HStack {
                                 ProgressView()
@@ -167,53 +166,54 @@ struct TailscaleSettingsContent: View {
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
                         Button("Cancel") {
-                            showingCredentialsInput = false
+                            self.showingCredentialsInput = false
                         }
                     }
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Button("Save") {
                             // Clear any previous error
-                            credentialSaveError = nil
+                            self.credentialSaveError = nil
 
                             // Save credentials (using legacy property names for compatibility)
-                            tailscaleService.organization = clientIdInput.isEmpty ? nil : clientIdInput
-                            tailscaleService.apiKey = clientSecretInput.isEmpty ? nil : clientSecretInput
+                            self.tailscaleService.organization = self.clientIdInput.isEmpty ? nil : self.clientIdInput
+                            self.tailscaleService.apiKey = self.clientSecretInput.isEmpty ? nil : self.clientSecretInput
 
                             // Start async task to validate and fetch data
                             Task {
                                 // Show loading state
-                                isSavingCredentials = true
+                                self.isSavingCredentials = true
 
                                 // Validate credentials and fetch devices
-                                await tailscaleService.refreshStatus()
+                                await self.tailscaleService.refreshStatus()
 
                                 // If successful, start discovery
-                                if tailscaleService.isRunning {
-                                    if enableDiscovery {
+                                if self.tailscaleService.isRunning {
+                                    if self.enableDiscovery {
                                         // Start discovery to find VibeTunnel servers
-                                        discoveryService.startDiscovery()
+                                        self.discoveryService.startDiscovery()
 
                                         // Wait a moment for discovery to complete
                                         try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
 
                                         // Start auto-refresh if enabled
-                                        if autoRefresh {
-                                            discoveryService.startAutoRefresh()
+                                        if self.autoRefresh {
+                                            self.discoveryService.startAutoRefresh()
                                         }
                                     }
 
                                     // Success! Clear loading state and dismiss
-                                    isSavingCredentials = false
-                                    showingCredentialsInput = false
+                                    self.isSavingCredentials = false
+                                    self.showingCredentialsInput = false
                                 } else {
                                     // If credentials are invalid, show error
-                                    isSavingCredentials = false
-                                    credentialSaveError = tailscaleService.statusError ?? "Failed to connect to Tailscale"
+                                    self.isSavingCredentials = false
+                                    self.credentialSaveError = self.tailscaleService.statusError ?? "Failed to connect to Tailscale"
                                 }
                             }
                         }
                         .fontWeight(.semibold)
-                        .disabled(clientIdInput.isEmpty || clientSecretInput.isEmpty || isSavingCredentials)
+                        .disabled(self.clientIdInput.isEmpty || self.clientSecretInput.isEmpty || self
+                            .isSavingCredentials)
                     }
                 }
             }
@@ -223,7 +223,6 @@ struct TailscaleSettingsContent: View {
 
     // MARK: - Sections
 
-    @ViewBuilder
     var statusSection: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.medium) {
             Text("Tailscale Configuration")
@@ -234,10 +233,10 @@ struct TailscaleSettingsContent: View {
                 HStack {
                     Label("Connection", systemImage: "network")
                     Spacer()
-                    statusView
+                    self.statusView
                 }
 
-                if tailscaleService.isRunning {
+                if self.tailscaleService.isRunning {
                     if let tailnet = tailscaleService.tailnetName {
                         HStack {
                             Label("Network", systemImage: "globe")
@@ -253,19 +252,19 @@ struct TailscaleSettingsContent: View {
                         Label("Devices", systemImage: "desktopcomputer")
                             .foregroundColor(.secondary)
                         Spacer()
-                        Text("\(tailscaleService.devices.count)")
+                        Text("\(self.tailscaleService.devices.count)")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
                 }
 
-                if !tailscaleService.isConfigured {
+                if !self.tailscaleService.isConfigured {
                     Divider()
 
                     Button {
-                        showingCredentialsInput = true
-                        clientIdInput = tailscaleService.organization ?? ""
-                        clientSecretInput = tailscaleService.apiKey ?? ""
+                        self.showingCredentialsInput = true
+                        self.clientIdInput = self.tailscaleService.organization ?? ""
+                        self.clientSecretInput = self.tailscaleService.apiKey ?? ""
                     } label: {
                         HStack {
                             Image(systemName: "key.fill")
@@ -288,9 +287,9 @@ struct TailscaleSettingsContent: View {
                             .font(.caption)
                             .foregroundColor(.green)
                         Button {
-                            showingCredentialsInput = true
-                            clientIdInput = tailscaleService.organization ?? ""
-                            clientSecretInput = tailscaleService.apiKey ?? ""
+                            self.showingCredentialsInput = true
+                            self.clientIdInput = self.tailscaleService.organization ?? ""
+                            self.clientSecretInput = self.tailscaleService.apiKey ?? ""
                         } label: {
                             Image(systemName: "pencil.circle")
                                 .font(.system(size: 16))
@@ -299,19 +298,19 @@ struct TailscaleSettingsContent: View {
                     }
 
                     // Add refresh button if not connected
-                    if !tailscaleService.isRunning {
+                    if !self.tailscaleService.isRunning {
                         Divider()
                         Button {
                             Task {
-                                isRefreshing = true
-                                await tailscaleService.refreshStatus()
-                                isRefreshing = false
+                                self.isRefreshing = true
+                                await self.tailscaleService.refreshStatus()
+                                self.isRefreshing = false
 
                                 // Start discovery if connected
-                                if tailscaleService.isRunning && enableDiscovery {
-                                    discoveryService.startDiscovery()
-                                    if autoRefresh {
-                                        discoveryService.startAutoRefresh()
+                                if self.tailscaleService.isRunning, self.enableDiscovery {
+                                    self.discoveryService.startDiscovery()
+                                    if self.autoRefresh {
+                                        self.discoveryService.startAutoRefresh()
                                     }
                                 }
                             }
@@ -322,14 +321,14 @@ struct TailscaleSettingsContent: View {
                                 Text("Retry Connection")
                                     .font(.system(size: 16))
                                 Spacer()
-                                if isRefreshing {
+                                if self.isRefreshing {
                                     ProgressView()
                                         .scaleEffect(0.8)
                                 }
                             }
                             .foregroundColor(.accentColor)
                         }
-                        .disabled(isRefreshing)
+                        .disabled(self.isRefreshing)
                     }
                 }
 
@@ -352,7 +351,6 @@ struct TailscaleSettingsContent: View {
         }
     }
 
-    @ViewBuilder
     var settingsSection: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.medium) {
             Text("Connection Preferences")
@@ -360,47 +358,47 @@ struct TailscaleSettingsContent: View {
                 .foregroundColor(Theme.Colors.terminalForeground)
 
             VStack(spacing: 0) {
-                Toggle(isOn: $enableDiscovery) {
+                Toggle(isOn: self.$enableDiscovery) {
                     Label("Auto-Discover Servers", systemImage: "magnifyingglass")
                 }
                 .toggleStyle(SwitchToggleStyle(tint: Theme.Colors.primaryAccent))
                 .padding()
-                .onChange(of: enableDiscovery) { _, newValue in
+                .onChange(of: self.enableDiscovery) { _, newValue in
                     if newValue {
                         Task {
-                            discoveryService.startDiscovery()
-                            if autoRefresh {
-                                discoveryService.startAutoRefresh()
+                            self.discoveryService.startDiscovery()
+                            if self.autoRefresh {
+                                self.discoveryService.startAutoRefresh()
                             }
                         }
                     } else {
-                        discoveryService.stopDiscovery()
-                        discoveryService.stopAutoRefresh()
+                        self.discoveryService.stopDiscovery()
+                        self.discoveryService.stopAutoRefresh()
                     }
                 }
 
                 Divider()
 
-                Toggle(isOn: $preferTailscale) {
+                Toggle(isOn: self.$preferTailscale) {
                     Label("Prefer Tailscale Connections", systemImage: "lock.shield")
                 }
                 .toggleStyle(SwitchToggleStyle(tint: Theme.Colors.primaryAccent))
                 .padding()
-                .disabled(!tailscaleService.isRunning)
+                .disabled(!self.tailscaleService.isRunning)
 
                 Divider()
 
-                Toggle(isOn: $autoRefresh) {
+                Toggle(isOn: self.$autoRefresh) {
                     Label("Auto-Refresh Discovery", systemImage: "arrow.triangle.2.circlepath")
                 }
                 .toggleStyle(SwitchToggleStyle(tint: Theme.Colors.primaryAccent))
                 .padding()
-                .disabled(!enableDiscovery)
-                .onChange(of: autoRefresh) { _, newValue in
-                    if newValue && enableDiscovery {
-                        discoveryService.startAutoRefresh()
+                .disabled(!self.enableDiscovery)
+                .onChange(of: self.autoRefresh) { _, newValue in
+                    if newValue, self.enableDiscovery {
+                        self.discoveryService.startAutoRefresh()
                     } else {
-                        discoveryService.stopAutoRefresh()
+                        self.discoveryService.stopAutoRefresh()
                     }
                 }
             }
@@ -412,7 +410,7 @@ struct TailscaleSettingsContent: View {
                     .font(.caption)
                     .foregroundColor(Theme.Colors.terminalForeground.opacity(0.6))
 
-                if autoRefresh && enableDiscovery && discoveryService.isAutoRefreshing {
+                if self.autoRefresh, self.enableDiscovery, self.discoveryService.isAutoRefreshing {
                     Text("• Auto-refreshing every 30 seconds")
                         .font(.caption)
                         .foregroundColor(.green.opacity(0.8))
@@ -424,7 +422,7 @@ struct TailscaleSettingsContent: View {
 
     @ViewBuilder
     var discoverySection: some View {
-        if enableDiscovery && tailscaleService.isRunning {
+        if self.enableDiscovery, self.tailscaleService.isRunning {
             VStack(alignment: .leading, spacing: Theme.Spacing.medium) {
                 HStack {
                     Text("Discovered Servers")
@@ -433,7 +431,7 @@ struct TailscaleSettingsContent: View {
 
                     Spacer()
 
-                    if discoveryService.isAutoRefreshing {
+                    if self.discoveryService.isAutoRefreshing {
                         HStack(spacing: 4) {
                             Image(systemName: "arrow.triangle.2.circlepath")
                                 .font(.caption)
@@ -446,7 +444,7 @@ struct TailscaleSettingsContent: View {
                 }
 
                 VStack(spacing: Theme.Spacing.small) {
-                    if discoveryService.isDiscovering {
+                    if self.discoveryService.isDiscovering {
                         HStack {
                             ProgressView()
                                 .scaleEffect(0.8)
@@ -454,13 +452,13 @@ struct TailscaleSettingsContent: View {
                                 .foregroundColor(.secondary)
                         }
                         .padding()
-                    } else if discoveryService.discoveredServers.isEmpty {
+                    } else if self.discoveryService.discoveredServers.isEmpty {
                         Text("No VibeTunnel servers found on Tailscale network")
                             .foregroundColor(.secondary)
                             .font(.caption)
                             .padding()
                     } else {
-                        ForEach(discoveryService.discoveredServers) { server in
+                        ForEach(self.discoveryService.discoveredServers) { server in
                             DiscoveredTailscaleServerRow(server: server)
                                 .padding(.horizontal)
                                 .padding(.vertical, 8)
@@ -469,19 +467,19 @@ struct TailscaleSettingsContent: View {
 
                     Button {
                         Task {
-                            await discoveryService.refresh()
+                            await self.discoveryService.refresh()
                         }
                     } label: {
                         Label("Refresh Servers", systemImage: "arrow.clockwise")
                     }
-                    .disabled(discoveryService.isDiscovering)
+                    .disabled(self.discoveryService.isDiscovering)
                     .padding()
                 }
                 .background(Theme.Colors.cardBackground)
                 .cornerRadius(Theme.CornerRadius.card)
 
-                if !discoveryService.discoveredServers.isEmpty {
-                    Text("\(discoveryService.discoveredServers.count) server(s) found on your Tailscale network")
+                if !self.discoveryService.discoveredServers.isEmpty {
+                    Text("\(self.discoveryService.discoveredServers.count) server(s) found on your Tailscale network")
                         .font(.caption)
                         .foregroundColor(Theme.Colors.terminalForeground.opacity(0.6))
                         .padding(.horizontal)
@@ -490,7 +488,6 @@ struct TailscaleSettingsContent: View {
         }
     }
 
-    @ViewBuilder
     var aboutSection: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.medium) {
             Text("Resources")
@@ -530,15 +527,13 @@ struct TailscaleSettingsContent: View {
             .cornerRadius(Theme.CornerRadius.card)
 
             Text(
-                "Tailscale provides secure, private networking between your devices without port forwarding or complex configuration."
-            )
-            .font(.caption)
-            .foregroundColor(Theme.Colors.terminalForeground.opacity(0.6))
-            .padding(.horizontal)
+                "Tailscale provides secure, private networking between your devices without port forwarding or complex configuration.")
+                .font(.caption)
+                .foregroundColor(Theme.Colors.terminalForeground.opacity(0.6))
+                .padding(.horizontal)
         }
     }
 
-    @ViewBuilder
     var resetSection: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.medium) {
             Text("Danger Zone")
@@ -547,7 +542,7 @@ struct TailscaleSettingsContent: View {
 
             VStack(spacing: 0) {
                 Button {
-                    showingResetConfirmation = true
+                    self.showingResetConfirmation = true
                 } label: {
                     HStack {
                         Label("Reset Tailscale Configuration", systemImage: "trash")
@@ -564,8 +559,7 @@ struct TailscaleSettingsContent: View {
             .cornerRadius(Theme.CornerRadius.card)
             .overlay(
                 RoundedRectangle(cornerRadius: Theme.CornerRadius.card)
-                    .stroke(Color.red.opacity(0.3), lineWidth: 1)
-            )
+                    .stroke(Color.red.opacity(0.3), lineWidth: 1))
 
             Text("Removes all Tailscale credentials and discovered servers")
                 .font(.caption)
@@ -578,14 +572,14 @@ struct TailscaleSettingsContent: View {
 
     @ViewBuilder
     var statusView: some View {
-        if isRefreshing {
+        if self.isRefreshing {
             ProgressView()
                 .scaleEffect(0.8)
-        } else if !tailscaleService.isConfigured {
+        } else if !self.tailscaleService.isConfigured {
             Label("Not Configured", systemImage: "xmark.circle.fill")
                 .foregroundColor(.red)
                 .font(.caption)
-        } else if tailscaleService.isRunning {
+        } else if self.tailscaleService.isRunning {
             Label("Connected", systemImage: "checkmark.circle.fill")
                 .foregroundColor(.green)
                 .font(.caption)
@@ -599,45 +593,45 @@ struct TailscaleSettingsContent: View {
     // MARK: - Methods
 
     func refreshStatus() async {
-        isRefreshing = true
-        await tailscaleService.refreshStatus()
+        self.isRefreshing = true
+        await self.tailscaleService.refreshStatus()
 
-        if enableDiscovery && tailscaleService.isRunning {
-            await discoveryService.refresh()
+        if self.enableDiscovery, self.tailscaleService.isRunning {
+            await self.discoveryService.refresh()
         }
 
-        isRefreshing = false
+        self.isRefreshing = false
     }
 
     private func resetConfiguration() {
         // Clear all Tailscale credentials
-        tailscaleService.clearCredentials()
+        self.tailscaleService.clearCredentials()
 
         // Reset discovery environment
-        discoveryService.resetEnvironment()
+        self.discoveryService.resetEnvironment()
 
         // Reset settings to defaults
-        enableDiscovery = true
-        preferTailscale = false
-        autoRefresh = true
+        self.enableDiscovery = true
+        self.preferTailscale = false
+        self.autoRefresh = true
 
         // Clear input fields
-        clientIdInput = ""
-        clientSecretInput = ""
+        self.clientIdInput = ""
+        self.clientSecretInput = ""
 
         // Force UI refresh by triggering state changes
         // This ensures the UI reflects the cleared state immediately
         Task { @MainActor in
             // Trigger a refresh to update UI
-            isRefreshing = true
+            self.isRefreshing = true
 
             // Small delay to ensure UI updates
             try? await Task.sleep(nanoseconds: 100_000_000) // 0.1 seconds
 
-            isRefreshing = false
+            self.isRefreshing = false
         }
 
-        logger.info("Tailscale configuration reset completed")
+        self.logger.info("Tailscale configuration reset completed")
     }
 }
 
@@ -650,7 +644,7 @@ struct DiscoveredTailscaleServerRow: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading) {
-                Text(server.displayName)
+                Text(self.server.displayName)
                     .font(.body)
 
                 HStack {
@@ -659,7 +653,7 @@ struct DiscoveredTailscaleServerRow: View {
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
-                    Text("Port \(String(server.port))")
+                    Text("Port \(String(self.server.port))")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -667,12 +661,12 @@ struct DiscoveredTailscaleServerRow: View {
 
             Spacer()
 
-            if isAdded {
+            if self.isAdded {
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundColor(.green)
             } else {
                 Button {
-                    addServer()
+                    self.addServer()
                 } label: {
                     Text("Add")
                         .font(.caption)
@@ -684,21 +678,21 @@ struct DiscoveredTailscaleServerRow: View {
                 }
             }
         }
-        .opacity(server.isReachable ? 1.0 : 0.6)
+        .opacity(self.server.isReachable ? 1.0 : 0.6)
     }
 
     private func addServer() {
         // Convert to ServerConfig and save
-        _ = TailscaleDiscoveryService.shared.serverConfig(from: server)
+        _ = TailscaleDiscoveryService.shared.serverConfig(from: self.server)
 
         // Add to known servers
-        TailscaleDiscoveryService.shared.addKnownServer(hostname: server.hostname)
+        TailscaleDiscoveryService.shared.addKnownServer(hostname: self.server.hostname)
 
         // Use HTTPS URL if available, otherwise construct HTTP URL
         let url: String = if let httpsUrl = server.httpsUrl {
             httpsUrl
         } else {
-            "http://\(server.ip ?? server.hostname):\(server.port)"
+            "http://\(self.server.ip ?? self.server.hostname):\(self.server.port)"
         }
 
         // Save as a server profile with complete info using the ServerProfile static method
@@ -706,27 +700,26 @@ struct DiscoveredTailscaleServerRow: View {
             id: UUID(),
             name: server.displayName,
             url: url,
-            host: server.ip ?? server.hostname,
-            port: server.port,
-            tailscaleHostname: server.hostname,
-            tailscaleIP: server.ip,
+            host: self.server.ip ?? self.server.hostname,
+            port: self.server.port,
+            tailscaleHostname: self.server.hostname,
+            tailscaleIP: self.server.ip,
             isTailscaleEnabled: true,
             preferTailscale: true,
-            httpsAvailable: server.httpsUrl != nil,
-            isPublic: server.isPublic,
-            preferSSL: server.httpsUrl != nil
-        )
+            httpsAvailable: self.server.httpsUrl != nil,
+            isPublic: self.server.isPublic,
+            preferSSL: self.server.httpsUrl != nil)
 
         // Use the proper ServerProfile.save method to ensure it's saved correctly
         ServerProfile.save(profile)
 
         withAnimation {
-            isAdded = true
+            self.isAdded = true
         }
 
         // Dismiss the settings view after a brief delay to show the checkmark
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            dismissSettings()
+            self.dismissSettings()
         }
     }
 }
@@ -743,7 +736,7 @@ struct TailscaleSettingsView: View {
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Button("Done") {
-                            dismiss()
+                            self.dismiss()
                         }
                     }
                 }

--- a/ios/VibeTunnel/Views/SystemLogsView.swift
+++ b/ios/VibeTunnel/Views/SystemLogsView.swift
@@ -23,7 +23,9 @@ struct SystemLogsView: View {
         case log = "Log"
         case debug = "Debug"
 
-        var displayName: String { rawValue }
+        var displayName: String {
+            rawValue
+        }
 
         func matches(_ line: String) -> Bool {
             switch self {

--- a/ios/VibeTunnel/Views/Terminal/CastPlayerView.swift
+++ b/ios/VibeTunnel/Views/Terminal/CastPlayerView.swift
@@ -225,8 +225,13 @@ class CastPlayerViewModel {
     var isSeeking = false
 
     var player: CastPlayer?
-    var header: CastFile? { self.player?.header }
-    var duration: TimeInterval { self.player?.duration ?? 0 }
+    var header: CastFile? {
+        self.player?.header
+    }
+
+    var duration: TimeInterval {
+        self.player?.duration ?? 0
+    }
 
     var onTerminalOutput: ((String) -> Void)?
     var onTerminalClear: (() -> Void)?

--- a/ios/VibeTunnel/Views/Terminal/GhosttyWebView.swift
+++ b/ios/VibeTunnel/Views/Terminal/GhosttyWebView.swift
@@ -59,6 +59,7 @@ struct GhosttyWebView: UIViewRepresentable {
         private var bufferRenderer = TerminalBufferRenderer()
         private var isReady = false
         private var pendingTerminalSize: TerminalSize?
+        private var pendingData: [(payload: String, followCursor: Bool)] = []
         private var lastTerminalSize: TerminalSize?
 
         init(_ parent: GhosttyWebView) {
@@ -233,10 +234,12 @@ struct GhosttyWebView: UIViewRepresentable {
             </html>
             """
 
+            // Try subdirectory first (folder reference), then bundle root (synchronized groups flatten)
             guard let ghosttyURL = Bundle.main.url(
                 forResource: "ghostty-web",
                 withExtension: "js",
                 subdirectory: "ghostty")
+                ?? Bundle.main.url(forResource: "ghostty-web", withExtension: "js")
             else {
                 self.logger.error("ghostty-web.js missing from bundle")
                 return
@@ -307,6 +310,14 @@ struct GhosttyWebView: UIViewRepresentable {
                 self.setTerminalSize(cols: size.cols, rows: size.rows)
                 self.pendingTerminalSize = nil
             }
+
+            // Flush any data that arrived before the terminal was ready
+            for item in self.pendingData {
+                self.webView?
+                    .evaluateJavaScript(
+                        "window.ghosttyAPI.writeToTerminal(\(item.payload), \(item.followCursor ? "true" : "false"))")
+            }
+            self.pendingData.removeAll()
         }
 
         func updateFontSize(_ size: CGFloat) {
@@ -329,6 +340,12 @@ struct GhosttyWebView: UIViewRepresentable {
         func feedData(_ data: String) {
             let followCursor = self.parent.viewModel?.isAutoScrollEnabled ?? true
             guard let payload = jsonString(data) else { return }
+
+            if !self.isReady {
+                self.pendingData.append((payload: payload, followCursor: followCursor))
+                return
+            }
+
             self.webView?
                 .evaluateJavaScript("window.ghosttyAPI.writeToTerminal(\(payload), \(followCursor ? "true" : "false"))")
         }
@@ -391,7 +408,7 @@ struct GhosttyWebView: UIViewRepresentable {
             return self.jsonString(fontFamily) ?? "\"monospace\""
         }
 
-        private func jsonString<T: Encodable>(_ value: T) -> String? {
+        private func jsonString(_ value: some Encodable) -> String? {
             guard let data = try? JSONEncoder().encode(value) else { return nil }
             return String(data: data, encoding: .utf8)
         }

--- a/ios/VibeTunnel/Views/Terminal/RecordingExportSheet.swift
+++ b/ios/VibeTunnel/Views/Terminal/RecordingExportSheet.swift
@@ -158,8 +158,7 @@ struct ShareSheet: UIViewControllerRepresentable {
     let items: [Any]
 
     func makeUIViewController(context: Context) -> UIActivityViewController {
-        let controller = UIActivityViewController(activityItems: items, applicationActivities: nil)
-        return controller
+        UIActivityViewController(activityItems: self.items, applicationActivities: nil)
     }
 
     func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}

--- a/ios/VibeTunnel/Views/Terminal/TerminalBufferPreview.swift
+++ b/ios/VibeTunnel/Views/Terminal/TerminalBufferPreview.swift
@@ -53,7 +53,6 @@ struct TerminalBufferPreview: View {
         .cornerRadius(Theme.CornerRadius.small)
     }
 
-    @ViewBuilder
     private func cellView(for cell: BufferCell) -> some View {
         Text(cell.char.isEmpty ? " " : cell.char)
             .font(Theme.Typography.terminalSystem(size: self.fontSize))

--- a/ios/VibeTunnel/Views/Terminal/TerminalView.swift
+++ b/ios/VibeTunnel/Views/Terminal/TerminalView.swift
@@ -268,13 +268,18 @@ struct TerminalView: View {
             self.selectedTheme.background
                 .ignoresSafeArea()
 
-            VStack(spacing: 0) {
+            ZStack {
+                // Always keep terminal rendered to preserve WKWebView/WASM state.
+                // Destroying and recreating GhosttyWebView loses all buffered terminal data.
+                self.terminalContent
+
+                // Overlay loading/error states on top of the terminal
                 if self.viewModel.isConnecting {
+                    self.selectedTheme.background
                     self.loadingView
                 } else if let error = viewModel.errorMessage {
+                    self.selectedTheme.background
                     self.errorView(error)
-                } else {
-                    self.terminalContent
                 }
             }
         }
@@ -643,32 +648,45 @@ class TerminalViewModel {
         self.connectionStatusTask?.cancel()
         self.connectionStatusTask = Task { [weak self] in
             guard let self else { return }
+            var hasConnectedOnce = false
+            var disconnectedAt: Date?
+            let disconnectGracePeriod: TimeInterval = 3.0
+
             while !Task.isCancelled {
                 let connected = self.bufferWebSocketClient.isConnected
-                await MainActor.run {
-                    self.isConnecting = false
-                    self.isConnected = connected
-                    if !connected {
-                        self.errorMessage = "WebSocket disconnected"
-                    } else {
+                let error = self.bufferWebSocketClient.connectionError
+
+                if connected {
+                    hasConnectedOnce = true
+                    disconnectedAt = nil
+                    await MainActor.run {
+                        self.isConnecting = false
+                        self.isConnected = true
                         self.errorMessage = nil
                     }
-                }
-                try? await Task.sleep(nanoseconds: 500_000_000) // Check every 0.5 seconds
-            }
-        }
-
-        // Monitor connection errors
-        self.connectionErrorTask?.cancel()
-        self.connectionErrorTask = Task { [weak self] in
-            guard let self else { return }
-            while !Task.isCancelled {
-                if let error = self.bufferWebSocketClient.connectionError {
+                } else if let error {
+                    disconnectedAt = nil
                     await MainActor.run {
-                        self.errorMessage = error.localizedDescription
                         self.isConnecting = false
+                        self.isConnected = false
+                        self.errorMessage = error.localizedDescription
+                    }
+                } else if hasConnectedOnce {
+                    // Brief disconnect — give auto-reconnect time before showing error
+                    if disconnectedAt == nil {
+                        disconnectedAt = Date()
+                    }
+                    if let since = disconnectedAt,
+                       Date().timeIntervalSince(since) > disconnectGracePeriod
+                    {
+                        await MainActor.run {
+                            self.isConnected = false
+                            self.errorMessage = "WebSocket disconnected"
+                        }
                     }
                 }
+                // Otherwise: still connecting initially, keep showing the loading spinner
+
                 try? await Task.sleep(nanoseconds: 500_000_000) // Check every 0.5 seconds
             }
         }

--- a/ios/VibeTunnelTests/APIErrorTests.swift
+++ b/ios/VibeTunnelTests/APIErrorTests.swift
@@ -115,7 +115,7 @@ struct APIErrorTests {
         ]
 
         for json in errorFormats {
-            let data = json.data(using: .utf8)!
+            let data = try #require(json.data(using: .utf8))
             let response = try JSONDecoder().decode(ErrorResponse.self, from: data)
 
             // Verify at least one error field is present
@@ -173,7 +173,7 @@ struct APIErrorTests {
             let startedAt: String
         }
 
-        let data = partialSession.data(using: .utf8)!
+        let data = try #require(partialSession.data(using: .utf8))
 
         #expect(throws: DecodingError.self) {
             try JSONDecoder().decode(Session.self, from: data)
@@ -337,7 +337,7 @@ struct APIErrorTests {
             {"error": "\(message.replacingOccurrences(of: "\"", with: "\\\""))"}
             """
 
-            let data = json.data(using: .utf8)!
+            let data = try #require(json.data(using: .utf8))
             let response = try JSONDecoder().decode(ErrorResponse.self, from: data)
             #expect(response.error == message)
         }

--- a/ios/VibeTunnelTests/AuthenticationTests.swift
+++ b/ios/VibeTunnelTests/AuthenticationTests.swift
@@ -7,7 +7,7 @@ struct AuthenticationTests {
 
     @Test("Password hashing and validation")
     func passwordHashing() {
-        // Test password requirements
+        /// Test password requirements
         func isValidPassword(_ password: String) -> Bool {
             password.count >= 8 &&
                 password.rangeOfCharacter(from: .uppercaseLetters) != nil &&
@@ -277,7 +277,7 @@ struct AuthenticationTests {
     // MARK: - Secure Storage
 
     @Test("Keychain storage security")
-    func keychainStorage() {
+    func keychainStorage() throws {
         struct KeychainItem {
             let service: String
             let account: String
@@ -299,10 +299,10 @@ struct AuthenticationTests {
             }
         }
 
-        let item = KeychainItem(
+        let item = try KeychainItem(
             service: "sh.vibetunnel.ios",
             account: "user-token",
-            data: "secret-token".data(using: .utf8)!,
+            data: #require("secret-token".data(using: .utf8)),
             accessGroup: nil)
 
         #expect(item.query[kSecClass as String] as? String == kSecClassGenericPassword as String)

--- a/ios/VibeTunnelTests/EdgeCaseTests.swift
+++ b/ios/VibeTunnelTests/EdgeCaseTests.swift
@@ -32,7 +32,7 @@ struct EdgeCaseTests {
 
         #expect(longString.count == maxReasonableLength)
 
-        // Test string truncation
+        /// Test string truncation
         func truncate(_ string: String, to maxLength: Int) -> String {
             if string.count <= maxLength {
                 return string
@@ -54,7 +54,7 @@ struct EdgeCaseTests {
         let maxInt = Int.max
         let minInt = Int.min
 
-        // Safe addition with overflow check
+        /// Safe addition with overflow check
         func safeAdd(_ a: Int, _ b: Int) -> Int? {
             let (result, overflow) = a.addingReportingOverflow(b)
             return overflow ? nil : result
@@ -92,7 +92,7 @@ struct EdgeCaseTests {
         #expect(infinity > 1_000_000)
         #expect(negInfinity < -1_000_000)
 
-        // Test safe division
+        /// Test safe division
         func safeDivide(_ a: Double, by b: Double) -> Double? {
             guard b != 0, !b.isNaN else { return nil }
             let result = a / b
@@ -117,7 +117,7 @@ struct EdgeCaseTests {
         #expect(emptyDict.isEmpty)
         #expect(emptySet.isEmpty)
 
-        // Safe array access
+        /// Safe array access
         func safeAccess<T>(_ array: [T], at index: Int) -> T? {
             guard index >= 0, index < array.count else { return nil }
             return array[index]
@@ -278,7 +278,7 @@ struct EdgeCaseTests {
         let megabyte = 1024 * 1024
         let size = 10 * megabyte // 10 MB
 
-        // Safely allocate memory
+        /// Safely allocate memory
         func safeAllocate(bytes: Int) -> Data? {
             guard bytes > 0, bytes < Int.max / 2 else { return nil }
             return Data(count: bytes)
@@ -332,7 +332,7 @@ struct EdgeCaseTests {
     // MARK: - JSON Edge Cases
 
     @Test("JSON encoding special cases")
-    func jSONEdgeCases() {
+    func jSONEdgeCases() throws {
         struct TestModel: Codable {
             let value: Any?
 
@@ -384,7 +384,7 @@ struct EdgeCaseTests {
         ]
 
         for (json, shouldSucceed) in edgeCases {
-            let data = json.data(using: .utf8)!
+            let data = try #require(json.data(using: .utf8))
             let decoded = try? JSONDecoder().decode(TestModel.self, from: data)
 
             if shouldSucceed {

--- a/ios/VibeTunnelTests/FileSystemTests.swift
+++ b/ios/VibeTunnelTests/FileSystemTests.swift
@@ -7,7 +7,7 @@ struct FileSystemTests {
 
     @Test("Path normalization and resolution")
     func pathNormalization() {
-        // Test path normalization
+        /// Test path normalization
         func normalizePath(_ path: String) -> String {
             (path as NSString).standardizingPath
         }
@@ -126,7 +126,7 @@ struct FileSystemTests {
 
     @Test("Recursive directory size calculation")
     func directorySizeCalculation() {
-        // Simulate directory size calculation
+        /// Simulate directory size calculation
         func calculateDirectorySize(files: [(name: String, size: Int64)]) -> Int64 {
             files.reduce(0) { $0 + $1.size }
         }
@@ -140,7 +140,7 @@ struct FileSystemTests {
         let totalSize = calculateDirectorySize(files: files)
         #expect(totalSize == 7168)
 
-        // Test size formatting
+        /// Test size formatting
         func formatFileSize(_ bytes: Int64) -> String {
             let formatter = ByteCountFormatter()
             formatter.countStyle = .file
@@ -306,7 +306,7 @@ struct FileSystemTests {
 
     @Test("Text encoding detection")
     func textEncodingDetection() {
-        // Test BOM (Byte Order Mark) detection
+        /// Test BOM (Byte Order Mark) detection
         func detectEncoding(from bom: [UInt8]) -> String.Encoding? {
             if bom.starts(with: [0xEF, 0xBB, 0xBF]) {
                 return .utf8
@@ -341,7 +341,7 @@ struct FileSystemTests {
         #expect(filePathFromURL("file://localhost/Users/test/file.txt") == "/Users/test/file.txt")
         #expect(filePathFromURL("https://example.com/file.txt") == nil)
 
-        // Test path to URL conversion
+        /// Test path to URL conversion
         func fileURLFromPath(_ path: String) -> URL? {
             URL(fileURLWithPath: path)
         }

--- a/ios/VibeTunnelTests/Mocks/MockSessionService.swift
+++ b/ios/VibeTunnelTests/Mocks/MockSessionService.swift
@@ -51,8 +51,7 @@ class MockSessionService: SessionServiceProtocol {
         if self.shouldThrowError {
             throw self.thrownError
         }
-        let exitedIds = self.sessions.filter { !$0.isRunning }.map(\.id)
-        return exitedIds
+        return self.sessions.filter { !$0.isRunning }.map(\.id)
     }
 
     func killAllSessions() async throws {

--- a/ios/VibeTunnelTests/Models/CastFileTests.swift
+++ b/ios/VibeTunnelTests/Models/CastFileTests.swift
@@ -14,8 +14,8 @@ struct CastFileTests {
         [3.012, "o", "exit\\r\\n"]
         """
 
-        let data = castContent.data(using: .utf8)!
-        let player = CastPlayer(data: data)!
+        let data = try #require(castContent.data(using: .utf8))
+        let player = try #require(CastPlayer(data: data))
 
         // Verify header
         #expect(player.header.version == 2)
@@ -42,8 +42,8 @@ struct CastFileTests {
         [0.0, "o", "Starting..."]
         """
 
-        let data = castContent.data(using: .utf8)!
-        let player = CastPlayer(data: data)!
+        let data = try #require(castContent.data(using: .utf8))
+        let player = try #require(CastPlayer(data: data))
 
         #expect(player.header.version == 2)
         #expect(player.header.width == 120)
@@ -55,33 +55,33 @@ struct CastFileTests {
     }
 
     @Test("Parse malformed cast file")
-    func parseMalformedCastFile() {
+    func parseMalformedCastFile() throws {
         let malformedContent = "This is not a valid cast file"
-        let data = malformedContent.data(using: .utf8)!
+        let data = try #require(malformedContent.data(using: .utf8))
 
         let player = CastPlayer(data: data)
         #expect(player == nil)
     }
 
     @Test("Parse cast file with invalid header")
-    func parseInvalidHeader() {
+    func parseInvalidHeader() throws {
         let invalidHeader = """
         {"invalid": "header"}
         [0.0, "o", "test"]
         """
-        let data = invalidHeader.data(using: .utf8)!
+        let data = try #require(invalidHeader.data(using: .utf8))
 
         let player = CastPlayer(data: data)
         #expect(player == nil)
     }
 
     @Test("Parse cast file with invalid event")
-    func parseInvalidEvent() {
+    func parseInvalidEvent() throws {
         let invalidEvent = """
         {"version": 2, "width": 80, "height": 24}
         [0.0, "invalid", "test"]
         """
-        let data = invalidEvent.data(using: .utf8)!
+        let data = try #require(invalidEvent.data(using: .utf8))
 
         // Should still parse successfully, including invalid events
         let player = CastPlayer(data: data)
@@ -98,8 +98,8 @@ struct CastFileTests {
         [10.25, "o", "End"]
         """
 
-        let data = castContent.data(using: .utf8)!
-        let player = CastPlayer(data: data)!
+        let data = try #require(castContent.data(using: .utf8))
+        let player = try #require(CastPlayer(data: data))
 
         #expect(player.duration == 10.25)
     }
@@ -110,8 +110,8 @@ struct CastFileTests {
         {"version": 2, "width": 80, "height": 24}
         """
 
-        let data = emptyContent.data(using: .utf8)!
-        let player = CastPlayer(data: data)!
+        let data = try #require(emptyContent.data(using: .utf8))
+        let player = try #require(CastPlayer(data: data))
 
         #expect(player.events.isEmpty)
         #expect(player.duration == 0.0)
@@ -126,8 +126,8 @@ struct CastFileTests {
         [2.0, "o", "After resize"]
         """
 
-        let data = resizeContent.data(using: .utf8)!
-        let player = CastPlayer(data: data)!
+        let data = try #require(resizeContent.data(using: .utf8))
+        let player = try #require(CastPlayer(data: data))
 
         #expect(player.events.count == 3)
         #expect(player.events[1].type == "r")
@@ -145,8 +145,8 @@ struct CastFileTests {
         [4.0, "o", "Event 5"]
         """
 
-        let data = castContent.data(using: .utf8)!
-        let player = CastPlayer(data: data)!
+        let data = try #require(castContent.data(using: .utf8))
+        let player = try #require(CastPlayer(data: data))
 
         // Get events up to time 2.5
         let eventsUpTo2_5 = player.events.filter { $0.time <= 2.5 }
@@ -162,7 +162,7 @@ struct CastFileTests {
 
     @Test("Parse cast file from file URL")
     @MainActor
-    func parseCastFileFromURL() async throws {
+    func parseCastFileFromURL() throws {
         // Create a temporary file
         let tempDir = FileManager.default.temporaryDirectory
         let fileURL = tempDir.appendingPathComponent("test.cast")
@@ -176,7 +176,7 @@ struct CastFileTests {
 
         // Read from URL and parse
         let data = try Data(contentsOf: fileURL)
-        let player = CastPlayer(data: data)!
+        let player = try #require(CastPlayer(data: data))
 
         #expect(player.header.version == 2)
         #expect(player.events.count == 1)
@@ -188,7 +188,7 @@ struct CastFileTests {
 
     @Test("Cast recorder functionality")
     @MainActor
-    func castRecorderFunctionality() {
+    func castRecorderFunctionality() throws {
         let recorder = CastRecorder(sessionId: "test-session", width: 120, height: 40)
 
         // Initial state
@@ -224,7 +224,7 @@ struct CastFileTests {
         #expect(castData != nil)
 
         // Verify exported data can be parsed back
-        let player = CastPlayer(data: castData!)
+        let player = try CastPlayer(data: #require(castData))
         #expect(player != nil)
         #expect(player?.header.version == 2)
         #expect(player?.header.width == 120)
@@ -242,8 +242,8 @@ struct CastFileTests {
         [0.2, "o", "Third"]
         """
 
-        let data = castContent.data(using: .utf8)!
-        let player = CastPlayer(data: data)!
+        let data = try #require(castContent.data(using: .utf8))
+        let player = try #require(CastPlayer(data: data))
 
         actor EventCollector {
             private var events: [CastEvent] = []
@@ -278,8 +278,8 @@ struct CastFileTests {
         [0.0, "o", "Themed output"]
         """
 
-        let data = castContent.data(using: .utf8)!
-        let player = CastPlayer(data: data)!
+        let data = try #require(castContent.data(using: .utf8))
+        let player = try #require(CastPlayer(data: data))
 
         #expect(player.header.theme?.foreground == "#FFFFFF")
         #expect(player.header.theme?.background == "#000000")
@@ -288,7 +288,7 @@ struct CastFileTests {
 
     @Test("Recording with no output produces empty events")
     @MainActor
-    func recordingWithNoOutput() {
+    func recordingWithNoOutput() throws {
         let recorder = CastRecorder(sessionId: "empty-test")
 
         recorder.startRecording()
@@ -298,7 +298,7 @@ struct CastFileTests {
         let castData = recorder.exportCastFile()
         #expect(castData != nil)
 
-        let player = CastPlayer(data: castData!)
+        let player = try CastPlayer(data: #require(castData))
         #expect(player != nil)
         #expect(player?.events.isEmpty == true)
         #expect(player?.duration == 0.0)

--- a/ios/VibeTunnelTests/Models/ServerConfigTests.swift
+++ b/ios/VibeTunnelTests/Models/ServerConfigTests.swift
@@ -224,7 +224,7 @@ struct ServerConfigTests {
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys
         let data = try encoder.encode(config)
-        let jsonString = String(data: data, encoding: .utf8)!
+        let jsonString = try #require(String(data: data, encoding: .utf8))
 
         // Assert
         #expect(jsonString.contains("\"host\":\"test.server\""))
@@ -237,7 +237,7 @@ struct ServerConfigTests {
         // Config with Tailscale HTTPS available
         let httpsConfig = ServerConfig(
             host: "10.0.0.1",
-            port: 4_020,
+            port: 4020,
             name: "VibeTunnel Server",
             tailscaleHostname: "my-machine.tailnet.ts.net",
             tailscaleIP: "100.64.0.1",
@@ -245,8 +245,7 @@ struct ServerConfigTests {
             preferTailscale: true,
             httpsAvailable: true,
             isPublic: false,
-            preferSSL: true
-        )
+            preferSSL: true)
 
         // Should use HTTPS URL when available and preferred
         let connectionUrl = httpsConfig.connectionURL()
@@ -266,25 +265,22 @@ struct ServerConfigTests {
         // Local only
         let localConfig = ServerConfig(
             host: "localhost",
-            port: 4_020
-        )
+            port: 4020)
         #expect(localConfig.availableConnectionTypes == .local)
 
         // Tailscale only
         let tailscaleOnlyConfig = ServerConfig(
             host: "100.64.0.1",
-            port: 4_020,
-            tailscaleHostname: "machine.ts.net"
-        )
+            port: 4020,
+            tailscaleHostname: "machine.ts.net")
         #expect(tailscaleOnlyConfig.availableConnectionTypes == .tailscale)
 
         // Both local and Tailscale
         let bothConfig = ServerConfig(
             host: "localhost",
-            port: 4_020,
+            port: 4020,
             tailscaleHostname: "machine.ts.net",
-            isTailscaleEnabled: true
-        )
+            isTailscaleEnabled: true)
         #expect(bothConfig.availableConnectionTypes == .both)
     }
 
@@ -293,7 +289,7 @@ struct ServerConfigTests {
         // Config with HTTPS available should use HTTPS for API calls
         let httpsConfig = ServerConfig(
             host: "100.64.0.1",
-            port: 4_020,
+            port: 4020,
             name: "Test Server",
             tailscaleHostname: "test-machine.tailnet.ts.net",
             tailscaleIP: "100.64.0.1",
@@ -301,8 +297,7 @@ struct ServerConfigTests {
             preferTailscale: true,
             httpsAvailable: true,
             isPublic: false,
-            preferSSL: true
-        )
+            preferSSL: true)
 
         // API URL should use HTTPS when available
         let apiUrl = httpsConfig.apiURL(path: "/api/sessions")
@@ -312,9 +307,8 @@ struct ServerConfigTests {
         // Config without HTTPS should use HTTP
         let httpConfig = ServerConfig(
             host: "localhost",
-            port: 4_020,
-            name: "Local Server"
-        )
+            port: 4020,
+            name: "Local Server")
 
         let httpApiUrl = httpConfig.apiURL(path: "/api/sessions")
         #expect(httpApiUrl.absoluteString == "http://localhost:4020/api/sessions")
@@ -326,41 +320,37 @@ struct ServerConfigTests {
         // HTTPS/SSL connection
         let httpsConfig = ServerConfig(
             host: "localhost",
-            port: 4_020,
+            port: 4020,
             name: "My Server",
             httpsAvailable: true,
-            preferSSL: true
-        )
+            preferSSL: true)
         #expect(httpsConfig.displayNameWithConnectionType.contains("🔒"))
 
         // Public (Funnel) connection
         let publicConfig = ServerConfig(
             host: "localhost",
-            port: 4_020,
+            port: 4020,
             name: "My Server",
-            isPublic: true
-        )
+            isPublic: true)
         #expect(publicConfig.displayNameWithConnectionType.contains("🌐"))
 
         // Tailscale without HTTPS
         let tailscaleConfig = ServerConfig(
             host: "100.64.0.1",
-            port: 4_020,
+            port: 4020,
             name: "My Server",
-            isTailscaleEnabled: true
-        )
+            isTailscaleEnabled: true)
         #expect(tailscaleConfig.displayNameWithConnectionType.contains("🔗"))
 
         // All indicators
         let allIndicatorsConfig = ServerConfig(
             host: "100.64.0.1",
-            port: 4_020,
+            port: 4020,
             name: "My Server",
             isTailscaleEnabled: true,
             httpsAvailable: true,
             isPublic: true,
-            preferSSL: true
-        )
+            preferSSL: true)
         let displayName = allIndicatorsConfig.displayNameWithConnectionType
         #expect(displayName.contains("🔒"))
         #expect(displayName.contains("🌐"))

--- a/ios/VibeTunnelTests/Models/ServerProfileTests.swift
+++ b/ios/VibeTunnelTests/Models/ServerProfileTests.swift
@@ -12,15 +12,14 @@ struct ServerProfileTests {
             name: "Test Server",
             url: "https://test-machine.tail98c6a0.ts.net",
             host: "100.64.0.1",
-            port: 4_020,
+            port: 4020,
             tailscaleHostname: "test-machine.tail98c6a0.ts.net",
             tailscaleIP: "100.64.0.1",
             isTailscaleEnabled: true,
             preferTailscale: true,
             httpsAvailable: true,
             isPublic: false,
-            preferSSL: true
-        )
+            preferSSL: true)
 
         // Act
         let config = profile.toServerConfig()
@@ -51,8 +50,7 @@ struct ServerProfileTests {
         let profile = ServerProfile(
             id: UUID(),
             name: "Local Server",
-            url: "http://localhost:4020"
-        )
+            url: "http://localhost:4020")
 
         // Act
         let config = profile.toServerConfig()
@@ -62,7 +60,7 @@ struct ServerProfileTests {
         guard let config else { return }
 
         #expect(config.host == "localhost")
-        #expect(config.port == 4_020)
+        #expect(config.port == 4020)
         #expect(config.isTailscaleEnabled == false)
         #expect(config.httpsAvailable == false)
 
@@ -70,7 +68,7 @@ struct ServerProfileTests {
         let connectionUrl = config.connectionURL()
         #expect(connectionUrl.scheme == "http")
         #expect(connectionUrl.host == "localhost")
-        #expect(connectionUrl.port == 4_020)
+        #expect(connectionUrl.port == 4020)
     }
 
     @Test("Handles IPv6 addresses correctly")
@@ -79,8 +77,7 @@ struct ServerProfileTests {
         let profile = ServerProfile(
             id: UUID(),
             name: "IPv6 Server",
-            url: "http://[::1]:8080"
-        )
+            url: "http://[::1]:8080")
 
         // Act
         let config = profile.toServerConfig()
@@ -90,23 +87,21 @@ struct ServerProfileTests {
         guard let config else { return }
 
         #expect(config.host == "::1") // Brackets should be removed
-        #expect(config.port == 8_080)
+        #expect(config.port == 8080)
     }
 
     @Test("ServerProfile storage and retrieval")
-    func storageAndRetrieval() {
+    func storageAndRetrieval() throws {
         // Arrange
-        let testDefaults = UserDefaults(suiteName: "test.serverprofile")!
+        let testDefaults = try #require(UserDefaults(suiteName: "test.serverprofile"))
         testDefaults.removePersistentDomain(forName: "test.serverprofile")
 
         let profile1 = ServerProfile(
             name: "Server 1",
-            url: "http://localhost:4020"
-        )
+            url: "http://localhost:4020")
         let profile2 = ServerProfile(
             name: "Server 2",
-            url: "https://test.example.com"
-        )
+            url: "https://test.example.com")
 
         // Act - Save profiles
         ServerProfile.save(profile1, to: testDefaults)
@@ -131,15 +126,14 @@ struct ServerProfileTests {
     }
 
     @Test("Updates last connected time")
-    func updateLastConnectedTime() {
+    func updateLastConnectedTime() throws {
         // Arrange
-        let testDefaults = UserDefaults(suiteName: "test.serverprofile.time")!
+        let testDefaults = try #require(UserDefaults(suiteName: "test.serverprofile.time"))
         testDefaults.removePersistentDomain(forName: "test.serverprofile.time")
 
         let profile = ServerProfile(
             name: "Test Server",
-            url: "http://localhost:4020"
-        )
+            url: "http://localhost:4020")
         ServerProfile.save(profile, to: testDefaults)
 
         // Act

--- a/ios/VibeTunnelTests/Models/SessionTests.swift
+++ b/ios/VibeTunnelTests/Models/SessionTests.swift
@@ -24,7 +24,7 @@ struct SessionTests {
         """
 
         // Act
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let session = try JSONDecoder().decode(Session.self, from: data)
 
         // Assert
@@ -60,7 +60,7 @@ struct SessionTests {
         """
 
         // Act
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let session = try JSONDecoder().decode(Session.self, from: data)
 
         // Assert
@@ -85,7 +85,7 @@ struct SessionTests {
         """
 
         // Act
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let session = try JSONDecoder().decode(Session.self, from: data)
 
         // Assert
@@ -140,7 +140,7 @@ struct SessionTests {
     }
 
     @Test("Formatted start time")
-    func testFormattedStartTime() throws {
+    func testFormattedStartTime() {
         // Test ISO8601 format
         let session = TestFixtures.validSession
         let formattedTime = session.formattedStartTime
@@ -156,7 +156,7 @@ struct SessionTests {
         let json = TestFixtures.sessionsJSON
 
         // Act
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         let sessions = try JSONDecoder().decode([Session].self, from: data)
 
         // Assert
@@ -178,7 +178,7 @@ struct SessionTests {
         """
 
         // Act & Assert
-        let data = json.data(using: .utf8)!
+        let data = try #require(json.data(using: .utf8))
         #expect(throws: Error.self) {
             try JSONDecoder().decode(Session.self, from: data)
         }

--- a/ios/VibeTunnelTests/Models/TerminalDataTests.swift
+++ b/ios/VibeTunnelTests/Models/TerminalDataTests.swift
@@ -7,7 +7,7 @@ struct TerminalDataTests {
     // MARK: - TerminalEvent Tests
 
     @Test("Parse header event")
-    func parseHeaderEvent() throws {
+    func parseHeaderEvent() {
         let headerJSON = """
         {
             "version": 2,
@@ -40,7 +40,7 @@ struct TerminalDataTests {
     }
 
     @Test("Parse minimal header event")
-    func parseMinimalHeaderEvent() throws {
+    func parseMinimalHeaderEvent() {
         let headerJSON = """
         {
             "version": 2,
@@ -67,7 +67,7 @@ struct TerminalDataTests {
     }
 
     @Test("Parse output event")
-    func parseOutputEvent() throws {
+    func parseOutputEvent() {
         let outputJSON = "[1.5, \"o\", \"Hello, world!\\r\\n\"]"
 
         let event = TerminalEvent(from: outputJSON)
@@ -82,7 +82,7 @@ struct TerminalDataTests {
     }
 
     @Test("Parse resize event")
-    func parseResizeEvent() throws {
+    func parseResizeEvent() {
         let resizeJSON = "[2.5, \"r\", \"80x25\"]"
 
         let event = TerminalEvent(from: resizeJSON)
@@ -97,7 +97,7 @@ struct TerminalDataTests {
     }
 
     @Test("Parse exit event")
-    func parseExitEvent() throws {
+    func parseExitEvent() {
         let exitJSON = "[\"exit\", 0, \"test-session-123\"]"
 
         let event = TerminalEvent(from: exitJSON)
@@ -112,7 +112,7 @@ struct TerminalDataTests {
     }
 
     @Test("Parse exit event with non-zero code")
-    func parseExitEventNonZero() throws {
+    func parseExitEventNonZero() {
         let exitJSON = "[\"exit\", 127, \"error-session\"]"
 
         let event = TerminalEvent(from: exitJSON)
@@ -127,41 +127,41 @@ struct TerminalDataTests {
     }
 
     @Test("Invalid JSON returns nil")
-    func invalidJSON() throws {
+    func invalidJSON() {
         let invalidJSON = "not valid json"
         let event = TerminalEvent(from: invalidJSON)
         #expect(event == nil)
     }
 
     @Test("Invalid event type returns nil")
-    func invalidEventType() throws {
+    func invalidEventType() {
         let invalidEvent = "[1.0, \"x\", \"unknown type\"]"
         let event = TerminalEvent(from: invalidEvent)
         #expect(event == nil)
     }
 
     @Test("Missing array elements returns nil")
-    func missingArrayElements() throws {
+    func missingArrayElements() {
         let incompleteEvent = "[1.0, \"o\"]"
         let event = TerminalEvent(from: incompleteEvent)
         #expect(event == nil)
     }
 
     @Test("Wrong data types in array returns nil")
-    func wrongDataTypes() throws {
+    func wrongDataTypes() {
         let wrongTypes = "[\"not-a-number\", \"o\", \"data\"]"
         let event = TerminalEvent(from: wrongTypes)
         #expect(event == nil)
     }
 
     @Test("Empty string returns nil")
-    func emptyString() throws {
+    func emptyString() {
         let event = TerminalEvent(from: "")
         #expect(event == nil)
     }
 
     @Test("Array with wrong exit format returns nil")
-    func wrongExitFormat() throws {
+    func wrongExitFormat() {
         // Wrong first element
         let wrongExit1 = "[\"not-exit\", 0, \"session\"]"
         #expect(TerminalEvent(from: wrongExit1) == nil)
@@ -306,7 +306,7 @@ struct TerminalDataTests {
     }
 
     @Test("Edge cases for terminal dimensions")
-    func terminalDimensionEdgeCases() throws {
+    func terminalDimensionEdgeCases() {
         // Minimum dimensions
         let minResize = TerminalResize(cols: 1, rows: 1)
         #expect(minResize.cols == 1)

--- a/ios/VibeTunnelTests/PerformanceTests.swift
+++ b/ios/VibeTunnelTests/PerformanceTests.swift
@@ -9,7 +9,7 @@ struct PerformanceTests {
     func stringConcatenation() {
         let iterations = 1000
 
-        // Test inefficient concatenation
+        /// Test inefficient concatenation
         func inefficientConcat() -> String {
             var result = ""
             for i in 0..<iterations {
@@ -18,7 +18,7 @@ struct PerformanceTests {
             return result
         }
 
-        // Test efficient concatenation
+        /// Test efficient concatenation
         func efficientConcat() -> String {
             var parts: [String] = []
             parts.reserveCapacity(iterations)
@@ -263,7 +263,7 @@ struct PerformanceTests {
     // MARK: - I/O Performance
 
     @Test("File I/O stress test")
-    func fileIO() {
+    func fileIO() throws {
         let tempDir = FileManager.default.temporaryDirectory
         let testFile = tempDir.appendingPathComponent("stress_test_\(UUID().uuidString).txt")
 
@@ -272,7 +272,7 @@ struct PerformanceTests {
         }
 
         let content = String(repeating: "Test data line\n", count: 1000)
-        let data = content.data(using: .utf8)!
+        let data = try #require(content.data(using: .utf8))
 
         // Write test
         do {
@@ -300,7 +300,7 @@ struct PerformanceTests {
     // MARK: - Network Simulation
 
     @Test("URL session task stress test")
-    func uRLSessionStress() {
+    func uRLSessionStress() throws {
         let session = URLSession(configuration: .ephemeral)
         let iterations = 10
         let group = DispatchGroup()
@@ -323,7 +323,7 @@ struct PerformanceTests {
             group.enter()
 
             // Create a data task with invalid URL to test error handling
-            let url = URL(string: "https://invalid-domain-\(i).test")!
+            let url = try #require(URL(string: "https://invalid-domain-\(i).test"))
             let task = session.dataTask(with: url) { _, _, error in
                 if error != nil {
                     Task {

--- a/ios/VibeTunnelTests/Services/BonjourDiscoveryServiceTests.swift
+++ b/ios/VibeTunnelTests/Services/BonjourDiscoveryServiceTests.swift
@@ -78,7 +78,7 @@ struct BonjourDiscoveryServiceTests {
     struct ServiceResolution {
         @Test("Resolve service can handle server data")
         @MainActor
-        func resolveService() async {
+        func resolveService() {
             // Given
             let testServer = DiscoveredServer(
                 name: "TestServer",
@@ -99,7 +99,7 @@ struct BonjourDiscoveryServiceTests {
 
         @Test("Resolve service handles IPv6 addresses correctly")
         @MainActor
-        func resolveServiceIPv6() async {
+        func resolveServiceIPv6() {
             // Given
             let ipv6Host = "fe80::1%en0" // IPv6 with interface
 
@@ -120,7 +120,7 @@ struct BonjourDiscoveryServiceTests {
 
         @Test("Resolve service uses ID-based lookup to avoid race conditions")
         @MainActor
-        func resolveServiceRaceCondition() async {
+        func resolveServiceRaceCondition() {
             // Given
             let server1 = DiscoveredServer(name: "Server1", host: "192.168.1.1", port: 4020, metadata: [:])
             let server2 = DiscoveredServer(name: "Server2", host: "192.168.1.2", port: 4020, metadata: [:])
@@ -150,7 +150,7 @@ struct BonjourDiscoveryServiceTests {
     struct ErrorHandling {
         @Test("Service handles empty browse results")
         @MainActor
-        func emptyBrowseResults() async {
+        func emptyBrowseResults() {
             // Given
             let service = BonjourDiscoveryService.shared
 
@@ -164,7 +164,7 @@ struct BonjourDiscoveryServiceTests {
 
         @Test("Multiple start calls are idempotent")
         @MainActor
-        func multipleStartCalls() async {
+        func multipleStartCalls() {
             // Given
             let service = BonjourDiscoveryService.shared
             service.stopDiscovery() // Clean state

--- a/ios/VibeTunnelTests/Services/BufferWebSocketClientTests.swift
+++ b/ios/VibeTunnelTests/Services/BufferWebSocketClientTests.swift
@@ -51,7 +51,7 @@ final class BufferWebSocketClientTests {
         // Arrange - server with HTTPS available
         let httpsConfig = ServerConfig(
             host: "100.64.0.1",
-            port: 4_020,
+            port: 4020,
             name: "Test Server",
             tailscaleHostname: "test-machine.tailnet.ts.net",
             tailscaleIP: "100.64.0.1",
@@ -59,8 +59,7 @@ final class BufferWebSocketClientTests {
             preferTailscale: true,
             httpsAvailable: true,
             isPublic: false,
-            preferSSL: true
-        )
+            preferSSL: true)
         TestFixtures.saveServerConfig(httpsConfig)
 
         // Create new client to pick up the config
@@ -73,7 +72,7 @@ final class BufferWebSocketClientTests {
         try await Task.sleep(nanoseconds: 100_000_000) // 100ms
 
         // Assert - should use WSS with HTTPS hostname
-        #expect(mockFactory.createdWebSockets.count == 1)
+        #expect(self.mockFactory.createdWebSockets.count == 1)
         let mockWebSocket = try #require(mockFactory.lastCreatedWebSocket)
         #expect(mockWebSocket.lastConnectURL?.scheme == "wss")
         #expect(mockWebSocket.lastConnectURL?.host == "test-machine.tailnet.ts.net")

--- a/ios/VibeTunnelTests/Services/ConnectionManagerTests.swift
+++ b/ios/VibeTunnelTests/Services/ConnectionManagerTests.swift
@@ -6,7 +6,7 @@ import Testing
 @MainActor
 struct ConnectionManagerTests {
     @Test("Saves and loads server configuration")
-    func serverConfigPersistence() throws {
+    func serverConfigPersistence() {
         // Arrange
         let mockStorage = MockStorage()
         let manager = ConnectionManager.createForTesting(storage: mockStorage)
@@ -38,7 +38,7 @@ struct ConnectionManagerTests {
     }
 
     @Test("Saves connection timestamp")
-    func connectionTimestamp() throws {
+    func connectionTimestamp() {
         // Arrange
         let mockStorage = MockStorage()
         let manager = ConnectionManager.createForTesting(storage: mockStorage)
@@ -65,7 +65,7 @@ struct ConnectionManagerTests {
     }
 
     @Test("Restores connection within time window")
-    func connectionRestorationWithinWindow() throws {
+    func connectionRestorationWithinWindow() {
         // Arrange - Set up a recent connection
         let mockStorage = MockStorage()
         let config = TestFixtures.validServerConfig
@@ -84,7 +84,7 @@ struct ConnectionManagerTests {
     }
 
     @Test("Does not restore stale connection")
-    func staleConnectionNotRestored() throws {
+    func staleConnectionNotRestored() {
         // Arrange - Set up an old connection (2 hours ago)
         let mockStorage = MockStorage()
         let config = TestFixtures.validServerConfig
@@ -104,7 +104,7 @@ struct ConnectionManagerTests {
     }
 
     @Test("Disconnect clears connection state")
-    func disconnectClearsState() async throws {
+    func disconnectClearsState() async {
         // Arrange
         let mockStorage = MockStorage()
         let manager = ConnectionManager.createForTesting(storage: mockStorage)
@@ -141,7 +141,7 @@ struct ConnectionManagerTests {
     }
 
     @Test("CurrentServerConfig returns saved config")
-    func testCurrentServerConfig() throws {
+    func testCurrentServerConfig() {
         // Arrange
         let mockStorage = MockStorage()
         let manager = ConnectionManager.createForTesting(storage: mockStorage)
@@ -159,7 +159,7 @@ struct ConnectionManagerTests {
     }
 
     @Test("Creates authentication service on save connection")
-    func authenticationServiceCreation() throws {
+    func authenticationServiceCreation() {
         // Arrange
         let mockStorage = MockStorage()
         let manager = ConnectionManager.createForTesting(storage: mockStorage)
@@ -173,7 +173,7 @@ struct ConnectionManagerTests {
     }
 
     @Test("Restores authentication service on load")
-    func authenticationServiceRestoration() throws {
+    func authenticationServiceRestoration() {
         // Arrange - Save a config first
         let mockStorage = MockStorage()
         let config = TestFixtures.validServerConfig
@@ -190,7 +190,7 @@ struct ConnectionManagerTests {
     }
 
     @Test("Clears authentication service on disconnect")
-    func authenticationServiceCleanup() async throws {
+    func authenticationServiceCleanup() async {
         // Arrange
         let mockStorage = MockStorage()
         let manager = ConnectionManager.createForTesting(storage: mockStorage)
@@ -222,7 +222,7 @@ struct ConnectionManagerTests {
     }
 
     @Test("Connection state changes are observable")
-    func connectionStateObservation() async throws {
+    func connectionStateObservation() {
         // Arrange
         let mockStorage = MockStorage()
         let manager = ConnectionManager.createForTesting(storage: mockStorage)
@@ -245,7 +245,7 @@ struct ConnectionManagerTests {
     }
 
     @Test("Thread safety of shared instance")
-    func sharedInstanceThreadSafety() async throws {
+    func sharedInstanceThreadSafety() async {
         // Test that the shared instance is properly MainActor-isolated
         let shared = ConnectionManager.shared
 
@@ -279,7 +279,7 @@ struct ConnectionManagerTests {
     }
 
     @Test("Authentication service cleanup on failed logout")
-    func authServiceCleanupOnFailedLogout() async throws {
+    func authServiceCleanupOnFailedLogout() async {
         // Arrange
         let mockStorage = MockStorage()
         let manager = ConnectionManager.createForTesting(storage: mockStorage)
@@ -319,7 +319,7 @@ struct ConnectionManagerTests {
 @MainActor
 struct ConnectionManagerIntegrationTests {
     @Test("Full connection lifecycle", .timeLimit(.minutes(1)))
-    func fullConnectionLifecycle() async throws {
+    func fullConnectionLifecycle() async {
         // Arrange
         let mockStorage = MockStorage()
         let manager = ConnectionManager.createForTesting(storage: mockStorage)

--- a/ios/VibeTunnelTests/Services/TailscaleDiscoveryServiceTests.swift
+++ b/ios/VibeTunnelTests/Services/TailscaleDiscoveryServiceTests.swift
@@ -32,7 +32,7 @@ struct TailscaleDiscoveryServiceTests {
 
     @Test("Stop discovery cancels active discovery")
     @MainActor
-    func stopDiscoveryCancelsActiveDiscovery() async {
+    func stopDiscoveryCancelsActiveDiscovery() {
         // Arrange
         let discoveryService = TailscaleDiscoveryService.shared
         let tailscaleService = TailscaleService.shared
@@ -196,20 +196,19 @@ struct TailscaleDiscoveryServiceTests {
         let tailscaleServer = TailscaleDiscoveryService.TailscaleServer(
             hostname: "test-mac.tailnet.ts.net",
             ip: "100.64.0.1",
-            port: 4_020,
+            port: 4020,
             deviceName: "test-mac",
             isReachable: true,
             lastSeen: Date(),
             httpsUrl: nil,
-            isPublic: false
-        )
+            isPublic: false)
 
         // Act
         let config = discoveryService.serverConfig(from: tailscaleServer)
 
         // Assert
         #expect(config.host == "100.64.0.1")
-        #expect(config.port == 4_020)
+        #expect(config.port == 4020)
         #expect(config.name == "test mac") // Note: displayName replaces - with space
         #expect(config.tailscaleHostname == "test-mac.tailnet.ts.net")
         #expect(config.tailscaleIP == "100.64.0.1")
@@ -225,13 +224,12 @@ struct TailscaleDiscoveryServiceTests {
         let tailscaleServer = TailscaleDiscoveryService.TailscaleServer(
             hostname: "test-mac.tailnet.ts.net",
             ip: nil,
-            port: 4_020,
+            port: 4020,
             deviceName: "test-mac",
             isReachable: true,
             lastSeen: Date(),
             httpsUrl: nil,
-            isPublic: false
-        )
+            isPublic: false)
 
         // Act
         let config = discoveryService.serverConfig(from: tailscaleServer)
@@ -250,13 +248,12 @@ struct TailscaleDiscoveryServiceTests {
         let server = TailscaleDiscoveryService.TailscaleServer(
             hostname: "test-machine.tail98c6a0.ts.net",
             ip: "100.64.0.1",
-            port: 4_020,
+            port: 4020,
             deviceName: "Test Machine",
             isReachable: true,
             lastSeen: Date(),
             httpsUrl: "https://test-machine.tail98c6a0.ts.net",
-            isPublic: false
-        )
+            isPublic: false)
 
         // Assert
         #expect(server.hostname == "test-machine.tail98c6a0.ts.net")
@@ -272,39 +269,36 @@ struct TailscaleDiscoveryServiceTests {
         let server1 = TailscaleDiscoveryService.TailscaleServer(
             hostname: "my-test-server.tailnet.ts.net",
             ip: nil,
-            port: 4_020,
+            port: 4020,
             deviceName: "my-test-server",
             isReachable: true,
             lastSeen: Date(),
             httpsUrl: nil,
-            isPublic: false
-        )
+            isPublic: false)
         #expect(server1.displayName == "my test server")
 
         // Test domain trimming
         let server2 = TailscaleDiscoveryService.TailscaleServer(
             hostname: "server.tailnet.ts.net",
             ip: nil,
-            port: 4_020,
+            port: 4020,
             deviceName: "server.tailnet",
             isReachable: true,
             lastSeen: Date(),
             httpsUrl: nil,
-            isPublic: false
-        )
+            isPublic: false)
         #expect(server2.displayName == "server")
 
         // Test fallback to device name
         let server3 = TailscaleDiscoveryService.TailscaleServer(
             hostname: "server",
             ip: nil,
-            port: 4_020,
+            port: 4020,
             deviceName: "fallback-name",
             isReachable: true,
             lastSeen: Date(),
             httpsUrl: nil,
-            isPublic: false
-        )
+            isPublic: false)
         #expect(server3.displayName == "fallback name")
     }
 }

--- a/ios/VibeTunnelTests/Services/TailscaleServiceTests.swift
+++ b/ios/VibeTunnelTests/Services/TailscaleServiceTests.swift
@@ -8,7 +8,7 @@ struct TailscaleServiceTests {
 
     @Test("Save and load OAuth credentials")
     @MainActor
-    func saveAndLoadCredentials() async {
+    func saveAndLoadCredentials() {
         // Arrange
         let service = TailscaleService.shared
         service.clearCredentials()
@@ -31,7 +31,7 @@ struct TailscaleServiceTests {
 
     @Test("Clear credentials removes all data including tokens")
     @MainActor
-    func testClearCredentials() async {
+    func testClearCredentials() {
         // Arrange
         let service = TailscaleService.shared
         service.organization = "k4cdcxxxxxxxx" // clientId
@@ -173,8 +173,7 @@ struct TailscaleServiceTests {
             expires: nil,
             keyExpiryDisabled: nil,
             updateAvailable: nil,
-            clientVersion: nil
-        )
+            clientVersion: nil)
         #expect(macDevice.isVibeTunnelServer == true)
 
         // Test Darwin detection
@@ -194,8 +193,7 @@ struct TailscaleServiceTests {
             expires: nil,
             keyExpiryDisabled: nil,
             updateAvailable: nil,
-            clientVersion: nil
-        )
+            clientVersion: nil)
         #expect(darwinDevice.isVibeTunnelServer == true)
 
         // Test tag detection
@@ -215,8 +213,7 @@ struct TailscaleServiceTests {
             expires: nil,
             keyExpiryDisabled: nil,
             updateAvailable: nil,
-            clientVersion: nil
-        )
+            clientVersion: nil)
         #expect(taggedDevice.isVibeTunnelServer == true)
 
         // Test non-server device
@@ -236,8 +233,7 @@ struct TailscaleServiceTests {
             expires: nil,
             keyExpiryDisabled: nil,
             updateAvailable: nil,
-            clientVersion: nil
-        )
+            clientVersion: nil)
         #expect(iosDevice.isVibeTunnelServer == false)
     }
 
@@ -263,8 +259,7 @@ struct TailscaleServiceTests {
             expires: nil,
             keyExpiryDisabled: nil,
             updateAvailable: nil,
-            clientVersion: nil
-        )
+            clientVersion: nil)
         #expect(recentDevice.isOnline == true)
 
         // Device seen 10 minutes ago - should be offline
@@ -284,8 +279,7 @@ struct TailscaleServiceTests {
             expires: nil,
             keyExpiryDisabled: nil,
             updateAvailable: nil,
-            clientVersion: nil
-        )
+            clientVersion: nil)
         #expect(oldDevice.isOnline == false)
 
         // Device with no lastSeen - should be offline
@@ -305,8 +299,7 @@ struct TailscaleServiceTests {
             expires: nil,
             keyExpiryDisabled: nil,
             updateAvailable: nil,
-            clientVersion: nil
-        )
+            clientVersion: nil)
         #expect(noLastSeenDevice.isOnline == false)
     }
 }

--- a/ios/VibeTunnelTests/SessionListViewModelTests.swift
+++ b/ios/VibeTunnelTests/SessionListViewModelTests.swift
@@ -71,7 +71,7 @@ struct SessionListViewModelTests {
     // MARK: - Initialization Tests
 
     @Test("ViewModel initializes with correct default state")
-    func initialState() async {
+    func initialState() {
         let (viewModel, _) = self.createViewModel()
 
         #expect(viewModel.sessions.isEmpty)
@@ -375,7 +375,7 @@ struct SessionListViewModelTests {
     // MARK: - Network Connectivity Tests
 
     @Test("isNetworkConnected reflects network monitor state")
-    func networkConnectivity() async {
+    func networkConnectivity() {
         let mockNetworkMonitor = MockNetworkMonitor(isConnected: true)
         let (viewModel, _) = self.createViewModel(mockNetworkMonitor: mockNetworkMonitor)
 
@@ -529,7 +529,7 @@ struct SessionListViewModelTests {
     // MARK: - UI State Tests
 
     @Test("UI state properties can be modified")
-    func uIStateManagement() async {
+    func uIStateManagement() throws {
         let (viewModel, _) = self.createViewModel()
 
         // Test all UI state properties
@@ -549,7 +549,7 @@ struct SessionListViewModelTests {
         viewModel.showingCastImporter = true
         #expect(viewModel.showingCastImporter == true)
 
-        let mockCastFile = CastFileItem(url: URL(string: "file://test.cast")!)
+        let mockCastFile = try CastFileItem(url: #require(URL(string: "file://test.cast")))
         viewModel.importedCastFile = mockCastFile
         #expect(viewModel.importedCastFile?.url.absoluteString == "file://test.cast")
 

--- a/ios/VibeTunnelTests/StandaloneTests.swift
+++ b/ios/VibeTunnelTests/StandaloneTests.swift
@@ -7,8 +7,8 @@ import Testing
 @Suite("Standalone API Tests", .tags(.critical, .networking))
 struct StandaloneAPITests {
     @Test("URL construction for API endpoints")
-    func uRLConstruction() {
-        let baseURL = URL(string: "http://localhost:8888")!
+    func uRLConstruction() throws {
+        let baseURL = try #require(URL(string: "http://localhost:8888"))
 
         // Test session endpoints
         let sessionsURL = baseURL.appendingPathComponent("api/sessions")
@@ -63,7 +63,7 @@ struct StandaloneAPITests {
         }
         """
 
-        let data = errorJSON.data(using: .utf8)!
+        let data = try #require(errorJSON.data(using: .utf8))
         let decoder = JSONDecoder()
         let errorResponse = try decoder.decode(ErrorResponse.self, from: data)
 
@@ -136,7 +136,7 @@ struct ModelValidationTests {
     }
 
     @Test("Server config URL generation")
-    func serverConfigURLs() {
+    func serverConfigURLs() throws {
         struct ServerConfig {
             let host: String
             let port: Int
@@ -144,12 +144,12 @@ struct ModelValidationTests {
 
             var baseURL: URL {
                 let scheme = self.useSSL ? "https" : "http"
-                return URL(string: "\(scheme)://\(self.host):\(self.port)")!
+                return try #require(URL(string: "\(scheme)://\(self.host):\(self.port)"))
             }
 
             var websocketURL: URL {
                 let scheme = self.useSSL ? "wss" : "ws"
-                return URL(string: "\(scheme)://\(self.host):\(self.port)")!
+                return try #require(URL(string: "\(scheme)://\(self.host):\(self.port)"))
             }
         }
 
@@ -230,7 +230,7 @@ struct DateFormattingTests {
     }
 
     @Test("RFC3339 date formats")
-    func rFC3339Formats() throws {
+    func rFC3339Formats() {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
 

--- a/ios/VibeTunnelTests/TerminalParsingTests.swift
+++ b/ios/VibeTunnelTests/TerminalParsingTests.swift
@@ -73,7 +73,7 @@ struct TerminalParsingTests {
         #expect(ANSIColor.red.brightVariant == 91)
         #expect(ANSIColor.red.backgroundVariant == 41)
 
-        // Test 256 color mode
+        /// Test 256 color mode
         func parse256Color(_ code: String) -> (r: Int, g: Int, b: Int)? {
             // ESC[38;5;Nm for foreground, ESC[48;5;Nm for background
             guard code.contains("38;5;") || code.contains("48;5;") else { return nil }

--- a/ios/VibeTunnelTests/ViewModels/ServerListViewModelTests.swift
+++ b/ios/VibeTunnelTests/ViewModels/ServerListViewModelTests.swift
@@ -113,20 +113,19 @@ struct ServerListViewModelTests {
 
     @Test("Connection status message shown during HTTPS fallback")
     func connectionStatusMessageDuringFallback() async throws {
-        let (viewModel, _) = createTestViewModel()
+        let (viewModel, _) = self.createTestViewModel()
 
         // Create profile with HTTPS that will fail
         let profile = ServerProfile(
             name: "Tailscale Server",
             url: "https://test-machine.tailnet.ts.net",
             host: "100.64.0.1",
-            port: 4_020,
+            port: 4020,
             tailscaleHostname: "test-machine.tailnet.ts.net",
             tailscaleIP: "100.64.0.1",
             httpsAvailable: true,
             isPublic: true,
-            preferSSL: true
-        )
+            preferSSL: true)
 
         try await viewModel.addProfile(profile)
 

--- a/ios/VibeTunnelTests/WebSocketReconnectionTests.swift
+++ b/ios/VibeTunnelTests/WebSocketReconnectionTests.swift
@@ -235,7 +235,7 @@ struct WebSocketReconnectionTests {
     // MARK: - State Persistence
 
     @Test("Connection state persistence")
-    func statePersistence() {
+    func statePersistence() throws {
         struct ConnectionState: Codable {
             let url: String
             let sessionId: String?
@@ -258,7 +258,7 @@ struct WebSocketReconnectionTests {
         // Decode
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        let decoded = try? decoder.decode(ConnectionState.self, from: data!)
+        let decoded = try? decoder.decode(ConnectionState.self, from: try #require(data))
 
         #expect(decoded?.url == state.url)
         #expect(decoded?.sessionId == state.sessionId)


### PR DESCRIPTION
## Summary

- Add Tailscale Serve discovery — iOS app probes both HTTP (port 4020) and HTTPS (port 443) in parallel, preferring HTTPS for automatic Tailscale identity authentication
- Fix connection corruption where health checks on port 4020 would clear HTTPS flags set by discovery, causing profile URLs to degrade to wrong ports and lose identity auth
- Fix WebSocket terminal rendering: ZStack overlay keeps WKWebView alive across state changes, pending data queue prevents silent JS evaluation failures on existing session resume
- Add 3-second disconnect grace period to prevent transient "WebSocket disconnected" errors during brief reconnects

## Key changes

- **Discovery**: Parallel HTTP/HTTPS probing with HTTPS preference for identity auth
- **Health checks**: Never downgrade Tailscale HTTPS flags — discovery is authoritative
- **Connection fallback**: Simplified HTTPS→HTTP fallback that doesn't persist corrupted intermediate state
- **Profile management**: Dedup by Tailscale hostname on add, auto-migrate corrupted port values
- **Terminal rendering**: ZStack overlay + pending data queue + disconnect grace period

## Test plan

- [x] Discover VibeTunnel servers via Tailscale with HTTPS (Tailscale Serve)
- [x] Automatic Tailscale identity auth (no password prompt)
- [x] Terminal renders correctly on new and existing sessions
- [x] No transient "WebSocket disconnected" flash during reconnects
- [x] Existing profiles with corrupted ports auto-migrate to 4020

🤖 Generated with [Claude Code](https://claude.com/claude-code)