### PR TITLE
fix(web): prevent mobile header controls from clipping on narrow screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Keep mobile session header controls visible and comfortably tappable at narrow phone widths (via [@nikolasdehor](https://github.com/nikolasdehor)) (#605)
 - Jitter iOS reconnection backoff within its configured cap to spread retries after outages (via [@bianbiandashen](https://github.com/bianbiandashen)) (#593)
 - Keep `vt` git metadata alive for sessions in repositories without an upstream branch, preventing forwarder crashes (via [@ndraiman](https://github.com/ndraiman)) (#566)
 - Keep HQ remotes registered through transient health-check failures and remove them only after three consecutive failures (via [@bianbiandashen](https://github.com/bianbiandashen) and [@nikolasdehor](https://github.com/nikolasdehor)) (#594)
@@ -48,7 +49,7 @@
 - Thanks [@yv-was-taken](https://github.com/yv-was-taken) for fixing global npm and Bun installs.
 - Thanks [@ChimeraFlutter](https://github.com/ChimeraFlutter) for fixing desktop terminal clipping.
 - Thanks [@Ilakiancs](https://github.com/Ilakiancs) for identifying lost argument boundaries in shell fallback execution.
-- Thanks [@nikolasdehor](https://github.com/nikolasdehor) for fixing `vt --title-mode` and shell fallback argument forwarding, preserving terminal link taps, and adding remote health-check regression coverage.
+- Thanks [@nikolasdehor](https://github.com/nikolasdehor) for fixing narrow mobile session headers, `vt --title-mode`, and shell fallback argument forwarding, preserving terminal link taps, and adding remote health-check regression coverage.
 - Thanks [@rothnic](https://github.com/rothnic) for defaulting to universal macOS binaries.
 
 ## [1.0.0-beta.15] - 2025-08-02

--- a/web/playwright.config.fast.ts
+++ b/web/playwright.config.fast.ts
@@ -66,6 +66,7 @@ export default defineConfig({
         '**/basic-session.spec.ts',
         '**/minimal-session.spec.ts',
         '**/session-navigation.spec.ts',
+        '**/session-header-responsive.spec.ts',
         '**/ui-features.spec.ts',
         '**/file-browser-basic.spec.ts',
         '**/terminal-basic.spec.ts',

--- a/web/src/client/components/session-view/compact-menu.ts
+++ b/web/src/client/components/session-view/compact-menu.ts
@@ -216,7 +216,7 @@ export class CompactMenu extends LitElement {
     return html`
       <div class="relative w-[44px] flex-shrink-0">
         <button
-          class="p-2 bg-bg-tertiary border ${this.showMenu ? 'text-primary border-primary' : 'text-primary border-border'} hover:border-primary hover:text-primary hover:bg-surface-hover rounded-lg transition-all duration-200"
+          class="w-11 h-11 p-0 md:w-auto md:h-auto md:p-2 flex items-center justify-center bg-bg-tertiary border ${this.showMenu ? 'text-primary border-primary' : 'text-primary border-border'} hover:border-primary hover:text-primary hover:bg-surface-hover rounded-lg transition-all duration-200"
           @click=${this.toggleMenu}
           @keydown=${this.handleMenuButtonKeyDown}
           title="More actions"

--- a/web/src/client/components/session-view/session-header.test.ts
+++ b/web/src/client/components/session-view/session-header.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { fixture, html } from '@open-wc/testing';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMockSession } from '@/test/utils/lit-test-utils';
 import type { SessionHeader } from './session-header.js';
 
@@ -19,28 +19,87 @@ vi.mock('../../services/terminal-socket-client.js', () => ({
 import './session-header.js';
 
 describe('SessionHeader', () => {
-  let element: SessionHeader;
-
-  beforeEach(async () => {
-    element = await fixture<SessionHeader>(html`
-      <session-header
-        .session=${createMockSession({ id: 'header-back-button' })}
-        .showBackButton=${true}
-      ></session-header>
-    `);
-  });
+  const elements: SessionHeader[] = [];
 
   afterEach(() => {
-    element.remove();
+    for (const element of elements) {
+      element.remove();
+    }
+    elements.length = 0;
   });
 
-  it('uses a 44px mobile target for the back button', () => {
-    const backButton = Array.from(element.querySelectorAll('button')).find(
-      (button) => button.textContent?.trim() === 'Back'
+  async function renderHeader(options: {
+    isMobile: boolean;
+    showBackButton?: boolean;
+    showSidebarToggle?: boolean;
+    sidebarCollapsed?: boolean;
+    onBack?: () => void;
+    onSidebarToggle?: () => void;
+  }): Promise<SessionHeader> {
+    const element = await fixture<SessionHeader>(html`
+      <session-header
+        .session=${createMockSession({ id: 'header-controls' })}
+        .isMobile=${options.isMobile}
+        .showBackButton=${options.showBackButton ?? false}
+        .showSidebarToggle=${options.showSidebarToggle ?? false}
+        .sidebarCollapsed=${options.sidebarCollapsed ?? false}
+        .onBack=${options.onBack}
+        .onSidebarToggle=${options.onSidebarToggle}
+      ></session-header>
+    `);
+    elements.push(element);
+    return element;
+  }
+
+  it('renders compact 44px mobile navigation controls and preserves callbacks', async () => {
+    const onBack = vi.fn();
+    const onSidebarToggle = vi.fn();
+    const element = await renderHeader({
+      isMobile: true,
+      showBackButton: true,
+      showSidebarToggle: true,
+      sidebarCollapsed: true,
+      onBack,
+      onSidebarToggle,
+    });
+
+    const backButton = element.querySelector<HTMLButtonElement>(
+      '[data-testid="session-back-button"]'
+    );
+    const sidebarButton = element.querySelector<HTMLButtonElement>(
+      '[data-testid="session-sidebar-toggle"]'
+    );
+    const chatButton = element.querySelector<HTMLButtonElement>(
+      '[data-testid="chat-mode-toggle-button-compact"]'
+    );
+    const menuButton = element.querySelector<HTMLButtonElement>(
+      'compact-menu button[aria-label="More actions menu"]'
     );
 
-    expect(backButton).toBeTruthy();
-    expect(backButton?.classList.contains('min-h-[44px]')).toBe(true);
-    expect(backButton?.classList.contains('sm:min-h-0')).toBe(true);
+    for (const button of [backButton, sidebarButton, chatButton, menuButton]) {
+      expect(button).toBeTruthy();
+      expect(button?.classList.contains('w-11')).toBe(true);
+      expect(button?.classList.contains('h-11')).toBe(true);
+    }
+
+    expect(backButton?.getAttribute('aria-label')).toBe('Back');
+    expect(backButton?.textContent?.trim()).toBe('');
+    expect(backButton?.querySelector('svg')).toBeTruthy();
+
+    backButton?.click();
+    sidebarButton?.click();
+    expect(onBack).toHaveBeenCalledTimes(1);
+    expect(onSidebarToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the desktop back label and responsive sizing classes', async () => {
+    const element = await renderHeader({ isMobile: false, showBackButton: true });
+    const backButton = element.querySelector<HTMLButtonElement>(
+      '[data-testid="session-back-button"]'
+    );
+
+    expect(backButton?.textContent?.trim()).toBe('Back');
+    expect(backButton?.classList.contains('md:w-auto')).toBe(true);
+    expect(backButton?.classList.contains('md:h-auto')).toBe(true);
   });
 });

--- a/web/src/client/components/session-view/session-header.ts
+++ b/web/src/client/components/session-view/session-header.ts
@@ -165,23 +165,38 @@ export class SessionHeader extends LitElement {
     if (!this.session) return null;
 
     return html`
+      <style>
+        .session-header-container {
+          --vt-header-padding-left: max(1rem, env(safe-area-inset-left));
+          --vt-header-padding-right: max(1rem, env(safe-area-inset-right));
+          padding-left: var(--vt-header-padding-left);
+          padding-right: var(--vt-header-padding-right);
+        }
+
+        @media (max-width: 480px) {
+          .session-header-container {
+            --vt-header-padding-left: max(0.5rem, env(safe-area-inset-left));
+            --vt-header-padding-right: max(0.5rem, env(safe-area-inset-right));
+          }
+        }
+      </style>
       <!-- Header content -->
       <div
-        class="flex items-center justify-between border-b border-border text-sm min-w-0 max-w-[100vw] bg-bg-secondary px-4 py-2 session-header-container"
-        style="padding-left: max(1rem, env(safe-area-inset-left)); padding-right: max(1rem, env(safe-area-inset-right));"
+        class="flex items-center justify-between border-b border-border text-sm min-w-0 max-w-[100vw] bg-bg-secondary py-2 session-header-container"
       >
-        <div class="flex items-center gap-3 min-w-0 flex-1 overflow-hidden flex-shrink">
+        <div class="flex items-center gap-2 sm:gap-3 min-w-0 flex-1 overflow-hidden flex-shrink">
           <!-- Sidebar Toggle (when sidebar is collapsed) - visible on all screen sizes -->
           ${
             this.showSidebarToggle && this.sidebarCollapsed
               ? html`
                 <button
-                  class="bg-bg-tertiary border border-border rounded-md p-2 text-primary transition-all duration-200 hover:bg-surface-hover hover:border-primary flex-shrink-0"
+                  class="bg-bg-tertiary border border-border rounded-md w-11 h-11 p-0 md:w-auto md:h-auto md:p-2 text-primary transition-all duration-200 hover:bg-surface-hover hover:border-primary flex items-center justify-center flex-shrink-0"
                   @click=${() => this.onSidebarToggle?.()}
                   title="Show sidebar (⌘B)"
                   aria-label="Show sidebar"
                   aria-expanded="false"
                   aria-controls="sidebar"
+                  data-testid="session-sidebar-toggle"
                 >
                   <!-- Right chevron icon to expand sidebar -->
                   <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor">
@@ -235,10 +250,20 @@ export class SessionHeader extends LitElement {
             this.showBackButton
               ? html`
                 <button
-                  class="bg-bg-tertiary border border-border rounded-md px-4 py-2.5 sm:px-3 sm:py-1.5 min-h-[44px] sm:min-h-0 flex items-center justify-center font-mono text-xs text-primary transition-all duration-200 hover:bg-surface-hover hover:border-primary flex-shrink-0"
+                  class="bg-bg-tertiary border border-border rounded-md w-11 h-11 p-0 md:w-auto md:h-auto md:px-3 md:py-1.5 flex items-center justify-center font-mono text-xs text-primary transition-all duration-200 hover:bg-surface-hover hover:border-primary flex-shrink-0"
                   @click=${() => this.onBack?.()}
+                  aria-label="Back"
+                  data-testid="session-back-button"
                 >
-                  Back
+                  ${
+                    this.isMobile
+                      ? html`
+                        <svg width="16" height="16" viewBox="0 0 20 20" fill="currentColor">
+                          <path d="M12.707 15.707a1 1 0 01-1.414 0l-5-5a1 1 0 010-1.414l5-5a1 1 0 011.414 1.414L8.414 10l4.293 4.293a1 1 0 010 1.414z"/>
+                        </svg>
+                      `
+                      : 'Back'
+                  }
                 </button>
               `
               : ''
@@ -323,7 +348,7 @@ export class SessionHeader extends LitElement {
             </div>
           </div>
         </div>
-        <div class="flex items-center gap-2 text-xs flex-shrink-0 ml-2">
+        <div class="flex items-center gap-1 sm:gap-2 text-xs flex-shrink-0 ml-1 sm:ml-2">
           <!-- Keyboard capture indicator (always visible) -->
           <keyboard-capture-indicator
             .active=${this.keyboardCaptureActive}
@@ -344,12 +369,13 @@ export class SessionHeader extends LitElement {
             this.useCompactMenu || this.isMobile
               ? html`
               <!-- Compact menu for tight spaces or mobile -->
-              <div class="flex items-center gap-2 flex-shrink-0">
+              <div class="flex items-center gap-1 sm:gap-2 flex-shrink-0">
                 <!-- Chat mode toggle button (always visible outside menu) -->
                 <button
-                  class="bg-bg-tertiary border border-border rounded-md p-2 text-primary transition-all duration-200 hover:bg-surface-hover hover:border-primary flex-shrink-0 ${this.chatMode ? 'bg-primary text-white border-primary' : ''}"
+                  class="bg-bg-tertiary border border-border rounded-md w-11 h-11 p-0 md:w-auto md:h-auto md:p-2 text-primary transition-all duration-200 hover:bg-surface-hover hover:border-primary flex items-center justify-center flex-shrink-0 ${this.chatMode ? 'bg-primary text-white border-primary' : ''}"
                   @click=${() => this.onToggleChatMode?.()}
                   title="${this.chatMode ? 'Switch to Terminal Mode' : 'Switch to Chat Mode'}"
+                  aria-label="${this.chatMode ? 'Switch to Terminal Mode' : 'Switch to Chat Mode'}"
                   data-testid="chat-mode-toggle-button-compact"
                 >
                   <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">

--- a/web/src/test/playwright/specs/session-header-responsive.spec.ts
+++ b/web/src/test/playwright/specs/session-header-responsive.spec.ts
@@ -1,0 +1,132 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect, test } from '../fixtures/test.fixture';
+import { TestSessionManager } from '../helpers/test-data-manager.helper';
+
+const androidUserAgent =
+  'Mozilla/5.0 (Linux; Android 14; Mobile) AppleWebKit/537.36 Chrome/125.0.0.0 Mobile Safari/537.36';
+
+async function expectInsideViewport(page: Page, locator: Locator, minimumSize = 44): Promise<void> {
+  const box = await locator.boundingBox();
+  const viewport = page.viewportSize();
+
+  expect(box).not.toBeNull();
+  expect(viewport).not.toBeNull();
+  if (!box || !viewport) return;
+
+  expect(box.x).toBeGreaterThanOrEqual(0);
+  expect(box.y).toBeGreaterThanOrEqual(0);
+  expect(box.x + box.width).toBeLessThanOrEqual(viewport.width);
+  expect(box.y + box.height).toBeLessThanOrEqual(viewport.height);
+  expect(box.width).toBeGreaterThanOrEqual(minimumSize);
+  expect(box.height).toBeGreaterThanOrEqual(minimumSize);
+}
+
+test.describe('mobile session header', () => {
+  test.use({
+    viewport: { width: 434, height: 965 },
+    userAgent: androidUserAgent,
+    isMobile: true,
+    hasTouch: true,
+  });
+
+  let sessionManager: TestSessionManager;
+
+  test.beforeEach(async ({ page }) => {
+    sessionManager = new TestSessionManager(page, 'header-mobile');
+    await sessionManager.createTrackedSession();
+    await expect(page.locator('session-header')).toBeVisible();
+  });
+
+  test.afterEach(async () => {
+    await sessionManager.cleanupAllSessions();
+  });
+
+  test('keeps navigation, chat, menu, and keyboard controls reachable at narrow widths', async ({
+    page,
+  }) => {
+    const headerControls = [
+      page.getByRole('button', { name: 'Show sidebar', exact: true }),
+      page.getByRole('button', { name: 'Switch to Chat Mode', exact: true }),
+      page.getByRole('button', { name: 'More actions menu', exact: true }),
+    ];
+
+    for (const viewport of [
+      { width: 700, height: 500 },
+      { width: 434, height: 965 },
+      { width: 390, height: 844 },
+      { width: 360, height: 800 },
+    ]) {
+      await page.setViewportSize(viewport);
+
+      await expect
+        .poll(() => page.evaluate(() => document.documentElement.scrollWidth))
+        .toBeLessThanOrEqual(viewport.width);
+
+      for (const control of headerControls) {
+        await expect(control).toBeVisible();
+        await expectInsideViewport(page, control);
+      }
+    }
+
+    await page.setViewportSize({ width: 434, height: 965 });
+    const menuButton = page.getByRole('button', { name: 'More actions menu', exact: true });
+    await menuButton.click();
+    await expect(page.getByTestId('compact-new-session')).toBeVisible();
+    await menuButton.click();
+    await expect(page.getByTestId('compact-new-session')).toBeHidden();
+
+    const keyboardButton = page.getByRole('button', { name: 'Keyboard', exact: true });
+    await expect(keyboardButton).toBeVisible();
+    await expectInsideViewport(page, keyboardButton);
+    await keyboardButton.click();
+    await expect(
+      page.getByRole('button', { name: 'Toggle mobile keyboard', exact: true })
+    ).toBeVisible();
+  });
+});
+
+test.describe('desktop session header', () => {
+  test.use({
+    viewport: { width: 1280, height: 720 },
+    userAgent:
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/125.0.0.0 Safari/537.36',
+    isMobile: false,
+    hasTouch: false,
+  });
+
+  let sessionManager: TestSessionManager;
+
+  test.beforeEach(async ({ page }) => {
+    sessionManager = new TestSessionManager(page, 'header-desktop');
+  });
+
+  test.afterEach(async () => {
+    await sessionManager.cleanupAllSessions();
+  });
+
+  test('preserves desktop header spacing and session details', async ({ page }) => {
+    const { sessionName } = await sessionManager.createTrackedSession();
+    const header = page.locator('.session-header-container');
+
+    await expect(header).toBeVisible();
+    await expect(header).toContainText(sessionName);
+    await expect
+      .poll(() =>
+        header.evaluate((element) => {
+          const styles = getComputedStyle(element);
+          return {
+            paddingLeft: styles.paddingLeft,
+            paddingRight: styles.paddingRight,
+            scrollWidth: document.documentElement.scrollWidth,
+            viewportWidth: window.innerWidth,
+          };
+        })
+      )
+      .toEqual({
+        paddingLeft: '16px',
+        paddingRight: '16px',
+        scrollWidth: 1280,
+        viewportWidth: 1280,
+      });
+  });
+});


### PR DESCRIPTION
## Summary

- keep session header controls inside narrow mobile viewports
- retain 44px tap targets across the app's full mobile breakpoint
- preserve desktop header spacing and control layout
- add unit and Playwright regression coverage, including the reported 434x965 viewport and nearby narrower widths

## Verification

- 434x965, 390x844, 360x800, and 700x500 mobile viewports: no horizontal overflow; sidebar, chat, and menu controls remain 44x44 and fully visible
- compact menu opens and closes; keyboard action opens the mobile quick-key controls
- 1280x720 desktop viewport: 16px header padding and no horizontal overflow
- unit tests: 654 passed, 14 skipped
- server tests: 572 passed, 75 skipped
- CI-equivalent Playwright suite: 24 passed, 3 skipped
- TypeScript, Biome, client build, diff checks, and structured autoreview pass

## Live Proof

Validated the exact final candidate in the existing Chrome profile with Android mobile emulation. The reported viewport and the wider mobile-breakpoint case both retain visible 44px header controls with no document overflow. Desktop rendering is unchanged.

A real affected Android device or emulator is not attached to this machine, so merge remains held pending that final device proof.
