### PR TITLE
fix(web): avoid stealing focus when tapping terminal links

### DIFF
--- a/web/src/client/components/terminal.test.ts
+++ b/web/src/client/components/terminal.test.ts
@@ -233,6 +233,42 @@ describe('Terminal', () => {
         });
       }
     });
+
+    it('should not steal focus when clicking a terminal link', async () => {
+      const terminalRoot = element.querySelector('.terminal-root') as HTMLElement | null;
+      const pasteInput = element.querySelector(
+        '.terminal-paste-input'
+      ) as HTMLTextAreaElement | null;
+      expect(terminalRoot).toBeTruthy();
+      expect(pasteInput).toBeTruthy();
+
+      const focusSpy = vi.spyOn(pasteInput as HTMLTextAreaElement, 'focus');
+
+      const link = document.createElement('a');
+      link.href = 'https://example.com';
+      link.textContent = 'example';
+      link.className = 'terminal-link';
+      terminalRoot?.appendChild(link);
+
+      link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+      expect(focusSpy).not.toHaveBeenCalled();
+    });
+
+    it('should focus paste input when clicking non-link terminal area', async () => {
+      const terminalRoot = element.querySelector('.terminal-root') as HTMLElement | null;
+      const pasteInput = element.querySelector(
+        '.terminal-paste-input'
+      ) as HTMLTextAreaElement | null;
+      expect(terminalRoot).toBeTruthy();
+      expect(pasteInput).toBeTruthy();
+
+      const focusSpy = vi.spyOn(pasteInput as HTMLTextAreaElement, 'focus');
+
+      terminalRoot?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+      expect(focusSpy).toHaveBeenCalled();
+    });
   });
 
   describe('terminal sizing', () => {

--- a/web/src/client/components/terminal.ts
+++ b/web/src/client/components/terminal.ts
@@ -465,8 +465,13 @@ export class Terminal extends LitElement {
     this.scrollToBottom();
   };
 
-  private handleClick = () => {
+  private handleClick = (e: MouseEvent) => {
     if (this.disableClick) return;
+    const target = e.target as HTMLElement | null;
+    if (target?.closest('a[href]')) {
+      // Keep native link behavior (especially important on mobile browsers).
+      return;
+    }
     const selection = document.getSelection();
     if (selection && selection.toString().length > 0) return;
     this.focus();


### PR DESCRIPTION
## Summary
- stop `vibe-terminal` root click handler from forcing paste-input focus when click target is a link
- preserve native anchor tap/click behavior (important for mobile browsers)
- add regression tests for link click vs normal terminal click focus behavior

## Why
On mobile, tapping URLs in terminal output can be interrupted when the terminal click handler always redirects focus to the hidden paste input. This change keeps link taps native while preserving existing click-to-focus behavior elsewhere.

## Testing
- `cd web && pnpm exec vitest run src/client/components/terminal.test.ts`
- `cd web && pnpm exec biome check src/client/components/terminal.ts src/client/components/terminal.test.ts`

Closes #545
