### PR TITLE
fix: terminal bottom content cut off on desktop browsers

### DIFF
--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -1154,11 +1154,11 @@ export class SessionView extends LitElement {
             -webkit-overflow-scrolling: touch;
           }
           
-          /* Desktop: Keep existing terminal behavior */
+          /* Desktop: Terminal fills available space */
           .terminal-area vibe-terminal,
           .terminal-area vibe-terminal-binary {
-            height: calc(100% + 50px) !important;
-            margin-bottom: -50px !important;
+            height: 100% !important;
+            margin-bottom: 0 !important;
           }
           
           /* Desktop: Keep transform for quick keys */


### PR DESCRIPTION
Fixes #607

The desktop terminal area applied `height: calc(100% + 50px)` with `margin-bottom: -50px`, causing the parent's `overflow: hidden` to clip the bottom ~50px of terminal content.

Replace with `height: 100%` and `margin-bottom: 0` so the terminal fills its grid cell without overflowing.

Manually tested on desktop Chrome (macOS, full screen, 100% zoom) — all terminal lines now fully visible.