### PR TITLE
fix(vt): tokenize --title-mode args correctly for fwd parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Keep Terminal Settings and other interactive overlays above the exited-session badge (via [@Nachx639](https://github.com/Nachx639)) (#643)
 - Fix npm and Bun global installs exiting early by recognizing the `vibetunnel` bin entry point (via [@yv-was-taken](https://github.com/yv-was-taken)) (#583)
 - Fix desktop terminal content being clipped at the bottom (via [@ChimeraFlutter](https://github.com/ChimeraFlutter)) (#608)
+- Forward `vt --title-mode` as separate option and value arguments (via [@nikolasdehor](https://github.com/nikolasdehor)) (#602)
 - Preserve native terminal link taps by avoiding paste-input focus steal on anchors (via [@nikolasdehor](https://github.com/nikolasdehor)) (#606)
 - Add Nix per-user profile path for cloudflared discovery (via [@bkase](https://github.com/bkase)) (#533)
 - Fall back to dns-sd for macOS mDNS advertisement when Bonjour fails
@@ -40,7 +41,7 @@
 - Thanks [@sourman](https://github.com/sourman) for documenting the Zig build prerequisite.
 - Thanks [@yv-was-taken](https://github.com/yv-was-taken) for fixing global npm and Bun installs.
 - Thanks [@ChimeraFlutter](https://github.com/ChimeraFlutter) for fixing desktop terminal clipping.
-- Thanks [@nikolasdehor](https://github.com/nikolasdehor) for preserving terminal link taps.
+- Thanks [@nikolasdehor](https://github.com/nikolasdehor) for fixing `vt --title-mode` forwarding and preserving terminal link taps.
 - Thanks [@rothnic](https://github.com/rothnic) for defaulting to universal macOS binaries.
 
 ## [1.0.0-beta.15] - 2025-08-02

--- a/web/bin/vt
+++ b/web/bin/vt
@@ -504,7 +504,7 @@ resolve_command() {
     case "$shell_name" in
         zsh)
             # For zsh, we need interactive mode to get aliases
-            exec_fwd ${VERBOSITY_ARGS:+$VERBOSITY_ARGS} ${TITLE_MODE_ARGS:+"$TITLE_MODE_ARGS"} "$user_shell" -i -c "$(printf '%q ' "$cmd" "$@")"
+            exec_fwd ${VERBOSITY_ARGS:+$VERBOSITY_ARGS} "${TITLE_MODE_ARGS[@]}" "$user_shell" -i -c "$(printf '%q ' "$cmd" "$@")"
             ;;
         bash)
             # For bash, enable alias expansion before parsing the command string.
@@ -518,11 +518,11 @@ shopt -s expand_aliases
 source ~/.bashrc 2>/dev/null || source ~/.bash_profile 2>/dev/null || true
 rm -f "$BASH_ENV"
 EOF
-            exec_fwd ${VERBOSITY_ARGS:+$VERBOSITY_ARGS} ${TITLE_MODE_ARGS:+"$TITLE_MODE_ARGS"} /usr/bin/env BASH_ENV="$bash_env_file" "$user_shell" -c "$cmd_string"
+            exec_fwd ${VERBOSITY_ARGS:+$VERBOSITY_ARGS} "${TITLE_MODE_ARGS[@]}" /usr/bin/env BASH_ENV="$bash_env_file" "$user_shell" -c "$cmd_string"
             ;;
         *)
             # Generic shell handling
-            exec_fwd ${VERBOSITY_ARGS:+$VERBOSITY_ARGS} ${TITLE_MODE_ARGS:+"$TITLE_MODE_ARGS"} "$user_shell" -c "$(printf '%q ' "$cmd" "$@")"
+            exec_fwd ${VERBOSITY_ARGS:+$VERBOSITY_ARGS} "${TITLE_MODE_ARGS[@]}" "$user_shell" -c "$(printf '%q ' "$cmd" "$@")"
             ;;
     esac
 }
@@ -693,9 +693,9 @@ if [[ "$1" == "--no-shell-wrap" || "$1" == "-S" ]]; then
 fi
 
 # Handle --title-mode option
-TITLE_MODE_ARGS=""
+TITLE_MODE_ARGS=()
 if [[ "$1" == "--title-mode" && $# -gt 1 ]]; then
-    TITLE_MODE_ARGS="--title-mode $2"
+    TITLE_MODE_ARGS=(--title-mode "$2")
     shift 2
 fi
 
@@ -703,7 +703,7 @@ fi
 if [ $# -gt 0 ] && [[ "$1" != -* ]]; then
     if [[ "$NO_SHELL_WRAP" == "true" ]]; then
         # Execute directly without shell wrapper
-        exec_fwd ${VERBOSITY_ARGS:+$VERBOSITY_ARGS} ${TITLE_MODE_ARGS:+"$TITLE_MODE_ARGS"} "$@"
+        exec_fwd ${VERBOSITY_ARGS:+$VERBOSITY_ARGS} "${TITLE_MODE_ARGS[@]}" "$@"
     else
         # Resolve binaries to absolute paths so the server uses the same executable
         cmd="$1"
@@ -711,11 +711,11 @@ if [ $# -gt 0 ] && [[ "$1" != -* ]]; then
         cmd_args=("$@")
 
         if [[ "$cmd" == */* ]]; then
-            exec_fwd ${VERBOSITY_ARGS:+$VERBOSITY_ARGS} ${TITLE_MODE_ARGS:+"$TITLE_MODE_ARGS"} "$cmd" "${cmd_args[@]}"
+            exec_fwd ${VERBOSITY_ARGS:+$VERBOSITY_ARGS} "${TITLE_MODE_ARGS[@]}" "$cmd" "${cmd_args[@]}"
         else
             resolved_path="$(resolve_binary_path "$cmd" || true)"
             if [[ -n "$resolved_path" ]]; then
-                exec_fwd ${VERBOSITY_ARGS:+$VERBOSITY_ARGS} ${TITLE_MODE_ARGS:+"$TITLE_MODE_ARGS"} "$resolved_path" "${cmd_args[@]}"
+                exec_fwd ${VERBOSITY_ARGS:+$VERBOSITY_ARGS} "${TITLE_MODE_ARGS[@]}" "$resolved_path" "${cmd_args[@]}"
             else
                 # Not a real binary, try alias resolution
                 resolve_command "$cmd" "${cmd_args[@]}"
@@ -724,5 +724,5 @@ if [ $# -gt 0 ] && [[ "$1" != -* ]]; then
     fi
 else
     # Run with fwd command (original behavior for options)
-    exec_fwd ${VERBOSITY_ARGS:+$VERBOSITY_ARGS} ${TITLE_MODE_ARGS:+"$TITLE_MODE_ARGS"} "$@"
+    exec_fwd ${VERBOSITY_ARGS:+$VERBOSITY_ARGS} "${TITLE_MODE_ARGS[@]}" "$@"
 fi

--- a/web/src/test/integration/vt-command.test.ts
+++ b/web/src/test/integration/vt-command.test.ts
@@ -1,5 +1,6 @@
 import { execSync, spawn } from 'child_process';
-import { existsSync } from 'fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
 import { join } from 'path';
 import { beforeAll, describe, expect, it } from 'vitest';
 
@@ -178,5 +179,41 @@ describe('vt command', () => {
   it('should be included in npm package files', () => {
     const packageJson = JSON.parse(require('fs').readFileSync(packageJsonPath, 'utf8'));
     expect(packageJson.files).toContain('bin/');
+  });
+
+  it('should pass --title-mode as separate argv tokens', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'vt-title-mode-'));
+    const mockVibetunnelPath = join(tempDir, 'mock-vibetunnel.sh');
+    const argvOutputPath = join(tempDir, 'argv.txt');
+
+    try {
+      writeFileSync(
+        mockVibetunnelPath,
+        `#!/usr/bin/env bash
+printf "%s\n" "$@" > "$VT_ARGV_OUTPUT"
+`,
+        'utf8'
+      );
+      chmodSync(mockVibetunnelPath, 0o755);
+
+      execSync(`bash "${vtScriptPath}" -S --title-mode dynamic echo test`, {
+        cwd: projectRoot,
+        stdio: 'pipe',
+        env: {
+          ...process.env,
+          VIBETUNNEL_BIN: mockVibetunnelPath,
+          VT_ARGV_OUTPUT: argvOutputPath,
+        },
+      });
+
+      const argv = readFileSync(argvOutputPath, 'utf8')
+        .split('\n')
+        .filter((line) => line.length > 0);
+
+      expect(argv.slice(0, 5)).toEqual(['fwd', '--title-mode', 'dynamic', 'echo', 'test']);
+      expect(argv).not.toContain('--title-mode dynamic');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/web/src/test/integration/vt-command.test.ts
+++ b/web/src/test/integration/vt-command.test.ts
@@ -1,4 +1,4 @@
-import { execSync, spawn } from 'child_process';
+import { execSync, spawn, spawnSync } from 'child_process';
 import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
@@ -190,28 +190,36 @@ describe('vt command', () => {
       writeFileSync(
         mockVibetunnelPath,
         `#!/usr/bin/env bash
-printf "%s\n" "$@" > "$VT_ARGV_OUTPUT"
+printf '%s\n' "$@" > "$VT_ARGV_OUTPUT"
 `,
         'utf8'
       );
       chmodSync(mockVibetunnelPath, 0o755);
 
-      execSync(`bash "${vtScriptPath}" -S --title-mode dynamic echo test`, {
-        cwd: projectRoot,
-        stdio: 'pipe',
-        env: {
-          ...process.env,
-          VIBETUNNEL_BIN: mockVibetunnelPath,
-          VT_ARGV_OUTPUT: argvOutputPath,
-        },
-      });
+      const result = spawnSync(
+        'bash',
+        [vtScriptPath, '-S', '--title-mode', 'static', 'echo', 'test'],
+        {
+          encoding: 'utf8',
+          cwd: projectRoot,
+          env: {
+            ...process.env,
+            VIBETUNNEL_BIN: mockVibetunnelPath,
+            VIBETUNNEL_SESSION_ID: '',
+            VT_ARGV_OUTPUT: argvOutputPath,
+          },
+        }
+      );
 
-      const argv = readFileSync(argvOutputPath, 'utf8')
-        .split('\n')
-        .filter((line) => line.length > 0);
-
-      expect(argv.slice(0, 5)).toEqual(['fwd', '--title-mode', 'dynamic', 'echo', 'test']);
-      expect(argv).not.toContain('--title-mode dynamic');
+      expect(result.status).toBe(0);
+      expect(result.stderr).toBe('');
+      expect(readFileSync(argvOutputPath, 'utf8').trimEnd().split('\n')).toEqual([
+        'fwd',
+        '--title-mode',
+        'static',
+        'echo',
+        'test',
+      ]);
     } finally {
       rmSync(tempDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- pass `--title-mode` and its value to every `vibetunnel fwd` path as separate argv tokens
- use a Bash array so empty and populated title-mode arguments expand safely
- add an argv-capture regression test using the valid `static` mode
- document the user-visible fix and credit @nikolasdehor

## Validation
- `/bin/bash` 3.2 syntax and direct argv proof
- `VIBETUNNEL_PREFER_DERIVED_DATA=1 pnpm exec vitest run src/test/integration/vt-command.test.ts --maxWorkers=4` (9 passed)
- `VIBETUNNEL_BIN="$PWD/bin/vibetunnel" pnpm run test:vt`
- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- structured Codex autoreview: clean
- full Vitest run: 1,439 passed, 111 skipped; nine unrelated local failures from missing native test binary, DOM-less client test configuration, and a concurrency flake

## Local Environment Notes
`pnpm run check` still reports the existing TS6 removal of `moduleResolution=node10`; its wrapper test also hit the known hard five-second timeout while the full suite ran concurrently. The corresponding format, lint, typecheck, focused wrapper, and regression commands pass independently.

Closes #568
