### PR TITLE
fix(server): add transient-failure tolerance to remote health checks

### DIFF
--- a/web/src/server/services/remote-registry.ts
+++ b/web/src/server/services/remote-registry.ts
@@ -12,6 +12,7 @@ export interface RemoteServer {
   registeredAt: Date;
   lastHeartbeat: Date;
   sessionIds: Set<string>; // Track which sessions belong to this remote
+  consecutiveFailures: number; // Consecutive health check failures
 }
 
 export class RemoteRegistry {
@@ -21,6 +22,7 @@ export class RemoteRegistry {
   private healthCheckInterval: NodeJS.Timeout | null = null;
   private readonly HEALTH_CHECK_INTERVAL = 15000; // Check every 15 seconds
   private readonly HEALTH_CHECK_TIMEOUT = 5000; // 5 second timeout per check
+  private readonly MAX_CONSECUTIVE_FAILURES = 3;
 
   constructor() {
     this.startHealthChecker();
@@ -44,6 +46,7 @@ export class RemoteRegistry {
       registeredAt: now,
       lastHeartbeat: now,
       sessionIds: new Set<string>(),
+      consecutiveFailures: 0,
     };
 
     this.remotes.set(remote.id, registeredRemote);
@@ -171,6 +174,12 @@ export class RemoteRegistry {
       clearTimeout(timeoutId);
 
       if (response.ok) {
+        if (remote.consecutiveFailures > 0) {
+          logger.debug(
+            `remote ${remote.name} recovered after ${remote.consecutiveFailures} failed checks`
+          );
+        }
+        remote.consecutiveFailures = 0;
         remote.lastHeartbeat = new Date();
         logger.debug(`health check passed for ${remote.name}`);
       } else {
@@ -178,10 +187,22 @@ export class RemoteRegistry {
       }
     } catch (error) {
       // During shutdown, don't log errors or unregister remotes
-      if (!isShuttingDown()) {
-        logger.warn(`remote failed health check: ${remote.name} (${remote.id})`, error);
-        // Remove the remote if it fails health check
+      if (isShuttingDown()) {
+        return;
+      }
+
+      remote.consecutiveFailures++;
+      if (remote.consecutiveFailures >= this.MAX_CONSECUTIVE_FAILURES) {
+        logger.warn(
+          `remote ${remote.name} (${remote.id}) failed ${remote.consecutiveFailures}/${this.MAX_CONSECUTIVE_FAILURES} health checks, removing`,
+          error
+        );
         this.unregister(remote.id);
+      } else {
+        logger.warn(
+          `remote ${remote.name} failed health check (${remote.consecutiveFailures}/${this.MAX_CONSECUTIVE_FAILURES})`,
+          error instanceof Error ? error.message : String(error)
+        );
       }
     }
   }

--- a/web/src/test/unit/remote-registry.test.ts
+++ b/web/src/test/unit/remote-registry.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RemoteRegistry } from '../../server/services/remote-registry.js';
+
+vi.mock('../../server/server.js', () => ({
+  isShuttingDown: () => false,
+}));
+
+describe('RemoteRegistry health tolerance', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps remote registered after one transient health check failure', async () => {
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockRejectedValueOnce(new Error('timeout'));
+    fetchMock.mockResolvedValue({ ok: true } as Response);
+
+    const registry = new RemoteRegistry();
+    const remote = registry.register({
+      id: 'r1',
+      name: 'remote-1',
+      url: 'http://localhost:9999',
+      token: 'token',
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+
+    expect(registry.getRemote(remote.id)).toBeDefined();
+    expect(registry.getRemote(remote.id)?.consecutiveFailures).toBe(1);
+
+    registry.destroy();
+  });
+
+  it('removes remote after three consecutive health check failures', async () => {
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    const registry = new RemoteRegistry();
+    registry.register({
+      id: 'r2',
+      name: 'remote-2',
+      url: 'http://localhost:9998',
+      token: 'token',
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+    expect(registry.getRemote('r2')).toBeDefined();
+
+    await vi.advanceTimersByTimeAsync(15000);
+    await Promise.resolve();
+    expect(registry.getRemote('r2')).toBeDefined();
+
+    await vi.advanceTimersByTimeAsync(15000);
+    await Promise.resolve();
+    expect(registry.getRemote('r2')).toBeUndefined();
+
+    registry.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- add transient failure tolerance to `RemoteRegistry` health checks
- track `consecutiveFailures` per remote
- unregister only after 3 consecutive failures (instead of immediate removal on first failure)
- reset failure counter on successful health check
- add unit tests for:
  - single transient failure keeps remote registered
  - 3 consecutive failures unregister remote

## Why
Distributed environments frequently hit temporary network/timeout issues. Removing remotes after a single failed probe causes unnecessary churn.

## Validation
- `cd web && pnpm exec vitest run src/test/unit/remote-registry.test.ts` ✅

Closes #594
