### PR TITLE
Harden CI, workflow refs, and bootstrap supply-chain paths

### DIFF
--- a/.github/actions/lint-reporter/action.yml
+++ b/.github/actions/lint-reporter/action.yml
@@ -32,7 +32,7 @@ runs:
 
     - name: Find Comment
       if: github.event_name == 'pull_request'
-      uses: peter-evans/find-comment@v3
+      uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
       id: fc
       continue-on-error: true
       with:
@@ -44,7 +44,7 @@ runs:
       if: github.event_name == 'pull_request'
       id: prepare
       continue-on-error: true
-      uses: actions/github-script@v7
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         github-token: ${{ inputs.github-token }}
         script: |
@@ -125,7 +125,7 @@ runs:
     
     - name: Create or Update Comment
       if: github.event_name == 'pull_request'
-      uses: peter-evans/create-or-update-comment@v4
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
       continue-on-error: true
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,22 @@ permissions:
   pull-requests: write
   issues: write
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Check which parts of the codebase have changed
   changes:
     name: Detect changes
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       web: ${{ steps.filter.outputs.web }}
       mac: ${{ steps.filter.outputs.mac }}
       ios: ${{ steps.filter.outputs.ios }}
     steps:
-    - uses: actions/checkout@v5
-    - uses: dorny/paths-filter@v4
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+    - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
       id: filter
       with:
         filters: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,12 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
 # Cancel in-progress runs when a new commit is pushed to the same PR
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
@@ -25,14 +31,14 @@ jobs:
     
     runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0  # Full history for better context
 
@@ -50,7 +56,7 @@ jobs:
       - name: Check if already reviewed
         id: check-review
         if: steps.check-permissions.outputs.is_fork != 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -83,12 +89,9 @@ jobs:
         if: steps.check-permissions.outputs.is_fork != 'true' && steps.check-review.outputs.skip != 'true'
         id: claude-review
         continue-on-error: true
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
-          # Use Claude Sonnet 4 (default model)
-          # model: "claude-opus-4-20250514"
           
           # Direct prompt for automated review with detailed instructions
           direct_prompt: |
@@ -139,7 +142,7 @@ jobs:
           
           # Enhanced tool access for better analysis
           allowed_tools: |
-            Bash(pnpm install)
+            Bash(pnpm install --frozen-lockfile)
             Bash(pnpm run build)
             Bash(pnpm run test)
             Bash(pnpm run test:*)
@@ -166,7 +169,7 @@ jobs:
       - name: Clean up old Claude comments
         if: steps.check-permissions.outputs.is_fork != 'true' && steps.check-review.outputs.skip != 'true'
         continue-on-error: true
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,12 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
 # Cancel in-progress runs when a new Claude command is triggered on the same issue/PR
 concurrency:
   group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
@@ -30,18 +36,15 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
@@ -50,7 +53,7 @@ jobs:
           # assignee_trigger: "claude-bot"
           
           # Optional: Allow Claude to run specific commands
-          allowed_tools: "Bash(pnpm install),Bash(pnpm run build),Bash(pnpm run test),Bash(pnpm run test:*),Bash(pnpm run lint),Bash(pnpm run lint:*),Bash(pnpm run typecheck),Bash(pnpm run format)"
+          allowed_tools: "Bash(pnpm install --frozen-lockfile),Bash(pnpm run build),Bash(pnpm run test),Bash(pnpm run test:*),Bash(pnpm run lint),Bash(pnpm run lint:*),Bash(pnpm run typecheck),Bash(pnpm run format)"
           
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |

--- a/.github/workflows/cleanup-claude-comments.yml
+++ b/.github/workflows/cleanup-claude-comments.yml
@@ -17,22 +17,26 @@ on:
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
     
     steps:
       - name: Checkout scripts
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           sparse-checkout: |
             .github/scripts/cleanup-claude-comments.js
       
       - name: Cleanup Claude comments on specific PR
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -48,7 +52,7 @@ jobs:
       
       - name: Cleanup Claude comments on closed PR
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -57,7 +61,7 @@ jobs:
       
       - name: Cleanup Claude comments on all recent PRs
         if: github.event_name == 'schedule'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -12,17 +12,17 @@ permissions:
 jobs:
   build-lint-test:
     name: Build, Lint, and Test iOS
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 30
     env:
       GITHUB_REPO_NAME: ${{ github.repository }}
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Setup Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
       with:
         xcode-version: '26.3'
     
@@ -34,7 +34,7 @@ jobs:
     # Node.js/pnpm not needed for iOS builds
     
     - name: Cache Homebrew packages
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       continue-on-error: true
       with:
         path: |
@@ -46,7 +46,7 @@ jobs:
           ${{ runner.os }}-brew-
     
     - name: Cache Swift packages
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       continue-on-error: true
       with:
         path: |
@@ -410,7 +410,7 @@ jobs:
     # ARTIFACT UPLOADS
     # Skip build artifact upload for PR builds to save time
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
       with:
         name: ios-build-artifacts
@@ -419,7 +419,7 @@ jobs:
     
     - name: Upload coverage artifacts
       if: always()
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       with:
         name: ios-coverage
         path: |
@@ -487,10 +487,10 @@ jobs:
         rm -rf * || true
         
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Download coverage artifacts
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
       with:
         name: ios-coverage
         path: ios-coverage-artifacts

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -15,17 +15,17 @@ env:
 jobs:
   build-lint-test:
     name: Build, Lint, and Test macOS
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 40
     env:
       GITHUB_REPO_NAME: ${{ github.repository }}
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Setup Xcode
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
       with:
         xcode-version: '26.1'
     
@@ -35,23 +35,23 @@ jobs:
         swift --version
     
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '24'
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       with:
-        version: 10
+        version: 10.15.0
         run_install: false
 
     - name: Setup Zig
-      uses: mlugg/setup-zig@v2
+      uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
       with:
         version: 0.15.2
     
     - name: Cache Homebrew packages
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       continue-on-error: true
       with:
         path: |
@@ -63,7 +63,7 @@ jobs:
           ${{ runner.os }}-brew-
     
     - name: Cache Swift packages
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       continue-on-error: true
       with:
         path: |
@@ -335,7 +335,7 @@ jobs:
     # Skip build artifact upload for PR builds to save time
     - name: Upload build artifacts
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       with:
         name: mac-build-artifacts
         path: |
@@ -345,7 +345,7 @@ jobs:
     
     - name: Upload coverage artifacts
       if: always()
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       with:
         name: mac-coverage
         path: |
@@ -423,10 +423,10 @@ jobs:
         rm -rf * || true
         
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Download coverage artifacts
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
       with:
         name: mac-coverage
         path: mac-coverage-artifacts

--- a/.github/workflows/monitor-ci.yml
+++ b/.github/workflows/monitor-ci.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
     - name: Check CI Status
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       id: check-status
       with:
         script: |
@@ -70,7 +70,7 @@ jobs:
     
     - name: Find Comment
       if: steps.check-status.outputs.should_comment == 'true'
-      uses: peter-evans/find-comment@v4
+      uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
       id: fc
       with:
         issue-number: ${{ steps.check-status.outputs.pr_number }}
@@ -79,7 +79,7 @@ jobs:
     
     - name: Create or Update Comment
       if: steps.check-status.outputs.should_comment == 'true'
-      uses: peter-evans/create-or-update-comment@v5
+      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ steps.check-status.outputs.pr_number }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   release-build-test:
     name: Build and Test Release Configuration
-    runs-on: macos-latest
+    runs-on: macos-15
     timeout-minutes: 60
     
     steps:
@@ -29,7 +29,7 @@ jobs:
         rm -rf * || true
         
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     
     - name: Verify Xcode
       run: |
@@ -37,23 +37,23 @@ jobs:
         swift --version
     
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '24'
     
     - name: Setup pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       with:
-        version: 10
+        version: 10.15.0
         dest: ~/pnpm-${{ github.run_id }}
 
     - name: Setup Zig
-      uses: mlugg/setup-zig@v2
+      uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
       with:
         version: 0.15.2
     
     - name: Cache Homebrew packages
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       continue-on-error: true
       with:
         path: |
@@ -103,7 +103,7 @@ jobs:
         echo "xcbeautify: $(xcbeautify --version || echo 'not found')"
     
     - name: Cache pnpm store
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       continue-on-error: true
       with:
         path: ~/.local/share/pnpm/store
@@ -234,7 +234,7 @@ jobs:
     # NOTIFY ON FAILURE
     - name: Notify on Failure
       if: failure()
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         script: |
           const issue = await github.rest.issues.create({

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -20,17 +20,17 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '24'
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       with:
-        version: 10
+        version: 10.15.0
         run_install: false
 
     - name: Install system dependencies
@@ -39,12 +39,12 @@ jobs:
         sudo apt-get install -y libpam0g-dev
 
     - name: Setup Zig
-      uses: mlugg/setup-zig@v2
+      uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
       with:
         version: 0.15.2
 
     - name: Cache TypeScript build info
-      uses: useblacksmith/cache@v5
+      uses: useblacksmith/cache@71c7c918062ba3861252d84b07fe5ab2a6b467a6 # v5
       continue-on-error: true
       with:
         path: |
@@ -65,7 +65,9 @@ jobs:
     - name: Build node-pty
       working-directory: web
       run: |
-        cd node-pty && npm install && npm run build
+        cd node-pty
+        pnpm install --frozen-lockfile --ignore-scripts
+        pnpm run build
 
     # Run all checks - build first, then tests
     - name: Run all checks
@@ -334,7 +336,7 @@ jobs:
     # Upload artifacts
     - name: Upload coverage artifacts
       if: always()
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       with:
         name: node-coverage
         path: |

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -26,19 +25,19 @@ defaults:
 jobs:
   test-npm-package:
     name: Test NPM Package
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
-          version: 10.12.1
+          version: 10.15.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 22
           cache: 'pnpm'
@@ -50,7 +49,7 @@ jobs:
           sudo apt-get install -y libpam0g-dev build-essential python3 make g++
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.15.2
 
@@ -59,7 +58,9 @@ jobs:
 
       - name: Build node-pty
         run: |
-          cd node-pty && npm install && npm run build
+          cd node-pty
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm run build
 
       - name: Build npm package
         run: pnpm run build:npm -- --current-only
@@ -139,14 +140,14 @@ jobs:
 
   npm-linux-dev:
     name: Linux npm dev build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -10,8 +10,7 @@ on:
       - '.github/workflows/playwright.yml'
 
 permissions:
-  pull-requests: write
-  issues: write
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -24,17 +23,17 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '22'
           
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
-          version: 10
+          version: 10.15.0
           
       - name: Get pnpm store directory
         shell: bash
@@ -42,7 +41,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
           
       - name: Setup pnpm cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -55,13 +54,13 @@ jobs:
           sudo apt-get install -y libpam0g-dev xvfb
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.15.2
           
       - name: Install dependencies
         working-directory: ./web
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
         
       - name: Build application
         working-directory: ./web
@@ -114,7 +113,7 @@ jobs:
           # VIBETUNNEL_SEA: "true"
           
       - name: Upload test results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: always()
         with:
           name: playwright-report
@@ -122,7 +121,7 @@ jobs:
           retention-days: 7
           
       - name: Upload test videos
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: always()
         with:
           name: playwright-videos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,22 +25,22 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Select Xcode 16.3
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
       with:
         xcode-version: '16.4'
     
     - name: Setup Node.js
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
       with:
         node-version: '24'
     
     - name: Setup pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
       with:
-        version: 10
+        version: 10.15.0
         run_install: false
     
     - name: Get pnpm store directory
@@ -49,7 +49,7 @@ jobs:
         echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
     
     - name: Setup pnpm cache
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       continue-on-error: true
       with:
         path: ${{ env.STORE_PATH }}
@@ -58,9 +58,9 @@ jobs:
           ${{ runner.os }}-pnpm-store-
     
     - name: Setup Bun
-      uses: oven-sh/setup-bun@v2
+      uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       with:
-        bun-version: latest
+        bun-version: 1.3.14
     
     - name: Install web dependencies
       working-directory: web
@@ -104,7 +104,7 @@ jobs:
         ls -la build/*.dmg build/*.zip
     
     - name: Upload Release Artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       with:
         name: mac-release
         path: |
@@ -114,7 +114,7 @@ jobs:
     
     - name: Create GitHub Release
       if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
       with:
         files: |
           mac/build/*.dmg
@@ -131,10 +131,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Select Xcode 16.3
-      uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
       with:
         xcode-version: '16.4'
     
@@ -157,7 +157,7 @@ jobs:
           -derivedDataPath build/DerivedData
     
     - name: Upload iOS Artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       with:
         name: ios-release
         path: ios/build/DerivedData/Build/Products/Release-iphoneos/

--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -6,6 +6,10 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   slack-notify:
     name: Send CI Results to Slack
@@ -14,10 +18,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       
     - name: Download workflow run data
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       id: workflow-data
       with:
         script: |
@@ -55,7 +59,7 @@ jobs:
           
     - name: Format Slack message
       id: slack-message
-      uses: actions/github-script@v8
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         script: |
           const data = ${{ steps.workflow-data.outputs.result }};

--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -13,8 +13,7 @@ on:
       - '.github/workflows/web-ci.yml'
 
 permissions:
-  pull-requests: write
-  issues: write
+  contents: read
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -29,15 +28,15 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
-          version: 10.12.1
+          version: 10.15.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
           cache: 'pnpm'
@@ -49,7 +48,7 @@ jobs:
           sudo apt-get install -y libpam0g-dev
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.15.2
 
@@ -61,7 +60,9 @@ jobs:
 
       - name: Build node-pty for TypeScript
         run: |
-          cd node-pty && npm install && npm run build
+          cd node-pty
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm run build
 
       - name: Run type checking
         run: pnpm run typecheck
@@ -74,15 +75,15 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
-          version: 10.12.1
+          version: 10.15.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
           cache: 'pnpm'
@@ -94,7 +95,7 @@ jobs:
           sudo apt-get install -y libpam0g-dev
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.15.2
 
@@ -103,13 +104,15 @@ jobs:
 
       - name: Build node-pty
         run: |
-          cd node-pty && npm install && npm run build
+          cd node-pty
+          pnpm install --frozen-lockfile --ignore-scripts
+          pnpm run build
 
       - name: Build project
         run: pnpm run build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: web-build
           path: |
@@ -122,15 +125,15 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
-          version: 10.12.1
+          version: 10.15.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: 24
           cache: 'pnpm'
@@ -142,7 +145,7 @@ jobs:
           sudo apt-get install -y libpam0g-dev
 
       - name: Setup Zig
-        uses: mlugg/setup-zig@v2
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
         with:
           version: 0.15.2
 
@@ -159,7 +162,7 @@ jobs:
         run: pnpm run test:server:coverage
 
       - name: Upload client coverage
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: always()
         with:
           name: client-coverage-report
@@ -167,7 +170,7 @@ jobs:
           retention-days: 7
 
       - name: Upload server coverage
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: always()
         with:
           name: server-coverage-report
@@ -179,7 +182,7 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Linux bootstrap (Node + Zig + deps)
         run: scripts/linux-bootstrap.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### ✨ Improvements
+- Pin CI actions, runner images, and downloaded build tools to immutable, checksum-verified versions (via [@davisbuilds](https://github.com/davisbuilds)) (#616)
 - Make the web app installable with correctly sized 192px and 512px manifest icons (via [@Tyoneva](https://github.com/Tyoneva)) (#615)
 - Enlarge mobile session navigation and terminal quick-key tap targets (via [@Nachx639](https://github.com/Nachx639)) (#647)
 - Rotate server logs at 50 MB while retaining one backup file (via [@Nachx639](https://github.com/Nachx639)) (#641)
@@ -45,6 +46,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
+- Thanks [@davisbuilds](https://github.com/davisbuilds) for hardening CI workflows and build-tool bootstrap paths.
 - Thanks [@apex-skyner](https://github.com/apex-skyner) and [@yashiels](https://github.com/yashiels) for identifying the macOS session-creation timestamp decoding failure.
 - Thanks [@waxzce](https://github.com/waxzce) for adding configurable IPv4/IPv6 server binding and restoring reliable iOS terminal rendering and input echo.
 - Thanks [@jiangwenhan](https://github.com/jiangwenhan) for improving Korean and CJK terminal input.

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -16,8 +16,8 @@ npm run build
 ## What the bootstrap does
 - Installs system deps: `curl`, `ca-certificates`, `xz-utils`, `python3`, `make`, `g++`, `git`
 - Installs `libpam0g-dev` for PAM auth native module
-- Installs Node.js 24.x (NodeSource) if missing or too old
-- Installs Zig (latest stable)
+- Installs checksum-verified Node.js 24.16.0 if missing or too old
+- Installs checksum-verified Zig 0.15.2
 
 ## SEA on Linux (disabled by default)
 SEA builds are skipped on Linux unless explicitly enabled.

--- a/mac/docs/BuildRequirements.md
+++ b/mac/docs/BuildRequirements.md
@@ -13,7 +13,7 @@ VibeTunnel for macOS now has a self-contained build system that automatically in
 When you build VibeTunnel in Xcode for the first time:
 
 1. **Install Build Dependencies** phase runs first
-   - Downloads and installs Bun locally to `.build-tools/bun/`
+   - Downloads a pinned Bun release, verifies its checksum, and installs it locally to `.build-tools/bun/`
    - No system-wide installation required
    - Works on both Intel and Apple Silicon Macs
 

--- a/mac/scripts/install-bun.sh
+++ b/mac/scripts/install-bun.sh
@@ -26,8 +26,8 @@ BUILD_TOOLS_DIR="$PROJECT_DIR/.build-tools"
 BUN_DIR="$BUILD_TOOLS_DIR/bun"
 BUN_BINARY="$BUN_DIR/bin/bun"
 
-# Version management - update this to use a specific Bun version
-BUN_VERSION="latest"
+# Pinned release assets verified against provider-published checksums.
+BUN_VERSION="1.3.14"
 
 echo -e "${GREEN}Checking for Bun...${NC}"
 
@@ -40,16 +40,64 @@ install_bun() {
     
     # Download and install Bun to local directory
     echo "Downloading Bun..."
-    export BUN_INSTALL="$BUN_DIR"
-    
-    # Use curl to download the install script and execute it
-    if command -v curl &> /dev/null; then
-        curl -fsSL https://bun.sh/install | bash > /dev/null 2>&1
-    else
+    if ! command -v curl &> /dev/null; then
         echo -e "${RED}Error: curl is required to download Bun${NC}"
         echo "curl should be available on macOS by default"
         exit 1
     fi
+
+    if ! command -v unzip &> /dev/null; then
+        echo -e "${RED}Error: unzip is required to install Bun${NC}"
+        exit 1
+    fi
+
+    local arch bun_asset bun_sha tmp_dir bun_archive extracted_bun
+    arch="$(uname -m)"
+    case "$arch" in
+        arm64|aarch64)
+            bun_asset="bun-darwin-aarch64.zip"
+            bun_sha="d8b96221828ad6f97ac7ac0ab7e95872341af763001e8803e8267652c2652620"
+            ;;
+        x86_64|amd64)
+            bun_asset="bun-darwin-x64.zip"
+            bun_sha="4183df3374623e5bab315c547cfa0974533cd457d86b73b639f7a87974cd6633"
+            ;;
+        *)
+            echo -e "${RED}Error: Unsupported architecture: $arch${NC}"
+            exit 1
+            ;;
+    esac
+
+    tmp_dir="$(mktemp -d)"
+    bun_archive="$tmp_dir/$bun_asset"
+    if ! curl -fsSL \
+        "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${bun_asset}" \
+        -o "$bun_archive"; then
+        rm -rf "$tmp_dir"
+        exit 1
+    fi
+
+    if ! echo "${bun_sha}  ${bun_archive}" | shasum -a 256 -c - >/dev/null 2>&1; then
+        echo -e "${RED}Error: Bun checksum verification failed${NC}"
+        rm -rf "$tmp_dir"
+        exit 1
+    fi
+
+    if ! unzip -q "$bun_archive" -d "$tmp_dir"; then
+        rm -rf "$tmp_dir"
+        exit 1
+    fi
+    extracted_bun="$tmp_dir/${bun_asset%.zip}/bun"
+    if [ ! -f "$extracted_bun" ]; then
+        echo -e "${RED}Error: Extracted Bun binary not found${NC}"
+        rm -rf "$tmp_dir"
+        exit 1
+    fi
+
+    mkdir -p "$BUN_DIR/bin"
+    cp "$extracted_bun" "$BUN_BINARY"
+    chmod +x "$BUN_BINARY"
+    rm -rf "$tmp_dir"
     
     # Verify installation
     if [ -f "$BUN_BINARY" ]; then

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,6 +1,8 @@
 # Use Node.js 22 as base image to support npm beta
 FROM node:22-slim
 
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
 # Install system dependencies required for node-pty and other native modules
 RUN apt-get update && apt-get install -y \
     python3 \
@@ -8,11 +10,28 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     git \
     curl \
+    xz-utils \
     libpam0g-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# Install latest npm (11.5.2 as of August 2025)
-RUN npm install -g npm@latest
+# Install the pinned Zig release for vibetunnel-fwd builds.
+SHELL ["/bin/bash", "-c"]
+ARG ZIG_VERSION=0.15.2
+ARG ZIG_AMD64_SHA256=02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239
+ARG ZIG_ARM64_SHA256=958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f
+RUN set -euo pipefail; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+      aarch64|arm64) zig_arch="aarch64-linux"; zig_sha="$ZIG_ARM64_SHA256";; \
+      x86_64|amd64) zig_arch="x86_64-linux"; zig_sha="$ZIG_AMD64_SHA256";; \
+      *) echo "unsupported arch: $arch" >&2; exit 1;; \
+    esac; \
+    zig_url="https://ziglang.org/download/${ZIG_VERSION}/zig-${zig_arch}-${ZIG_VERSION}.tar.xz"; \
+    curl -fsSL "$zig_url" -o /tmp/zig.tar.xz; \
+    echo "${zig_sha}  /tmp/zig.tar.xz" | sha256sum -c -; \
+    mkdir -p /usr/local/zig /usr/local/bin; \
+    tar -xf /tmp/zig.tar.xz -C /usr/local/zig --strip-components=1; \
+    ln -sf /usr/local/zig/zig /usr/local/bin/zig
 
 # Set working directory
 WORKDIR /app
@@ -21,11 +40,21 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 COPY node-pty/package.json ./node-pty/
 
-# Install pnpm
-RUN npm install -g pnpm@latest
+# Install the package-manager version declared by package.json.
+RUN corepack enable && corepack prepare pnpm@10.15.0 --activate
 
 # Copy all source code first (needed for postinstall scripts)
 COPY . .
+
+# The web-only Docker context excludes the repository-level forwarder sources.
+ARG VT_FWD_COMMIT=586a728d4138a96338b05943f05576a25f0679d7
+RUN git init /tmp/vt-src \
+    && git -C /tmp/vt-src remote add origin https://github.com/amantus-ai/vibetunnel.git \
+    && git -C /tmp/vt-src fetch --depth 1 origin "$VT_FWD_COMMIT" \
+    && git -C /tmp/vt-src checkout --detach FETCH_HEAD \
+    && mkdir -p /app/native \
+    && cp -R /tmp/vt-src/native/vt-fwd /app/native/vt-fwd \
+    && rm -rf /tmp/vt-src
 
 # Install dependencies
 RUN pnpm install --frozen-lockfile

--- a/web/Dockerfile.standalone
+++ b/web/Dockerfile.standalone
@@ -3,6 +3,8 @@
 
 FROM node:24-trixie-slim
 
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+
 # Install system dependencies and common development tools
 RUN apt-get update && apt-get install -y \
     python3 \
@@ -27,37 +29,67 @@ RUN apt-get update && apt-get install -y \
     && ln -sf /bin/dash /bin/sh \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Zig (latest stable) for vibetunnel-fwd build
+# Install the pinned Zig release for vibetunnel-fwd builds.
 SHELL ["/bin/bash", "-c"]
 ARG ZIG_VERSION=0.15.2
+ARG ZIG_AMD64_SHA256=02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239
+ARG ZIG_ARM64_SHA256=958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f
+ARG PNPM_VERSION=10.15.0
+ARG TYPESCRIPT_VERSION=6.0.3
+ARG TS_NODE_VERSION=10.9.2
+ARG NODEMON_VERSION=3.1.14
+ARG NGROK_VERSION=3.39.7
+ARG NGROK_REPO_ASC_SHA256=8a57c28e1779e2a8e5bba3865fffd6805e15898988c235eae862f3069c3f2c28
+ARG CLOUDFLARED_VERSION=2026.6.0
+ARG CLOUDFLARED_AMD64_SHA256=08d27c4c5d3ed73ee3e98ef2ddceb4ad09fd4cfc28e243565a189538e8ccd706
+ARG CLOUDFLARED_ARM64_SHA256=8482ebf1e74a2a4a1a9f1e090e17e3de08423f94100ece6789287cb26fb9480f
 RUN set -euo pipefail; \
     arch="$(uname -m)"; \
     case "$arch" in \
-      aarch64|arm64) zig_arch="aarch64-linux";; \
-      x86_64|amd64) zig_arch="x86_64-linux";; \
+      aarch64|arm64) zig_arch="aarch64-linux"; zig_sha="$ZIG_ARM64_SHA256";; \
+      x86_64|amd64) zig_arch="x86_64-linux"; zig_sha="$ZIG_AMD64_SHA256";; \
       *) echo "unsupported arch: $arch" >&2; exit 1;; \
     esac; \
     zig_url="https://ziglang.org/download/${ZIG_VERSION}/zig-${zig_arch}-${ZIG_VERSION}.tar.xz"; \
     mkdir -p /usr/local/zig /usr/local/bin; \
-    curl -sL "$zig_url" -o /tmp/zig.tar.xz; \
+    curl -fsSL "$zig_url" -o /tmp/zig.tar.xz; \
+    echo "${zig_sha}  /tmp/zig.tar.xz" | sha256sum -c -; \
     tar -xf /tmp/zig.tar.xz -C /usr/local/zig --strip-components=1; \
     ln -sf /usr/local/zig/zig /usr/local/bin/zig; \
     zig version
 
-# Install ngrok
-RUN curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc | tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null \
-    && echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | tee /etc/apt/sources.list.d/ngrok.list \
-    && apt-get update \
-    && apt-get install -y ngrok \
-    || echo "Ngrok installation failed, continuing without it"
+# Install ngrok from its signed repository at an exact package version.
+RUN set -euo pipefail; \
+    curl -fsSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc -o /tmp/ngrok.asc; \
+    echo "${NGROK_REPO_ASC_SHA256}  /tmp/ngrok.asc" | sha256sum -c -; \
+    mkdir -p /etc/apt/keyrings; \
+    install -m 0644 /tmp/ngrok.asc /etc/apt/keyrings/ngrok.asc; \
+    echo "deb [signed-by=/etc/apt/keyrings/ngrok.asc] https://ngrok-agent.s3.amazonaws.com buster main" \
+      > /etc/apt/sources.list.d/ngrok.list; \
+    apt-get update; \
+    apt-get install -y "ngrok=${NGROK_VERSION}"; \
+    rm -rf /var/lib/apt/lists/* /tmp/ngrok.asc
 
-# Install cloudflared
-RUN curl -L https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 -o /usr/local/bin/cloudflared \
-    && chmod +x /usr/local/bin/cloudflared \
-    || echo "Cloudflared installation failed, continuing without it"
+# Install cloudflared from a pinned release.
+RUN set -euo pipefail; \
+    arch="$(uname -m)"; \
+    case "$arch" in \
+      aarch64|arm64) cloudflared_arch="arm64"; cloudflared_sha="$CLOUDFLARED_ARM64_SHA256";; \
+      x86_64|amd64) cloudflared_arch="amd64"; cloudflared_sha="$CLOUDFLARED_AMD64_SHA256";; \
+      *) echo "unsupported arch: $arch" >&2; exit 1;; \
+    esac; \
+    cloudflared_url="https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-${cloudflared_arch}"; \
+    curl -fsSL "$cloudflared_url" -o /usr/local/bin/cloudflared; \
+    echo "${cloudflared_sha}  /usr/local/bin/cloudflared" | sha256sum -c -; \
+    chmod +x /usr/local/bin/cloudflared
 
-# Install common dev tools
-RUN npm install -g pnpm typescript ts-node nodemon
+# Install the package manager and pinned development CLIs advertised by this image.
+RUN corepack enable \
+    && corepack prepare "pnpm@${PNPM_VERSION}" --activate \
+    && npm install --global \
+      "typescript@${TYPESCRIPT_VERSION}" \
+      "ts-node@${TS_NODE_VERSION}" \
+      "nodemon@${NODEMON_VERSION}"
 
 # Set working directory for VibeTunnel
 WORKDIR /app
@@ -75,13 +107,13 @@ RUN pnpm install --frozen-lockfile
 # Copy source code
 COPY . .
 
-# Ensure vt-fwd sources exist (for web-only context builds)
-ARG VT_FWD_REF
+# Ensure vt-fwd sources exist for web-only context builds.
+ARG VT_FWD_COMMIT=586a728d4138a96338b05943f05576a25f0679d7
 RUN if [ ! -d /app/native/vt-fwd ]; then \
-      ref="${VT_FWD_REF:-v$(node -p "require('./package.json').version")}"; \
-      git clone --depth 1 --filter=blob:none --sparse --branch "$ref" https://github.com/amantus-ai/vibetunnel.git /tmp/vt-src \
-        || git clone --depth 1 --filter=blob:none --sparse https://github.com/amantus-ai/vibetunnel.git /tmp/vt-src; \
-      git -C /tmp/vt-src sparse-checkout set native/vt-fwd; \
+      git init /tmp/vt-src; \
+      git -C /tmp/vt-src remote add origin https://github.com/amantus-ai/vibetunnel.git; \
+      git -C /tmp/vt-src fetch --depth 1 origin "$VT_FWD_COMMIT"; \
+      git -C /tmp/vt-src checkout --detach FETCH_HEAD; \
       mkdir -p /app/native; \
       cp -R /tmp/vt-src/native/vt-fwd /app/native/vt-fwd; \
       rm -rf /tmp/vt-src; \
@@ -100,6 +132,8 @@ EXPOSE 4020
 
 # Set environment variables
 ENV NODE_ENV=production
+ENV VIBETUNNEL_BUNDLED=true
+ENV BUILD_PUBLIC_PATH=/app/public
 ENV PORT=4020
 ENV PATH="/workspace/node_modules/.bin:${PATH}"
 

--- a/web/node-pty/package.json
+++ b/web/node-pty/package.json
@@ -4,6 +4,7 @@
   "description": "Minimal PTY implementation without threading - vendored from node-pty",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b",
   "scripts": {
     "build": "tsc && node-gyp rebuild",
     "clean": "rimraf lib build",

--- a/web/scripts/linux-bootstrap.sh
+++ b/web/scripts/linux-bootstrap.sh
@@ -25,7 +25,7 @@ ${SUDO} apt-get install -y -qq \
   libpam0g-dev \
   > /dev/null
 
-# Node.js 24.x via NodeSource if missing or too old
+# Checksum-verified Node.js 24.x release if missing or too old.
 need_node=1
 if command -v node >/dev/null 2>&1; then
   node_major="$(node -p 'process.versions.node.split(".")[0]')"
@@ -36,8 +36,32 @@ if command -v node >/dev/null 2>&1; then
 fi
 
 if [ "$need_node" -eq 1 ]; then
-  curl -fsSL https://deb.nodesource.com/setup_24.x | ${SUDO} bash - >/dev/null
-  ${SUDO} apt-get install -y -qq nodejs > /dev/null
+  NODE_VERSION="24.16.0"
+  arch="$(uname -m)"
+  case "$arch" in
+    aarch64|arm64)
+      node_arch="arm64"
+      node_sha="524659219d6a207a7400f2bde15d19ba060ffbe0d32a8643319ad67e3bb64c78"
+      ;;
+    x86_64|amd64)
+      node_arch="x64"
+      node_sha="d804845d34eddc21dc1092b519d643ef40b1f58ec5dec5c22b1f4bd8fabde6c9"
+      ;;
+    *) echo "unsupported arch: $arch"; exit 1;;
+  esac
+
+  node_archive="/tmp/node-v${NODE_VERSION}-linux-${node_arch}.tar.xz"
+  node_root="/usr/local/lib/nodejs"
+  node_dir="${node_root}/node-v${NODE_VERSION}-linux-${node_arch}"
+  curl -fsSL \
+    "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${node_arch}.tar.xz" \
+    -o "$node_archive"
+  echo "${node_sha}  ${node_archive}" | sha256sum -c -
+  ${SUDO} mkdir -p "$node_root" /usr/local/bin
+  ${SUDO} tar -xf "$node_archive" -C "$node_root"
+  for executable in node npm npx corepack; do
+    ${SUDO} ln -sf "${node_dir}/bin/${executable}" "/usr/local/bin/${executable}"
+  done
 fi
 
 # Zig if missing. Keep this aligned with CI and Dockerfile.standalone.
@@ -49,40 +73,26 @@ fi
 if [ "$need_zig" -eq 1 ]; then
   arch="$(uname -m)"
   case "$arch" in
-    aarch64|arm64) export ZIG_TARGET="aarch64-linux";;
-    x86_64|amd64) export ZIG_TARGET="x86_64-linux";;
+    aarch64|arm64)
+      ZIG_TARGET="aarch64-linux"
+      zig_sha="958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f"
+      ;;
+    x86_64|amd64)
+      ZIG_TARGET="x86_64-linux"
+      zig_sha="02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239"
+      ;;
     *) echo "unsupported arch: $arch"; exit 1;;
   esac
 
-  zig_url="$(python3 - <<'PY'
-import json, urllib.request, os, sys
+  zig_url="https://ziglang.org/download/${ZIG_VERSION}/zig-${ZIG_TARGET}-${ZIG_VERSION}.tar.xz"
 
-target = os.environ.get('ZIG_TARGET')
-version = os.environ.get('ZIG_VERSION', '0.15.2')
-data = json.load(urllib.request.urlopen('https://ziglang.org/download/index.json'))
-entry = data.get(version)
-if entry and target in entry:
-  print(entry[target]['tarball'])
-  sys.exit(0)
-print('')
-PY
-)"
-
-  if [ -z "$zig_url" ]; then
-    echo "failed to resolve Zig download URL"
-    exit 1
-  fi
-
-  zig_root="$HOME/.local/zig"
-  zig_bin="$HOME/.local/bin"
-  if [ -n "$SUDO" ]; then
-    zig_root="/usr/local/zig"
-    zig_bin="/usr/local/bin"
-  fi
+  zig_root="/usr/local/zig"
+  zig_bin="/usr/local/bin"
 
   ${SUDO} mkdir -p "$zig_root"
   ${SUDO} mkdir -p "$zig_bin"
-  curl -sL "$zig_url" -o /tmp/zig.tar.xz
+  curl -fsSL "$zig_url" -o /tmp/zig.tar.xz
+  echo "${zig_sha}  /tmp/zig.tar.xz" | sha256sum -c -
   ${SUDO} tar -xf /tmp/zig.tar.xz -C "$zig_root" --strip-components=1
   ${SUDO} ln -sf "$zig_root/zig" "$zig_bin/zig"
 fi
@@ -91,7 +101,7 @@ node -v
 npm -v
 zig version
 
-echo "\nNext steps:"
+printf '\nNext steps:\n'
 echo "  cd web"
 echo "  npm install"
 echo "  npm run build"


### PR DESCRIPTION
## Summary
- pin executable GitHub Actions to immutable commit objects and add explicit least-privilege workflow permissions
- pin hosted runner images and cancel superseded CI runs so macOS jobs do not consume hours on stale heads
- verify downloaded toolchains and replace mutable bootstrap/install paths in Docker, macOS, and Linux setup
- preserve the documented standalone image development CLIs with exact versions

## CI behavior
- macOS and iOS use `macos-15` instead of a moving runner alias
- macOS CI has a 40-minute job timeout; iOS has 30 minutes; nightly has 60 minutes
- new commits cancel older CI runs for the same PR or ref
- Ubuntu jobs use `ubuntu-24.04`
- nested package installs use the repository lockfile and frozen resolution

## Verification
- `actionlint` and YAML parsing pass for all workflows and the composite action
- every changed third-party action ref resolves to a direct commit object
- `shellcheck` passes for both changed bootstrap scripts
- web type/lint checks and the nested terminal package clean install/build pass
- Bun and Linux bootstrap scripts pass clean temporary-environment tests
- primary and standalone Docker images build successfully
- the exact standalone image is healthy and was live-tested in Chrome
- the exact macOS app build launches its bundled server and returns healthy responses
- final structured autoreview reports no actionable findings

## Safety
Public Model Identifier Gate: PASS. The exact diff, workflows, tests/fixtures/generated surfaces, selected logs, built artifacts, browser proof, and this PR body contain no model identifiers.

Thanks @davisbuilds for the original hardening work.