### PR TITLE
fix: CJK character display and IME input support in browser terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Keep Korean and other CJK IME composition events intact and position desktop candidate windows at the terminal cursor (via [@jiangwenhan](https://github.com/jiangwenhan)) (#617)
 - Prevent rapid iOS slash-command redraws from queuing redundant smooth terminal scrolling (via [@Ilakiancs](https://github.com/Ilakiancs)) (#590)
 - Keep mobile session header controls visible and comfortably tappable at narrow phone widths (via [@nikolasdehor](https://github.com/nikolasdehor)) (#605)
 - Jitter iOS reconnection backoff within its configured cap to spread retries after outages (via [@bianbiandashen](https://github.com/bianbiandashen)) (#593)
@@ -41,6 +42,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
+- Thanks [@jiangwenhan](https://github.com/jiangwenhan) for improving Korean and CJK terminal input.
 - Thanks [@Tyoneva](https://github.com/Tyoneva) for improving web app installation and icon support.
 - Thanks [@ndraiman](https://github.com/ndraiman) for fixing native forwarder crashes while collecting git metadata.
 - Thanks [@bianbiandashen](https://github.com/bianbiandashen) for preventing transient remote health-check failures from prematurely unregistering servers and spreading iOS reconnect attempts after outages.

--- a/docs/cjk-ime-input.md
+++ b/docs/cjk-ime-input.md
@@ -38,7 +38,7 @@ SessionView
 
 **File**: `cursor-position.ts`
 
-The cursor position tracking system uses a shared utility function for terminal renderers that expose cursor coordinates (currently the buffer-based terminal):
+The cursor position tracking system uses renderer-specific cursor coordinates:
 
 #### Coordinate System
 ```typescript
@@ -58,7 +58,7 @@ export function calculateCursorPosition(
 4. **IME Positioning**: Returns coordinates suitable for IME input placement
 
 #### Terminal Type Support
-- **Ghostty Terminal (`vibe-terminal`)**: Does not expose cursor coordinates yet; IME input falls back to a safe fixed position.
+- **Ghostty Terminal (`vibe-terminal`)**: Uses the active buffer cursor and renderer cell metrics.
 - **Buffer Terminal (`vibe-terminal-buffer`)**: Uses `buffer.cursorX/Y` from VT snapshot data.
 
 #### Key Features
@@ -238,7 +238,7 @@ input.placeholder = 'Type here...';
 ### Desktop Features
 - **Dynamic cursor positioning**: IME popup follows terminal cursor exactly
 - **Global paste handling**: Paste works anywhere in terminal area
-- **Composition state tracking**: Via `data-ime-composing` DOM attribute
+- **Composition state tracking**: Via native `KeyboardEvent.isComposing` plus the `data-ime-composing` DOM attribute
 - **Focus retention**: Active mechanism prevents accidental focus loss
 - **Invisible integration**: Zero visual footprint for users
 - **Performance optimized**: Minimal resource usage when not composing

--- a/web/src/client/components/session-view/lifecycle-event-manager.test.ts
+++ b/web/src/client/components/session-view/lifecycle-event-manager.test.ts
@@ -81,5 +81,49 @@ describe('LifecycleEventManager', () => {
       // Should not call consumeEvent for browser shortcuts
       expect(eventUtils.consumeEvent).not.toHaveBeenCalled();
     });
+
+    it('should leave native IME composition events to the browser', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        getInputManager: vi.fn(),
+        handleKeyboardInput: vi.fn(),
+      };
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+      manager.setSession({
+        id: 'test-session',
+        status: 'running',
+      } as Parameters<typeof manager.setSession>[0]);
+
+      const composingEvent = new KeyboardEvent('keydown', { key: 'Process' });
+      Object.defineProperty(composingEvent, 'isComposing', { value: true });
+
+      manager.keyboardHandler(composingEvent);
+
+      expect(eventUtils.consumeEvent).not.toHaveBeenCalled();
+      expect(mockCallbacks.getInputManager).not.toHaveBeenCalled();
+      expect(mockCallbacks.handleKeyboardInput).not.toHaveBeenCalled();
+    });
+
+    it('should leave composition events marked by the desktop IME input untouched', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        getInputManager: vi.fn(),
+        handleKeyboardInput: vi.fn(),
+      };
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+      document.body.setAttribute('data-ime-composing', 'true');
+
+      try {
+        manager.keyboardHandler(new KeyboardEvent('keydown', { key: 'a' }));
+      } finally {
+        document.body.removeAttribute('data-ime-composing');
+      }
+
+      expect(eventUtils.consumeEvent).not.toHaveBeenCalled();
+      expect(mockCallbacks.getInputManager).not.toHaveBeenCalled();
+      expect(mockCallbacks.handleKeyboardInput).not.toHaveBeenCalled();
+    });
   });
 });

--- a/web/src/client/components/session-view/lifecycle-event-manager.ts
+++ b/web/src/client/components/session-view/lifecycle-event-manager.ts
@@ -257,8 +257,8 @@ export class LifecycleEventManager extends ManagerEventEmitter {
       }
     }
 
-    // Check if IME composition is active - InputManager handles this
-    if (document.body.getAttribute('data-ime-composing') === 'true') {
+    // Native composition state covers events that arrive before our DOM marker is updated.
+    if (e.isComposing || document.body.getAttribute('data-ime-composing') === 'true') {
       return;
     }
 

--- a/web/src/client/components/terminal.test.ts
+++ b/web/src/client/components/terminal.test.ts
@@ -276,6 +276,63 @@ describe('Terminal', () => {
     });
   });
 
+  describe('IME cursor positioning', () => {
+    it('returns the rendered cursor position relative to the session terminal', () => {
+      if (!mockTerminal) return;
+
+      const terminalContainer = element.querySelector('#terminal-container') as HTMLElement | null;
+      expect(terminalContainer).toBeTruthy();
+
+      mockTerminal.buffer.active.cursorX = 4;
+      mockTerminal.buffer.active.cursorY = 3;
+      mockTerminal.renderer = {
+        getMetrics: () => ({ width: 9, height: 18 }),
+        charWidth: 9,
+        charHeight: 18,
+      };
+
+      vi.spyOn(terminalContainer as HTMLElement, 'getBoundingClientRect').mockReturnValue({
+        left: 100,
+        top: 200,
+        right: 900,
+        bottom: 600,
+        width: 800,
+        height: 400,
+        x: 100,
+        y: 200,
+        toJSON: () => ({}),
+      });
+
+      const sessionTerminal = document.createElement('div');
+      sessionTerminal.id = 'session-terminal';
+      vi.spyOn(sessionTerminal, 'getBoundingClientRect').mockReturnValue({
+        left: 40,
+        top: 50,
+        right: 940,
+        bottom: 650,
+        width: 900,
+        height: 600,
+        x: 40,
+        y: 50,
+        toJSON: () => ({}),
+      });
+      document.body.appendChild(sessionTerminal);
+
+      try {
+        expect(element.getCursorInfo()).toEqual({ x: 96, y: 204 });
+      } finally {
+        sessionTerminal.remove();
+      }
+    });
+
+    it('returns null when renderer cursor metrics are unavailable', () => {
+      if (!mockTerminal) return;
+      mockTerminal.renderer = null;
+
+      expect(element.getCursorInfo()).toBeNull();
+    });
+  });
+
   describe('terminal sizing', () => {
     beforeEach(async () => {
       await element.firstUpdated();

--- a/web/src/client/components/terminal.ts
+++ b/web/src/client/components/terminal.ts
@@ -585,6 +585,43 @@ export class Terminal extends LitElement {
   };
 
   /**
+   * Return the rendered cursor position relative to the session terminal.
+   * Desktop IME inputs use this to place the native candidate window at the cursor.
+   */
+  public getCursorInfo(): { x: number; y: number } | null {
+    if (!this.terminal || !this.container) return null;
+
+    try {
+      const renderer = this.terminal.renderer;
+      if (!renderer) return null;
+
+      const metrics = renderer.getMetrics();
+      const charWidth = metrics?.width || renderer.charWidth || 8;
+      const charHeight = metrics?.height || renderer.charHeight || this.fontSize * 1.2;
+      if (charWidth <= 0 || charHeight <= 0) return null;
+
+      const buffer = this.terminal.buffer.active;
+      const terminalRect = this.container.getBoundingClientRect();
+      const absoluteX = terminalRect.left + buffer.cursorX * charWidth;
+      const absoluteY = terminalRect.top + buffer.cursorY * charHeight;
+
+      const sessionTerminal = document.getElementById(TERMINAL_IDS.SESSION_TERMINAL);
+      if (!sessionTerminal) {
+        return { x: absoluteX, y: absoluteY };
+      }
+
+      const sessionRect = sessionTerminal.getBoundingClientRect();
+      return {
+        x: absoluteX - sessionRect.left,
+        y: absoluteY - sessionRect.top,
+      };
+    } catch (error) {
+      logger.warn('Failed to get terminal cursor position:', error);
+      return null;
+    }
+  }
+
+  /**
    * Get the current input line (text the user has typed on the current line).
    * Used to sync chat mode input with the terminal state.
    */


### PR DESCRIPTION
Fixes #571.

## 问题 / Problem

在 macOS Chrome 和 Safari 中使用韩文 2-set 输入法时，终端可能在组合过程中拦截键盘事件，导致预编辑文本被拆成独立字母。Ghostty 终端也没有向桌面 IME 输入层提供光标坐标，因此候选窗口会回退到固定位置。

With the macOS Korean 2-set input source, the terminal could intercept keyboard events while native composition was active, decomposing pre-edit text into separate letters. The Ghostty terminal also did not expose cursor coordinates to the desktop IME input layer, so the candidate window fell back to a fixed position.

## 改动 / Changes

- 在键盘事件处理器中同时检查原生 `KeyboardEvent.isComposing` 和现有 DOM 组合状态标记。
- 从 Ghostty 活动缓冲区和渲染器单元格尺寸计算终端光标坐标，供桌面 IME 候选窗口定位。
- 添加组合事件和光标定位回归测试。
- 更新 CJK IME 文档和 changelog，并保留原贡献者署名。

- Honor both native `KeyboardEvent.isComposing` and the existing DOM composition marker before terminal shortcut handling.
- Calculate the Ghostty cursor position from the active buffer and renderer cell metrics for desktop IME candidate placement.
- Add regression coverage for composition-event handling and cursor positioning.
- Update the CJK IME documentation and changelog while preserving contributor credit.

The proposed locale forcing and CJK font-stack changes were intentionally omitted: current `main` already passes composed UTF-8 bytes correctly, and those changes were unrelated to the reproduced input-event defect.

## Maintainer Verification

- Focused client tests: 60 passed.
- Full client suite, serial: 35 files and 664 tests passed; 14 skipped.
- Standard TypeScript typecheck, lint, production client build, and VT tests passed.
- Structured branch review completed with no actionable findings.
- Exact production build tested with real macOS input sources in Chrome and Safari:
  - Korean 2-set composition produced NFC Hangul exactly once.
  - Japanese composition committed composed CJK text exactly once.
  - Latin typing, paste, arrow keys, terminal echo, and selection remained functional.
  - IME candidate input followed the rendered terminal cursor.
- Mobile Chrome emulation tested at 434x965 and 390x844:
  - composition routed once through the mobile input;
  - quick keys and keyboard controls remained reachable;
  - no horizontal clipping or overflow.
- Desktop layout rechecked at 1440x1000.

Local `build:ci` completed the client and server phases, then stopped at the Zig forwarder because the host has Zig 0.16 while repository CI pins Zig 0.15.2. Exact-head GitHub Actions remains the authoritative forwarder and macOS build proof.

## Public Artifact Safety

The exact candidate diff, changed tests, documentation, changelog, workflow surface, generated build output, local proof images, and this PR body were audited. No model identifiers are present in the candidate or public proof.
