### PR TITLE
chore: add tests and slight docs mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Visit [http://localhost:4020](http://localhost:4020) to see all your terminal se
 
 - **🌐 Browser-Based Access** - Control your Mac terminal from any device with a web browser
 - **🚀 Zero Configuration** - No SSH keys, no port forwarding, no complexity
-- **🤖 AI Agent Friendly** - Perfect for monitoring Claude Code, ChatGPT, or any terminal-based AI tools
+- **🤖 AI Agent Friendly** - Perfect for monitoring Claude Code (including via Ollama), ChatGPT, or any terminal-based AI tools
 - **📊 Session Activity Indicators** - Real-time activity tracking shows which sessions are active or idle
 - **🔄 Git Follow Mode** - Terminal automatically follows your IDE's branch switching
 - **⌨️ Smart Keyboard Handling** - Intelligent shortcut routing with toggleable capture modes. When capture is active, use Cmd+1...9/0 (Mac) or Ctrl+1...9/0 (Linux) to quickly switch between sessions

--- a/web/src/test/utils/process-tree.test.ts
+++ b/web/src/test/utils/process-tree.test.ts
@@ -136,6 +136,33 @@ describe('process-tree', () => {
       expect(isClaudeInProcessTree()).toBe(true);
     });
 
+    it('should detect ollama launch claude', () => {
+      const mockOutput = `  PID  PPID COMMAND
+12345 67890 /usr/local/bin/ollama launch claude --model qwen3.5:397b-cloud -- --dangerously-skip-permissions`;
+
+      vi.mocked(execSync).mockReturnValueOnce(mockOutput);
+
+      expect(isClaudeInProcessTree()).toBe(true);
+    });
+
+    it('should detect ollama run claude', () => {
+      const mockOutput = `  PID  PPID COMMAND
+12345 67890 /usr/local/bin/ollama run claude --dangerously-skip-permissions`;
+
+      vi.mocked(execSync).mockReturnValueOnce(mockOutput);
+
+      expect(isClaudeInProcessTree()).toBe(true);
+    });
+
+    it('should detect claude-code binary directly', () => {
+      const mockOutput = `  PID  PPID COMMAND
+12345 67890 /usr/local/bin/claude-code --dangerously-skip-permissions`;
+
+      vi.mocked(execSync).mockReturnValueOnce(mockOutput);
+
+      expect(isClaudeInProcessTree()).toBe(true);
+    });
+
     it('should return false when claude is not in tree', () => {
       const mockOutput = `  PID  PPID COMMAND
 12345 67890 /usr/bin/node /path/to/other-app.js


### PR DESCRIPTION
add ollama process tree detection tests and docs

what:
- test cases for detecting ollama launch claude, ollama run claude, claude-code in process tree
- new section in claude docs for running via ollama wrapper
- readme tweak mentioning ollama support

why:
- vbtunnel already detects ollama wrapper but was undocumented and untested

run:
`vt zsh -c "ollama launch claude --model <model> -- --dangerously-skip-permissions"` etc..

ty for the dope project!