### PR TITLE
docs: clarify vt install from macOS app is script (not symlink)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The `vt` command is a smart wrapper that forwards your terminal sessions through
 - Available from both the Mac app and npm package installations
 
 **Installation sources**:
-- **macOS App**: Creates `/usr/local/bin/vt` symlink during installation
+- **macOS App**: Installs the `vt` wrapper script at `/usr/local/bin/vt` during installation
 - **npm Package**: Installs `vt` globally, with intelligent Mac app detection
 
 **Smart detection**:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,7 +18,7 @@ VibeTunnel deployment encompasses macOS app distribution, automatic updates via 
 
 **CLI Tools Package** - Command line binaries installed to /usr/local/bin
 - vibetunnel binary (main CLI tool)
-- vt wrapper script/symlink (convenience command)
+- vt wrapper script (convenience command)
 - Installed via mac/VibeTunnel/Utilities/CLIInstaller.swift
 
 ## Platform Deployment

--- a/mac/VibeTunnel/Utilities/CLIInstaller.swift
+++ b/mac/VibeTunnel/Utilities/CLIInstaller.swift
@@ -5,11 +5,11 @@ import Observation
 import os.log
 import SwiftUI
 
-/// Service responsible for creating symlinks to command line tools with sudo authentication.
+/// Service responsible for installing the vt wrapper script with sudo authentication.
 ///
 /// ## Overview
-/// This service creates symlinks from the application bundle's resources to system locations like /usr/local/bin
-/// to enable command line access to bundled tools. It handles sudo authentication through system dialogs.
+/// This service copies the wrapper script from the application bundle to /usr/local/bin to enable command line
+/// access to VibeTunnel. It handles sudo authentication through system dialogs.
 ///
 /// ## Usage
 /// ```swift
@@ -20,7 +20,7 @@ import SwiftUI
 /// ## Safety Considerations
 /// - Always prompts user before performing operations requiring sudo
 /// - Provides clear error messages and graceful failure handling
-/// - Checks for existing symlinks and handles conflicts appropriately
+/// - Replaces existing files or symlinks at the installation path
 /// - Logs all operations for debugging purposes
 @MainActor
 @Observable

--- a/mac/VibeTunnelTests/CLIInstallerTests.swift
+++ b/mac/VibeTunnelTests/CLIInstallerTests.swift
@@ -292,26 +292,24 @@ struct CLIInstallerTests {
             echo "Created directory /usr/local/bin"
         fi
 
-        # Remove existing symlink if it exists
+        # Remove existing vt if it exists
         if [ -L "\(targetPath)" ] || [ -f "\(targetPath)" ]; then
             rm -f "\(targetPath)"
             echo "Removed existing file at \(targetPath)"
         fi
 
-        # Create the symlink
-        ln -s "\(sourcePath)" "\(targetPath)"
-        echo "Created symlink from \(sourcePath) to \(targetPath)"
-
-        # Make sure the symlink is executable
+        # Copy vt script from app bundle
+        cp "\(sourcePath)" "\(targetPath)"
         chmod +x "\(targetPath)"
-        echo "Set executable permissions on \(targetPath)"
+        echo "Installed vt script at \(targetPath)"
         """
 
         // Verify script structure
         #expect(expectedScript.contains("#!/bin/bash"))
         #expect(expectedScript.contains("set -e"))
         #expect(expectedScript.contains("mkdir -p"))
-        #expect(expectedScript.contains("ln -s"))
+        #expect(expectedScript.contains("cp "))
+        #expect(!expectedScript.contains("ln -s"))
         #expect(expectedScript.contains("chmod +x"))
     }
 


### PR DESCRIPTION
## Summary
- Clarify that the macOS app copies the `vt` wrapper script to `/usr/local/bin/vt`.
- Align deployment docs, installer API comments, and the script-generation fixture with the existing `cp` + `chmod` implementation.
- Keep npm symlink documentation unchanged; that installation path still uses symlinks.

Closes #592

## Verification
- Confirmed `CLIInstaller.performInstallation()` removes an existing file or symlink, copies the bundled script, and marks it executable.
- `swiftformat --lint mac/VibeTunnel/Utilities/CLIInstaller.swift mac/VibeTunnelTests/CLIInstallerTests.swift --config apple/.swiftformat`
- `swiftlint lint --config apple/.swiftlint.yml mac/VibeTunnel/Utilities/CLIInstaller.swift mac/VibeTunnelTests/CLIInstallerTests.swift`
- Structured autoreview: no actionable findings.
- Focused Xcode test was blocked before Swift compilation by local host toolchains: Homebrew Zig 0.16 is newer than the repo API, while pinned Zig 0.15.2 cannot link its build runner on macOS 26.5. GitHub CI uses the pinned repo toolchain.
