### PR TITLE
fix(server): persist JWT signing secret across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug Fixes
 - Fix session creation "data couldn't be read" error on Mac app (#500)
+- Persist JWT signing secrets across server restarts without weakening file permissions or concurrent startup safety (via [@matthias-scale](https://github.com/matthias-scale)) (#637)
 - Restore mobile terminal touch scrolling, responsive width fitting, pinch zoom, and scrollback retention during output and layout changes (via [@Nachx639](https://github.com/Nachx639)) (#645)
 - Stabilize mobile keyboard reopening and reserve terminal space for quick keys without overlapping the action bar (via [@Nachx639](https://github.com/Nachx639)) (#646)
 - Detach only the VibeTunnel tmux client without assuming the default prefix (via [@Nachx639](https://github.com/Nachx639)) (#644)
@@ -30,6 +31,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
+- Thanks [@matthias-scale](https://github.com/matthias-scale) for preserving authenticated browser sessions across server restarts.
 - Thanks [@Nachx639](https://github.com/Nachx639) for adding log rotation, improving mobile keyboard behavior, terminal scrolling, and tap targets, and fixing tmux detach behavior, dependency security, Terminal Settings width sync, and exited-session overlay layering.
 - Thanks [@sourman](https://github.com/sourman) for documenting the Zig build prerequisite.
 - Thanks [@yv-was-taken](https://github.com/yv-was-taken) for fixing global npm and Bun installs.

--- a/README.md
+++ b/README.md
@@ -395,6 +395,10 @@ export VIBETUNNEL_PASSWORD=your-secure-password
 npm run start
 ```
 
+JWT signing keys are generated once in `~/.vibetunnel/jwt-secret` with owner-only
+permissions, so browser sessions remain valid across server restarts. Set `JWT_SECRET`
+to use an operator-managed signing secret instead; rotating either value logs out clients.
+
 #### 3. SSH Key Authentication
 Use Ed25519 SSH keys from `~/.ssh/authorized_keys`:
 ```bash

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -95,6 +95,13 @@ export function generateToken(userId: string): string {
 }
 ```
 
+### Signing Secret Persistence
+
+When `JWT_SECRET` is unset, the server generates a 64-byte signing secret and stores it
+at `~/.vibetunnel/jwt-secret` with `0600` permissions. The same key is reused after a
+restart, keeping existing browser tokens valid. Set `JWT_SECRET` to supply an
+operator-managed key; rotating or deleting the active key invalidates existing tokens.
+
 ### Token Validation
 
 ```typescript

--- a/web/README.md
+++ b/web/README.md
@@ -175,6 +175,7 @@ VibeTunnel respects the following environment variables:
 PORT=8080                           # Default port if --port not specified
 VIBETUNNEL_USERNAME=myuser          # Username (for env-based auth, not CLI)
 VIBETUNNEL_PASSWORD=mypass          # Password (for env-based auth, not CLI)
+JWT_SECRET=long-random-secret        # Optional JWT signing key override
 VIBETUNNEL_CONTROL_DIR=/path        # Control directory for session data
 VIBETUNNEL_SESSION_ID=abc123        # Current session ID (set automatically inside sessions)
 VIBETUNNEL_LOG_LEVEL=debug          # Log level: error, warn, info, verbose, debug

--- a/web/src/server/services/auth-service.test.ts
+++ b/web/src/server/services/auth-service.test.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as jwt from 'jsonwebtoken';
 import * as os from 'os';
 import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -24,6 +25,12 @@ describe('AuthService JWT secret persistence', () => {
   const secretPath = path.join(mockHomeDir, '.vibetunnel', 'jwt-secret');
   let savedJwtSecret: string | undefined;
 
+  const createFsError = (code: string, message: string) => {
+    const error = new Error(message) as NodeJS.ErrnoException;
+    error.code = code;
+    return error;
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     // The constructor schedules a cleanup interval; fake timers keep it from lingering.
@@ -36,8 +43,13 @@ describe('AuthService JWT secret persistence', () => {
     vi.mocked(os.homedir).mockReturnValue(mockHomeDir);
     vi.mocked(fs.existsSync).mockReturnValue(false);
     vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
-    vi.mocked(fs.readFileSync).mockReturnValue('');
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw createFsError('ENOENT', 'file not found');
+    });
     vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+    vi.mocked(fs.chmodSync).mockImplementation(() => undefined);
+    vi.mocked(fs.linkSync).mockImplementation(() => undefined);
+    vi.mocked(fs.unlinkSync).mockImplementation(() => undefined);
   });
 
   afterEach(() => {
@@ -56,11 +68,13 @@ describe('AuthService JWT secret persistence', () => {
       recursive: true,
     });
     expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
-    const [writtenPath, writtenSecret, opts] = vi.mocked(fs.writeFileSync).mock.calls[0];
-    expect(writtenPath).toBe(secretPath);
+    const [tempPath, writtenSecret, opts] = vi.mocked(fs.writeFileSync).mock.calls[0];
+    expect(tempPath).toMatch(`${secretPath}.`);
     expect(typeof writtenSecret).toBe('string');
     expect((writtenSecret as string).length).toBeGreaterThan(0);
-    expect(opts).toEqual({ mode: 0o600 });
+    expect(opts).toEqual({ flag: 'wx', mode: 0o600 });
+    expect(fs.linkSync).toHaveBeenCalledWith(tempPath, secretPath);
+    expect(fs.unlinkSync).toHaveBeenCalledWith(tempPath);
   });
 
   it('loads the existing secret without rewriting, so tokens survive a restart', () => {
@@ -78,19 +92,21 @@ describe('AuthService JWT secret persistence', () => {
     const instanceB = new AuthService();
 
     expect(fs.writeFileSync).not.toHaveBeenCalled();
+    expect(fs.chmodSync).toHaveBeenCalledWith(secretPath, 0o600);
     // The token minted before the restart still verifies after it — the whole point.
     expect(instanceB.verifyToken(token)).toEqual({ valid: true, userId: 'alice' });
   });
 
-  it('regenerates and persists when the on-disk secret file is empty', () => {
+  it('regenerates invalid persisted secrets instead of accepting weak signing keys', () => {
     vi.mocked(fs.existsSync).mockReturnValue(true);
-    vi.mocked(fs.readFileSync).mockReturnValue('   \n');
+    vi.mocked(fs.readFileSync).mockReturnValue('short');
 
     new AuthService();
 
+    expect(fs.unlinkSync).toHaveBeenCalledWith(secretPath);
     expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
     const writtenSecret = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
-    expect(writtenSecret.trim().length).toBeGreaterThan(0);
+    expect(writtenSecret).toMatch(/^[0-9a-f]{128}$/);
   });
 
   it('uses JWT_SECRET env var and never touches disk when it is set', () => {
@@ -119,5 +135,28 @@ describe('AuthService JWT secret persistence', () => {
     // Auth still works in-process despite the persistence failure.
     const token = (service as AuthService).generateTokenForUser('carol');
     expect((service as AuthService).verifyToken(token)).toEqual({ valid: true, userId: 'carol' });
+  });
+
+  it('loads the winner when another process creates the secret concurrently', () => {
+    const concurrentSecret = 'ab'.repeat(64);
+    vi.mocked(fs.readFileSync)
+      .mockImplementationOnce(() => {
+        throw createFsError('ENOENT', 'file not found');
+      })
+      .mockReturnValue(concurrentSecret);
+    vi.mocked(fs.linkSync).mockImplementationOnce(() => {
+      throw createFsError('EEXIST', 'file already exists');
+    });
+
+    const service = new AuthService();
+    const token = jwt.sign({ userId: 'race-winner' }, concurrentSecret);
+
+    const tempPath = vi.mocked(fs.writeFileSync).mock.calls[0][0];
+    expect(fs.writeFileSync).toHaveBeenCalledWith(tempPath, expect.any(String), {
+      flag: 'wx',
+      mode: 0o600,
+    });
+    expect(fs.linkSync).toHaveBeenCalledWith(tempPath, secretPath);
+    expect(service.verifyToken(token)).toEqual({ valid: true, userId: 'race-winner' });
   });
 });

--- a/web/src/server/services/auth-service.test.ts
+++ b/web/src/server/services/auth-service.test.ts
@@ -1,0 +1,123 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthService } from './auth-service.js';
+
+// Mock modules
+vi.mock('fs');
+vi.mock('os');
+
+// Mock logger to avoid path issues
+vi.mock('../utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    log: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+describe('AuthService JWT secret persistence', () => {
+  const mockHomeDir = '/home/testuser';
+  const secretPath = path.join(mockHomeDir, '.vibetunnel', 'jwt-secret');
+  let savedJwtSecret: string | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The constructor schedules a cleanup interval; fake timers keep it from lingering.
+    vi.useFakeTimers();
+
+    savedJwtSecret = process.env.JWT_SECRET;
+    process.env.JWT_SECRET = undefined;
+    delete process.env.JWT_SECRET;
+
+    vi.mocked(os.homedir).mockReturnValue(mockHomeDir);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+    vi.mocked(fs.mkdirSync).mockImplementation(() => undefined);
+    vi.mocked(fs.readFileSync).mockReturnValue('');
+    vi.mocked(fs.writeFileSync).mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (savedJwtSecret === undefined) {
+      delete process.env.JWT_SECRET;
+    } else {
+      process.env.JWT_SECRET = savedJwtSecret;
+    }
+  });
+
+  it('generates and persists a secret (0600) when none exists on disk', () => {
+    new AuthService();
+
+    expect(fs.mkdirSync).toHaveBeenCalledWith(path.join(mockHomeDir, '.vibetunnel'), {
+      recursive: true,
+    });
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+    const [writtenPath, writtenSecret, opts] = vi.mocked(fs.writeFileSync).mock.calls[0];
+    expect(writtenPath).toBe(secretPath);
+    expect(typeof writtenSecret).toBe('string');
+    expect((writtenSecret as string).length).toBeGreaterThan(0);
+    expect(opts).toEqual({ mode: 0o600 });
+  });
+
+  it('loads the existing secret without rewriting, so tokens survive a restart', () => {
+    // First "boot": no file → generates + persists. Capture the generated secret.
+    const instanceA = new AuthService();
+    const persistedSecret = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    const token = instanceA.generateTokenForUser('alice');
+
+    // Second "boot" (server restart): file now present with the same secret.
+    vi.clearAllMocks();
+    vi.mocked(os.homedir).mockReturnValue(mockHomeDir);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(persistedSecret);
+
+    const instanceB = new AuthService();
+
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+    // The token minted before the restart still verifies after it — the whole point.
+    expect(instanceB.verifyToken(token)).toEqual({ valid: true, userId: 'alice' });
+  });
+
+  it('regenerates and persists when the on-disk secret file is empty', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue('   \n');
+
+    new AuthService();
+
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+    const writtenSecret = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    expect(writtenSecret.trim().length).toBeGreaterThan(0);
+  });
+
+  it('uses JWT_SECRET env var and never touches disk when it is set', () => {
+    process.env.JWT_SECRET = 'env-provided-secret';
+
+    const service = new AuthService();
+
+    expect(fs.existsSync).not.toHaveBeenCalled();
+    expect(fs.readFileSync).not.toHaveBeenCalled();
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+    // Token signed with the env secret round-trips.
+    const token = service.generateTokenForUser('bob');
+    expect(service.verifyToken(token)).toEqual({ valid: true, userId: 'bob' });
+  });
+
+  it('falls back to an in-memory secret without throwing when disk access fails', () => {
+    vi.mocked(fs.writeFileSync).mockImplementation(() => {
+      throw new Error('EROFS: read-only file system');
+    });
+
+    let service: AuthService | undefined;
+    expect(() => {
+      service = new AuthService();
+    }).not.toThrow();
+
+    // Auth still works in-process despite the persistence failure.
+    const token = (service as AuthService).generateTokenForUser('carol');
+    expect((service as AuthService).verifyToken(token)).toEqual({ valid: true, userId: 'carol' });
+  });
+});

--- a/web/src/server/services/auth-service.ts
+++ b/web/src/server/services/auth-service.ts
@@ -7,6 +7,9 @@ import { createLogger } from '../utils/logger.js';
 import { authenticate as pamAuthenticate } from './authenticate-pam-loader.js';
 
 const logger = createLogger('auth-service');
+const JWT_SECRET_BYTES = 64;
+const JWT_SECRET_PATTERN = new RegExp(`^[0-9a-f]{${JWT_SECRET_BYTES * 2}}$`);
+const JWT_SECRET_CREATE_ATTEMPTS = 3;
 
 interface AuthChallenge {
   challengeId: string;
@@ -48,7 +51,55 @@ export class AuthService {
   }
 
   private generateSecret(): string {
-    return crypto.randomBytes(64).toString('hex');
+    return crypto.randomBytes(JWT_SECRET_BYTES).toString('hex');
+  }
+
+  private hasFileErrorCode(error: unknown, code: string): error is NodeJS.ErrnoException {
+    return error instanceof Error && (error as NodeJS.ErrnoException).code === code;
+  }
+
+  private readPersistedSecret(secretPath: string): string | null {
+    try {
+      const existing = fs.readFileSync(secretPath, 'utf8').trim();
+      if (!JWT_SECRET_PATTERN.test(existing)) {
+        logger.warn('Persisted JWT secret is invalid; regenerating');
+        try {
+          fs.unlinkSync(secretPath);
+        } catch (error) {
+          if (!this.hasFileErrorCode(error, 'ENOENT')) throw error;
+        }
+        return null;
+      }
+
+      fs.chmodSync(secretPath, 0o600);
+      logger.debug('Loaded persisted JWT secret');
+      return existing;
+    } catch (error) {
+      if (this.hasFileErrorCode(error, 'ENOENT')) return null;
+      throw error;
+    }
+  }
+
+  private publishSecret(secretPath: string, secret: string): boolean {
+    const tempPath = `${secretPath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+    try {
+      fs.writeFileSync(tempPath, secret, { flag: 'wx', mode: 0o600 });
+      try {
+        fs.linkSync(tempPath, secretPath);
+        return true;
+      } catch (error) {
+        if (this.hasFileErrorCode(error, 'EEXIST')) return false;
+        throw error;
+      }
+    } finally {
+      try {
+        fs.unlinkSync(tempPath);
+      } catch (error) {
+        if (!this.hasFileErrorCode(error, 'ENOENT')) {
+          logger.warn(`Failed to remove temporary JWT secret ${tempPath}:`, error);
+        }
+      }
+    }
   }
 
   /**
@@ -65,20 +116,20 @@ export class AuthService {
     const secretPath = path.join(secretDir, 'jwt-secret');
 
     try {
-      if (fs.existsSync(secretPath)) {
-        const existing = fs.readFileSync(secretPath, 'utf8').trim();
-        if (existing) {
-          logger.debug('Loaded persisted JWT secret');
-          return existing;
+      fs.mkdirSync(secretDir, { recursive: true });
+
+      for (let attempt = 0; attempt < JWT_SECRET_CREATE_ATTEMPTS; attempt++) {
+        const existing = this.readPersistedSecret(secretPath);
+        if (existing) return existing;
+
+        const secret = this.generateSecret();
+        if (this.publishSecret(secretPath, secret)) {
+          logger.log(`Generated and persisted new JWT secret at ${secretPath}`);
+          return secret;
         }
-        logger.warn('Persisted JWT secret file is empty; regenerating');
       }
 
-      const secret = this.generateSecret();
-      fs.mkdirSync(secretDir, { recursive: true });
-      fs.writeFileSync(secretPath, secret, { mode: 0o600 }); // owner-only
-      logger.log(`Generated and persisted new JWT secret at ${secretPath}`);
-      return secret;
+      throw new Error('JWT secret changed repeatedly during startup');
     } catch (error) {
       logger.error(
         'Failed to persist JWT secret; using in-memory secret (tokens will not survive a restart):',

--- a/web/src/server/services/auth-service.ts
+++ b/web/src/server/services/auth-service.ts
@@ -1,6 +1,12 @@
 import * as crypto from 'crypto';
+import * as fs from 'fs';
 import * as jwt from 'jsonwebtoken';
+import * as os from 'os';
+import * as path from 'path';
+import { createLogger } from '../utils/logger.js';
 import { authenticate as pamAuthenticate } from './authenticate-pam-loader.js';
+
+const logger = createLogger('auth-service');
 
 interface AuthChallenge {
   challengeId: string;
@@ -28,8 +34,14 @@ export class AuthService {
   private challengeTimeout = 5 * 60 * 1000; // 5 minutes
 
   constructor() {
-    // Generate or load JWT secret
-    this.jwtSecret = process.env.JWT_SECRET || this.generateSecret();
+    // Resolve the JWT signing secret. Priority:
+    //   1. JWT_SECRET env var (explicit operator override)
+    //   2. persisted secret on disk (~/.vibetunnel/jwt-secret)
+    //   3. freshly generated secret, persisted for next time
+    // Persisting is essential: without it a new random secret is created on every
+    // server start, instantly invalidating every previously-issued token and causing
+    // 401 storms from open clients after a restart.
+    this.jwtSecret = process.env.JWT_SECRET || this.loadOrCreateSecret();
 
     // Clean up expired challenges every minute
     setInterval(() => this.cleanupExpiredChallenges(), 60000);
@@ -37,6 +49,43 @@ export class AuthService {
 
   private generateSecret(): string {
     return crypto.randomBytes(64).toString('hex');
+  }
+
+  /**
+   * Load the JWT signing secret from disk, generating and persisting one if absent.
+   * Falls back to an in-memory secret if disk access fails, so auth still works
+   * (tokens just won't survive a restart in that degraded case).
+   */
+  private loadOrCreateSecret(): string {
+    // Account-global location, mirroring VapidManager (~/.vibetunnel/vapid). Deliberately
+    // NOT derived from VIBETUNNEL_CONTROL_DIR: the mac app points that at the per-session
+    // control dir, which can be cleaned/rotated — losing the secret there would silently
+    // regenerate it and reintroduce the restart 401 storm.
+    const secretDir = path.join(os.homedir(), '.vibetunnel');
+    const secretPath = path.join(secretDir, 'jwt-secret');
+
+    try {
+      if (fs.existsSync(secretPath)) {
+        const existing = fs.readFileSync(secretPath, 'utf8').trim();
+        if (existing) {
+          logger.debug('Loaded persisted JWT secret');
+          return existing;
+        }
+        logger.warn('Persisted JWT secret file is empty; regenerating');
+      }
+
+      const secret = this.generateSecret();
+      fs.mkdirSync(secretDir, { recursive: true });
+      fs.writeFileSync(secretPath, secret, { mode: 0o600 }); // owner-only
+      logger.log(`Generated and persisted new JWT secret at ${secretPath}`);
+      return secret;
+    } catch (error) {
+      logger.error(
+        'Failed to persist JWT secret; using in-memory secret (tokens will not survive a restart):',
+        error
+      );
+      return this.generateSecret();
+    }
   }
 
   private cleanupExpiredChallenges(): void {

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -12,6 +12,8 @@ vi.mock('ghostty-web', () => ({
 
 // Disable SEA loader for tests
 process.env.VIBETUNNEL_SEA = '';
+// Prevent spawned test servers from creating persistent signing material in the real home.
+process.env.JWT_SECRET ??= 'vibetunnel-test-only-jwt-secret';
 
 // Polyfill crypto for Node.js environments
 if (!globalThis.crypto) {


### PR DESCRIPTION
## Problem

`AuthService` generated a new random JWT signing secret on every server start. Every restart therefore invalidated existing browser tokens and caused repeated 401 responses until users logged in again.

## Fix

- Persist the generated 64-byte secret at `~/.vibetunnel/jwt-secret`.
- Keep `JWT_SECRET` as the highest-priority operator override.
- Validate persisted secrets and repair their permissions to `0600`.
- Publish first-run secrets atomically with an exclusive temporary file plus hard link, so concurrent server starts all converge on one complete key.
- Regenerate invalid files and fall back to an in-memory secret when persistence is unavailable.
- Keep test servers from writing signing material into the developer's real home directory.

The path is intentionally account-global rather than derived from `VIBETUNNEL_CONTROL_DIR`, which can be cleaned or rotated. Upgrading may require one final login; subsequent restarts preserve sessions. Rotating `JWT_SECRET` or deleting the persisted key intentionally logs clients out.

## Proof

- Reproduced on `main`: a token from one `AuthService` instance fails verification in a fresh instance.
- Verified with a temporary home: a token survives restart, the stored secret is 128 hex characters, and its mode is `0600`.
- Verified 24 simultaneous first boots: all 24 tokens validate against the winning persisted key and no temporary files remain.
- `pnpm exec vitest run src/server/services/auth-service.test.ts --mode=server --maxWorkers=1`
- `pnpm exec vitest run --mode=server --coverage --maxWorkers=4`
- Lint, format check, standard typecheck, and VT syntax/functionality gate pass.

## Tests

Regression coverage includes first-run persistence, restart survival, permission repair, invalid-secret regeneration, environment override precedence, disk failure fallback, and concurrent startup winner reload.
