### PR TITLE
fix(mac): add iso8601 date strategy to JSONDecoder in performRequest

### DIFF
--- a/mac/VibeTunnel/Core/Services/ServerManager.swift
+++ b/mac/VibeTunnel/Core/Services/ServerManager.swift
@@ -737,7 +737,9 @@ extension ServerManager {
                 message: errorData?.error ?? "Request failed with status \(httpResponse.statusCode)")
         }
 
-        return try JSONDecoder().decode(T.self, from: data)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(T.self, from: data)
     }
 
     /// Perform a network request that returns no body (void response)


### PR DESCRIPTION
## Summary

Closes #635.

- Set `decoder.dateDecodingStrategy = .iso8601` in `ServerManager.performRequest()` before decoding the response body

## Context

`performRequest()` decoded all responses using a bare `JSONDecoder()` with no date strategy configured. Swift's default strategy (`.deferredToDate`) expects dates as Unix timestamps, but the server returns `createdAt` as an ISO 8601 string (e.g. `"2026-05-31T19:10:57.655Z"`).

`CreateSessionResponse.createdAt` is a non-optional `Date`, so the decoder throws and Foundation surfaces it as **"The data couldn't be read because it is missing"** — a misleading message for a type mismatch, displayed as an alert dialog in the menu bar app every time a new session is spawned.

The session itself opens and works correctly (the `fwd` command runs independently), but the error dialog appears on every spawn.

## Changes

| File | Change |
|------|--------|
| `mac/VibeTunnel/Core/Services/ServerManager.swift` | Construct `JSONDecoder` with `.iso8601` date decoding strategy before decoding |

## Validation

- Reproduced on macOS 15.7.7 + VibeTunnel v1.0.0-beta.15: spawning a session via quick-start command showed the alert every time
- Patched binary installed locally: alert no longer appears, session creation succeeds silently
- Change is confined to `performRequest()` — all response types decoded through this path now handle ISO 8601 dates correctly