### PR TITLE
fix(server): preserve quoted args in shell fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Fix npm and Bun global installs exiting early by recognizing the `vibetunnel` bin entry point (via [@yv-was-taken](https://github.com/yv-was-taken)) (#583)
 - Fix desktop terminal content being clipped at the bottom (via [@ChimeraFlutter](https://github.com/ChimeraFlutter)) (#608)
 - Forward `vt --title-mode` as separate option and value arguments (via [@nikolasdehor](https://github.com/nikolasdehor)) (#602)
+- Preserve exact argument boundaries when commands fall back to shell alias execution (via [@Ilakiancs](https://github.com/Ilakiancs) and [@nikolasdehor](https://github.com/nikolasdehor)) (#603)
 - Preserve native terminal link taps by avoiding paste-input focus steal on anchors (via [@nikolasdehor](https://github.com/nikolasdehor)) (#606)
 - Add Nix per-user profile path for cloudflared discovery (via [@bkase](https://github.com/bkase)) (#533)
 - Fall back to dns-sd for macOS mDNS advertisement when Bonjour fails
@@ -41,7 +42,8 @@
 - Thanks [@sourman](https://github.com/sourman) for documenting the Zig build prerequisite.
 - Thanks [@yv-was-taken](https://github.com/yv-was-taken) for fixing global npm and Bun installs.
 - Thanks [@ChimeraFlutter](https://github.com/ChimeraFlutter) for fixing desktop terminal clipping.
-- Thanks [@nikolasdehor](https://github.com/nikolasdehor) for fixing `vt --title-mode` forwarding and preserving terminal link taps.
+- Thanks [@Ilakiancs](https://github.com/Ilakiancs) for identifying lost argument boundaries in shell fallback execution.
+- Thanks [@nikolasdehor](https://github.com/nikolasdehor) for fixing `vt --title-mode` and shell fallback argument forwarding and preserving terminal link taps.
 - Thanks [@rothnic](https://github.com/rothnic) for defaulting to universal macOS binaries.
 
 ## [1.0.0-beta.15] - 2025-08-02

--- a/web/src/server/pty/process-utils.ts
+++ b/web/src/server/pty/process-utils.ts
@@ -66,18 +66,43 @@ function existsSync(filePath: string): boolean {
   }
 }
 
-/**
- * Quote argv entries into a single POSIX shell command string.
- * Preserves spaces and shell-special characters when we must use `-c`.
- */
-function formatPosixCommand(args: string[]): string {
-  return args
-    .map((arg) => {
-      if (arg.length === 0) return "''";
-      if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(arg)) return arg;
-      return `'${arg.replace(/'/g, `'\"'\"'`)}'`;
-    })
-    .join(' ');
+function buildShellCommandArgs(
+  shellPath: string,
+  command: string[],
+  interactive = false,
+  login = false
+): string[] {
+  const shellName = path
+    .basename(shellPath)
+    .toLowerCase()
+    .replace(/\.exe$/, '');
+  const [commandName, ...commandArgs] = command;
+  const shellArgs: string[] = [];
+
+  // Alias expansion requires a literal command word, so reject anything that could add shell syntax.
+  if (!/^[A-Za-z0-9_@%+,./:-]+$/.test(commandName)) {
+    throw new Error(`Unsafe shell fallback command name: ${commandName}`);
+  }
+
+  if (interactive) {
+    shellArgs.push(shellName === 'fish' ? '--interactive' : '-i');
+  }
+  // csh/tcsh only accept -l as the sole option, so it cannot be combined with -c.
+  if (login && shellName !== 'csh' && shellName !== 'tcsh') {
+    shellArgs.push(shellName === 'fish' ? '--login' : '-l');
+  }
+
+  if (shellName === 'csh' || shellName === 'tcsh') {
+    const argReferences = commandArgs.map((_, index) => `"$argv[${index + 1}]:q"`).join(' ');
+    const commandText = argReferences ? `${commandName} ${argReferences}` : commandName;
+    return [...shellArgs, '-c', commandText, '-b', ...commandArgs];
+  }
+
+  if (shellName === 'fish') {
+    return [...shellArgs, '-c', `${commandName} $argv`, ...commandArgs];
+  }
+
+  return [...shellArgs, '-c', `${commandName} "$@"`, '--', ...commandArgs];
 }
 
 /**
@@ -348,7 +373,7 @@ export function resolveCommand(command: string[]): {
         // Non-interactive command execution
         return {
           command: userShell,
-          args: ['-c', formatPosixCommand(command)],
+          args: buildShellCommandArgs(userShell, command),
           useShell: true,
           resolvedFrom: 'shell',
         };
@@ -356,7 +381,7 @@ export function resolveCommand(command: string[]): {
         // Interactive shell session
         return {
           command: userShell,
-          args: ['-i', '-c', formatPosixCommand(command)],
+          args: buildShellCommandArgs(userShell, command, true),
           useShell: true,
           resolvedFrom: 'shell',
           isInteractive: true,
@@ -394,7 +419,7 @@ export function resolveCommand(command: string[]): {
         // The -l flag makes it a login shell, ensuring profile/rc files are sourced
         return {
           command: userShell,
-          args: ['-i', '-l', '-c', formatPosixCommand(command)],
+          args: buildShellCommandArgs(userShell, command, true, true),
           useShell: true,
           resolvedFrom: 'alias',
         };
@@ -402,7 +427,7 @@ export function resolveCommand(command: string[]): {
         // No shell config found, use basic execution
         return {
           command: userShell,
-          args: ['-c', formatPosixCommand(command)],
+          args: buildShellCommandArgs(userShell, command),
           useShell: true,
           resolvedFrom: 'shell',
         };
@@ -411,7 +436,7 @@ export function resolveCommand(command: string[]): {
       // Interactive shell session: use -i and -l for proper initialization
       return {
         command: userShell,
-        args: ['-i', '-l', '-c', formatPosixCommand(command)],
+        args: buildShellCommandArgs(userShell, command, true, true),
         useShell: true,
         resolvedFrom: 'shell',
         isInteractive: true,

--- a/web/src/server/pty/process-utils.ts
+++ b/web/src/server/pty/process-utils.ts
@@ -67,6 +67,20 @@ function existsSync(filePath: string): boolean {
 }
 
 /**
+ * Quote argv entries into a single POSIX shell command string.
+ * Preserves spaces and shell-special characters when we must use `-c`.
+ */
+function formatPosixCommand(args: string[]): string {
+  return args
+    .map((arg) => {
+      if (arg.length === 0) return "''";
+      if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(arg)) return arg;
+      return `'${arg.replace(/'/g, `'\"'\"'`)}'`;
+    })
+    .join(' ');
+}
+
+/**
  * Check if a process is currently running by PID
  * Uses platform-appropriate methods for reliable detection
  */
@@ -334,7 +348,7 @@ export function resolveCommand(command: string[]): {
         // Non-interactive command execution
         return {
           command: userShell,
-          args: ['-c', command.join(' ')],
+          args: ['-c', formatPosixCommand(command)],
           useShell: true,
           resolvedFrom: 'shell',
         };
@@ -342,7 +356,7 @@ export function resolveCommand(command: string[]): {
         // Interactive shell session
         return {
           command: userShell,
-          args: ['-i', '-c', command.join(' ')],
+          args: ['-i', '-c', formatPosixCommand(command)],
           useShell: true,
           resolvedFrom: 'shell',
           isInteractive: true,
@@ -380,7 +394,7 @@ export function resolveCommand(command: string[]): {
         // The -l flag makes it a login shell, ensuring profile/rc files are sourced
         return {
           command: userShell,
-          args: ['-i', '-l', '-c', command.join(' ')],
+          args: ['-i', '-l', '-c', formatPosixCommand(command)],
           useShell: true,
           resolvedFrom: 'alias',
         };
@@ -388,7 +402,7 @@ export function resolveCommand(command: string[]): {
         // No shell config found, use basic execution
         return {
           command: userShell,
-          args: ['-c', command.join(' ')],
+          args: ['-c', formatPosixCommand(command)],
           useShell: true,
           resolvedFrom: 'shell',
         };
@@ -397,7 +411,7 @@ export function resolveCommand(command: string[]): {
       // Interactive shell session: use -i and -l for proper initialization
       return {
         command: userShell,
-        args: ['-i', '-l', '-c', command.join(' ')],
+        args: ['-i', '-l', '-c', formatPosixCommand(command)],
         useShell: true,
         resolvedFrom: 'shell',
         isInteractive: true,

--- a/web/src/test/unit/fwd-argument-parsing.test.ts
+++ b/web/src/test/unit/fwd-argument-parsing.test.ts
@@ -54,6 +54,26 @@ describe('ProcessUtils command parsing', () => {
       expect(result.args).toContain('myalias --some-flag');
     });
 
+    it('should preserve quoted args with spaces in shell fallback', () => {
+      const command = ['myalias', '--message', 'hello world'];
+      const result = ProcessUtils.resolveCommand(command);
+
+      expect(result.useShell).toBe(true);
+      expect(result.resolvedFrom).toBe('alias');
+      expect(result.args).toContain('-c');
+      expect(result.args).toContain("myalias --message 'hello world'");
+    });
+
+    it('should escape single quotes safely in shell fallback', () => {
+      const command = ['myalias', '--message', "it's done"];
+      const result = ProcessUtils.resolveCommand(command);
+
+      expect(result.useShell).toBe(true);
+      expect(result.resolvedFrom).toBe('alias');
+      expect(result.args).toContain('-c');
+      expect(result.args).toContain("myalias --message 'it'\"'\"'s done'");
+    });
+
     it('should handle regular binaries in PATH', () => {
       // Common commands that should exist in PATH
       const testCommands = [

--- a/web/src/test/unit/fwd-argument-parsing.test.ts
+++ b/web/src/test/unit/fwd-argument-parsing.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'child_process';
-import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -36,10 +36,33 @@ function captureFallbackArgs(
       aliasDefinition.replace('$CAPTURE', capturePath),
       'utf8'
     );
+
+    let testShellPath = shellPath;
+    if (shellPath === '/bin/bash') {
+      const binDir = join(tempHome, 'bin');
+      mkdirSync(binDir);
+      testShellPath = join(binDir, 'bash');
+      writeFileSync(
+        testShellPath,
+        [
+          '#!/bin/bash',
+          'args=()',
+          'for arg in "$@"; do',
+          '  [[ "$arg" == "-l" ]] || args+=("$arg")',
+          'done',
+          `exec /bin/bash --noprofile --rcfile "$HOME/.bashrc" "\${args[@]}"`,
+          '',
+        ].join('\n'),
+        'utf8'
+      );
+      chmodSync(testShellPath, 0o755);
+    }
+
     process.env.HOME = tempHome;
-    process.env.SHELL = shellPath;
+    process.env.SHELL = testShellPath;
 
     const resolved = ProcessUtils.resolveCommand(['vt_test_alias', ...expectedArgs]);
+    expect(resolved.resolvedFrom).toBe('alias');
     const result = spawnSync(resolved.command, resolved.args, {
       env: { ...process.env, HOME: tempHome },
     });
@@ -77,13 +100,16 @@ describe('ProcessUtils command parsing', () => {
       // The actual command is in the args after -c
       const cIndex = result.args.indexOf('-c');
       expect(cIndex).toBeGreaterThan(-1);
-      // ProcessUtils preserves the command string after -c
-      // In some environments this may include the full shell invocation
       const commandAfterC = result.args[cIndex + 1];
-      expect(commandAfterC).toMatch(/echo "hello"/);
-      // In some environments, ProcessUtils may resolve this as 'shell' instead of 'path'
-      expect(['path', 'shell']).toContain(result.resolvedFrom);
-      expect(result.useShell).toBe(result.resolvedFrom === 'shell');
+      if (result.resolvedFrom === 'path') {
+        expect(commandAfterC).toBe('echo "hello"');
+        expect(result.useShell).toBe(false);
+      } else {
+        expect(commandAfterC).toBe('/bin/zsh "$@"');
+        expect(result.args.slice(cIndex + 2)).toEqual(['--', '-i', '-c', 'echo "hello"']);
+        expect(['shell', 'alias']).toContain(result.resolvedFrom);
+        expect(result.useShell).toBe(true);
+      }
       expect(result.isInteractive).toBe(true);
     });
 
@@ -147,7 +173,7 @@ describe('ProcessUtils command parsing', () => {
     });
 
     itWithBash('should preserve arbitrary arguments through a Bash alias fallback', () => {
-      captureFallbackArgs('/bin/bash', '.bash_profile', "alias vt_test_alias='$CAPTURE'\n");
+      captureFallbackArgs('/bin/bash', '.bashrc', "alias vt_test_alias='$CAPTURE'\n");
     });
 
     itWithTcsh('should preserve arbitrary arguments through a tcsh alias fallback', () => {
@@ -215,13 +241,21 @@ describe('ProcessUtils command parsing', () => {
       // The actual command is preserved after -c
       const cIndex = result.args.indexOf('-c');
       expect(cIndex).toBeGreaterThan(-1);
-      // ProcessUtils preserves the command string after -c
-      // In some environments this may include the full shell invocation
       const commandAfterC = result.args[cIndex + 1];
-      expect(commandAfterC).toMatch(/claude --dangerously-skip-permissions/);
-      // In some environments, ProcessUtils may resolve this as 'shell' instead of 'path'
-      expect(['path', 'shell']).toContain(result.resolvedFrom);
-      expect(result.useShell).toBe(result.resolvedFrom === 'shell');
+      if (result.resolvedFrom === 'path') {
+        expect(commandAfterC).toBe('claude --dangerously-skip-permissions');
+        expect(result.useShell).toBe(false);
+      } else {
+        expect(commandAfterC).toBe('/bin/zsh "$@"');
+        expect(result.args.slice(cIndex + 2)).toEqual([
+          '--',
+          '-i',
+          '-c',
+          'claude --dangerously-skip-permissions',
+        ]);
+        expect(['shell', 'alias']).toContain(result.resolvedFrom);
+        expect(result.useShell).toBe(true);
+      }
       expect(result.isInteractive).toBe(true);
     });
 

--- a/web/src/test/unit/fwd-argument-parsing.test.ts
+++ b/web/src/test/unit/fwd-argument-parsing.test.ts
@@ -1,5 +1,62 @@
+import { spawnSync } from 'child_process';
+import { chmodSync, existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProcessUtils } from '../../server/pty/process-utils.js';
+
+const itWithBash = existsSync('/bin/bash') ? it : it.skip;
+const itWithTcsh = existsSync('/bin/tcsh') ? it : it.skip;
+
+function captureFallbackArgs(
+  shellPath: string,
+  configName: string,
+  aliasDefinition: string
+): string[] {
+  const tempHome = mkdtempSync(join(tmpdir(), 'vt-shell-fallback-'));
+  const capturePath = join(tempHome, 'capture-args.sh');
+  const originalHome = process.env.HOME;
+  const originalShell = process.env.SHELL;
+  const expectedArgs = [
+    'hello world',
+    "it's done",
+    '',
+    '$HOME; echo injected',
+    '-n',
+    'line1\nline2',
+    'double"quote',
+    'back\\slash',
+  ];
+
+  try {
+    writeFileSync(capturePath, '#!/bin/sh\nprintf \'%s\\000\' "$@"\n', 'utf8');
+    chmodSync(capturePath, 0o755);
+    writeFileSync(
+      join(tempHome, configName),
+      aliasDefinition.replace('$CAPTURE', capturePath),
+      'utf8'
+    );
+    process.env.HOME = tempHome;
+    process.env.SHELL = shellPath;
+
+    const resolved = ProcessUtils.resolveCommand(['vt_test_alias', ...expectedArgs]);
+    const result = spawnSync(resolved.command, resolved.args, {
+      env: { ...process.env, HOME: tempHome },
+    });
+
+    expect(result.status, result.stderr.toString('utf8')).toBe(0);
+    const actualArgs = result.stdout.toString('utf8').split('\0');
+    actualArgs.pop();
+    expect(actualArgs).toEqual(expectedArgs);
+    return actualArgs;
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalShell === undefined) delete process.env.SHELL;
+    else process.env.SHELL = originalShell;
+    rmSync(tempHome, { recursive: true, force: true });
+  }
+}
 
 describe('ProcessUtils command parsing', () => {
   beforeEach(() => {
@@ -46,32 +103,55 @@ describe('ProcessUtils command parsing', () => {
     it('should handle aliases that require shell resolution', () => {
       // Simulate a command that's not in PATH (like an alias)
       const command = ['myalias', '--some-flag'];
-      const result = ProcessUtils.resolveCommand(command);
+      const originalShell = process.env.SHELL;
+      process.env.SHELL = '/bin/bash';
 
-      expect(result.useShell).toBe(true);
-      expect(result.resolvedFrom).toBe('alias');
-      expect(result.args).toContain('-c');
-      expect(result.args).toContain('myalias --some-flag');
+      try {
+        const result = ProcessUtils.resolveCommand(command);
+        const commandIndex = result.args.indexOf('-c') + 1;
+
+        expect(result.useShell).toBe(true);
+        expect(result.resolvedFrom).toBe('alias');
+        expect(result.args[commandIndex]).toBe('myalias "$@"');
+        expect(result.args.slice(commandIndex + 1)).toEqual(['--', '--some-flag']);
+      } finally {
+        if (originalShell === undefined) delete process.env.SHELL;
+        else process.env.SHELL = originalShell;
+      }
     });
 
-    it('should preserve quoted args with spaces in shell fallback', () => {
-      const command = ['myalias', '--message', 'hello world'];
-      const result = ProcessUtils.resolveCommand(command);
+    it('should pass fish fallback arguments through $argv', () => {
+      const originalShell = process.env.SHELL;
+      process.env.SHELL = '/bin/fish';
 
-      expect(result.useShell).toBe(true);
-      expect(result.resolvedFrom).toBe('alias');
-      expect(result.args).toContain('-c');
-      expect(result.args).toContain("myalias --message 'hello world'");
+      try {
+        const commandArgs = ['hello world', "it's done", '', '-n'];
+        const result = ProcessUtils.resolveCommand(['myalias', ...commandArgs]);
+        const commandIndex = result.args.indexOf('-c') + 1;
+
+        expect(result.args[commandIndex]).toBe('myalias $argv');
+        expect(result.args.slice(commandIndex + 1)).toEqual(commandArgs);
+      } finally {
+        if (originalShell === undefined) delete process.env.SHELL;
+        else process.env.SHELL = originalShell;
+      }
     });
 
-    it('should escape single quotes safely in shell fallback', () => {
-      const command = ['myalias', '--message', "it's done"];
-      const result = ProcessUtils.resolveCommand(command);
+    it('should reject shell syntax in unresolved command names', () => {
+      expect(() =>
+        ProcessUtils.resolveCommand(['missing; touch /tmp/vt-shell-injection', '--flag'])
+      ).toThrow('Unsafe shell fallback command name');
+      expect(() => ProcessUtils.resolveCommand(['FOO=bar', 'echo', 'injected'])).toThrow(
+        'Unsafe shell fallback command name'
+      );
+    });
 
-      expect(result.useShell).toBe(true);
-      expect(result.resolvedFrom).toBe('alias');
-      expect(result.args).toContain('-c');
-      expect(result.args).toContain("myalias --message 'it'\"'\"'s done'");
+    itWithBash('should preserve arbitrary arguments through a Bash alias fallback', () => {
+      captureFallbackArgs('/bin/bash', '.bash_profile', "alias vt_test_alias='$CAPTURE'\n");
+    });
+
+    itWithTcsh('should preserve arbitrary arguments through a tcsh alias fallback', () => {
+      captureFallbackArgs('/bin/tcsh', '.tcshrc', "alias vt_test_alias '$CAPTURE \\!*'\n");
     });
 
     it('should handle regular binaries in PATH', () => {
@@ -165,11 +245,12 @@ describe('ProcessUtils command parsing', () => {
 
       const command = ['nonexistentcommand123', '--flag'];
       const result = ProcessUtils.resolveCommand(command);
+      const commandIndex = result.args.indexOf('-c') + 1;
 
       expect(result.useShell).toBe(true);
       expect(result.resolvedFrom).toBe('alias');
-      expect(result.args).toContain('-c');
-      expect(result.args).toContain('nonexistentcommand123 --flag');
+      expect(result.args[commandIndex]).toContain('nonexistentcommand123');
+      expect(result.args.slice(commandIndex + 1)).toContain('--flag');
     });
   });
 });

--- a/web/src/test/unit/fwd-argument-parsing.test.ts
+++ b/web/src/test/unit/fwd-argument-parsing.test.ts
@@ -1,5 +1,13 @@
 import { spawnSync } from 'child_process';
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -15,6 +23,7 @@ function captureFallbackArgs(
 ): string[] {
   const tempHome = mkdtempSync(join(tmpdir(), 'vt-shell-fallback-'));
   const capturePath = join(tempHome, 'capture-args.sh');
+  const captureOutputPath = join(tempHome, 'captured-args');
   const originalHome = process.env.HOME;
   const originalShell = process.env.SHELL;
   const expectedArgs = [
@@ -29,7 +38,11 @@ function captureFallbackArgs(
   ];
 
   try {
-    writeFileSync(capturePath, '#!/bin/sh\nprintf \'%s\\000\' "$@"\n', 'utf8');
+    writeFileSync(
+      capturePath,
+      '#!/bin/sh\nprintf \'%s\\000\' "$@" > "$VT_CAPTURE_OUTPUT"\n',
+      'utf8'
+    );
     chmodSync(capturePath, 0o755);
     writeFileSync(
       join(tempHome, configName),
@@ -64,11 +77,11 @@ function captureFallbackArgs(
     const resolved = ProcessUtils.resolveCommand(['vt_test_alias', ...expectedArgs]);
     expect(resolved.resolvedFrom).toBe('alias');
     const result = spawnSync(resolved.command, resolved.args, {
-      env: { ...process.env, HOME: tempHome },
+      env: { ...process.env, HOME: tempHome, VT_CAPTURE_OUTPUT: captureOutputPath },
     });
 
     expect(result.status, result.stderr.toString('utf8')).toBe(0);
-    const actualArgs = result.stdout.toString('utf8').split('\0');
+    const actualArgs = readFileSync(captureOutputPath, 'utf8').split('\0');
     actualArgs.pop();
     expect(actualArgs).toEqual(expectedArgs);
     return actualArgs;


### PR DESCRIPTION
## Summary
- preserve exact argv boundaries when `ProcessUtils` falls back to shell execution
- pass user arguments through shell positional parameters instead of interpolating them into `-c` command text
- support Bourne-style shells, fish, csh, and tcsh while leaving PowerShell/cmd behavior unchanged
- reject unsafe unresolved command names before shell fallback
- add regression coverage for spaces, quotes, backslashes, empty values, newlines, dash-prefixed values, and shell metacharacters

## Validation
- `cd web && pnpm exec vitest run src/test/unit/fwd-argument-parsing.test.ts src/test/integration/vt-wrapper-extra.e2e.test.ts` (16 passed)
- `cd web && VIBETUNNEL_BIN="$PWD/bin/vibetunnel" pnpm run test:vt`
- real Bash and tcsh alias fallback proof
- `cd web && pnpm exec vitest run --mode=server --maxWorkers=4` (568 passed, 75 skipped)
- `cd web && pnpm run format:check`
- `cd web && pnpm run lint`
- `cd web && pnpm run typecheck`
- branch autoreview: clean
- full Vitest: 1,444 passed, 111 skipped; eight unrelated local-environment failures remain in DOM-less quick-key tests and native-binary-dependent title tests
- GitHub Actions: 11 passed, two expected skips

## Notes
Supersedes #591 with a smaller server-only implementation. The changelog credits both @Ilakiancs for the original report/fix and @nikolasdehor for this focused follow-up.
