### PR TITLE
fix(web): update CLI install instructions path in empty state

### DIFF
--- a/web/src/client/components/session-list.ts
+++ b/web/src/client/components/session-list.ts
@@ -818,7 +818,7 @@ export class SessionList extends LitElement {
                             </div>
                             <div class="text-sm text-text-muted space-y-1">
                               <div>→ Click the VibeTunnel menu bar icon</div>
-                              <div>→ Go to Settings → Advanced → Install CLI Tools</div>
+                              <div>→ Go to Settings → General → Command Line Tool</div>
                             </div>
                           </div>
 


### PR DESCRIPTION
## Summary
- Update empty-session onboarding text in web UI
- Replace outdated path `Settings → Advanced → Install CLI Tools`
- Use current path `Settings → General → Command Line Tool`

## Why
The current message sends users to an outdated settings location, causing friction during initial setup.

## Changed file
- web/src/client/components/session-list.ts

Related to #582
