### PR TITLE
fix(web): sync terminal width selector when reopening settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug Fixes
 - Fix session creation "data couldn't be read" error on Mac app (#500)
+- Restore the configured terminal width when reopening Terminal Settings (via [@Nachx639](https://github.com/Nachx639)) (#640)
 - Keep Terminal Settings and other interactive overlays above the exited-session badge (via [@Nachx639](https://github.com/Nachx639)) (#643)
 - Fix npm and Bun global installs exiting early by recognizing the `vibetunnel` bin entry point (via [@yv-was-taken](https://github.com/yv-was-taken)) (#583)
 - Fix desktop terminal content being clipped at the bottom (via [@ChimeraFlutter](https://github.com/ChimeraFlutter)) (#608)
@@ -23,7 +24,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
-- Thanks [@Nachx639](https://github.com/Nachx639) for fixing exited-session overlay layering.
+- Thanks [@Nachx639](https://github.com/Nachx639) for fixing Terminal Settings width sync and exited-session overlay layering.
 - Thanks [@sourman](https://github.com/sourman) for documenting the Zig build prerequisite.
 - Thanks [@yv-was-taken](https://github.com/yv-was-taken) for fixing global npm and Bun installs.
 - Thanks [@ChimeraFlutter](https://github.com/ChimeraFlutter) for fixing desktop terminal clipping.

--- a/web/src/client/components/session-view/width-selector.test.ts
+++ b/web/src/client/components/session-view/width-selector.test.ts
@@ -2,7 +2,7 @@
 
 import { fixture } from '@open-wc/testing';
 import { html } from 'lit';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Z_INDEX } from '../../utils/constants.js';
 import './width-selector.js';
 import type { TerminalSettingsModal } from './width-selector.js';
@@ -32,9 +32,36 @@ describe('TerminalSettingsModal', () => {
 
     const widthSelect = document.querySelector('select') as HTMLSelectElement | null;
     expect(widthSelect).toBeTruthy();
+    expect(widthSelect?.value).toBe('80');
 
     const themeSelect = document.querySelector('#theme-select') as HTMLSelectElement | null;
     expect(themeSelect).toBeTruthy();
+  });
+
+  it('should restore the configured width when reopening', async () => {
+    element.visible = false;
+    await element.updateComplete;
+    element.terminalMaxCols = 120;
+    element.visible = true;
+    await element.updateComplete;
+
+    const widthSelect = element.querySelector('select') as HTMLSelectElement;
+    expect(widthSelect.value).toBe('120');
+  });
+
+  it('should select custom widths and allow switching to fit-to-window', async () => {
+    const onWidthSelect = vi.fn();
+    element.onWidthSelect = onWidthSelect;
+    element.terminalMaxCols = 123;
+    await element.updateComplete;
+
+    const widthSelect = element.querySelector('select') as HTMLSelectElement;
+    expect(widthSelect.value).toBe('custom');
+
+    widthSelect.value = '0';
+    widthSelect.dispatchEvent(new Event('change'));
+
+    expect(onWidthSelect).toHaveBeenCalledWith(0);
   });
 
   it('should not render legacy binary mode toggle', async () => {

--- a/web/src/client/components/session-view/width-selector.ts
+++ b/web/src/client/components/session-view/width-selector.ts
@@ -105,6 +105,26 @@ export class TerminalSettingsModal extends LitElement {
         }
       });
     }
+
+    // Same fix for the width select: when bound via Lit, the value can be applied
+    // before the dynamic <option>s exist, leaving the select stuck on its first
+    // option ("Fit to Window"). Force the correct value after the DOM is ready.
+    if (
+      changedProperties.has('terminalMaxCols') ||
+      changedProperties.has('visible') ||
+      changedProperties.has('showCustomInput')
+    ) {
+      requestAnimationFrame(() => {
+        const widthSelect = this.querySelector('#width-select') as HTMLSelectElement;
+        if (widthSelect) {
+          const isCustomValue =
+            this.terminalMaxCols > 0 &&
+            !COMMON_TERMINAL_WIDTHS.find((w) => w.value === this.terminalMaxCols);
+          widthSelect.value =
+            isCustomValue || this.showCustomInput ? 'custom' : String(this.terminalMaxCols);
+        }
+      });
+    }
   }
 
   render() {
@@ -155,6 +175,7 @@ export class TerminalSettingsModal extends LitElement {
             <div class="grid grid-cols-[120px_1fr] gap-4 items-center">
               <label class="text-sm font-medium text-text-bright text-right">Width</label>
               <select
+                id="width-select"
                 class="w-full bg-bg-secondary border border-border rounded-md pl-4 pr-10 py-3 text-sm font-mono text-text focus:border-primary focus:shadow-glow-sm cursor-pointer appearance-none"
                 style="background-image: url('data:image/svg+xml;charset=UTF-8,%3csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 20 20%22 fill=%22${this.getArrowColor()}%22%3e%3cpath fill-rule=%22evenodd%22 d=%22M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z%22 clip-rule=%22evenodd%22/%3e%3c/svg%3e'); background-position: right 0.75rem center; background-repeat: no-repeat; background-size: 1.25em 1.25em;"
                 .value=${isCustomValue || this.showCustomInput ? 'custom' : String(this.terminalMaxCols)}

--- a/web/src/client/components/session-view/width-selector.ts
+++ b/web/src/client/components/session-view/width-selector.ts
@@ -89,6 +89,14 @@ export class TerminalSettingsModal extends LitElement {
     return getTextColorEncoded();
   }
 
+  private getSelectedWidthValue(): string {
+    const isCustomValue =
+      this.terminalMaxCols > 0 &&
+      !COMMON_TERMINAL_WIDTHS.find((width) => width.value === this.terminalMaxCols);
+
+    return isCustomValue || this.showCustomInput ? 'custom' : String(this.terminalMaxCols);
+  }
+
   // legacy binary-mode preference removed (v3 WS + ghostty is always-on)
 
   updated(changedProperties: Map<string | number | symbol, unknown>) {
@@ -106,24 +114,15 @@ export class TerminalSettingsModal extends LitElement {
       });
     }
 
-    // Same fix for the width select: when bound via Lit, the value can be applied
-    // before the dynamic <option>s exist, leaving the select stuck on its first
-    // option ("Fit to Window"). Force the correct value after the DOM is ready.
     if (
       changedProperties.has('terminalMaxCols') ||
       changedProperties.has('visible') ||
       changedProperties.has('showCustomInput')
     ) {
-      requestAnimationFrame(() => {
-        const widthSelect = this.querySelector('#width-select') as HTMLSelectElement;
-        if (widthSelect) {
-          const isCustomValue =
-            this.terminalMaxCols > 0 &&
-            !COMMON_TERMINAL_WIDTHS.find((w) => w.value === this.terminalMaxCols);
-          widthSelect.value =
-            isCustomValue || this.showCustomInput ? 'custom' : String(this.terminalMaxCols);
-        }
-      });
+      const widthSelect = this.querySelector('#width-select') as HTMLSelectElement | null;
+      if (widthSelect) {
+        widthSelect.value = this.getSelectedWidthValue();
+      }
     }
   }
 
@@ -134,9 +133,7 @@ export class TerminalSettingsModal extends LitElement {
     logger.debug('Dialog opening, terminal theme:', this.terminalTheme);
 
     // Check if we're showing a custom value that doesn't match presets
-    const isCustomValue =
-      this.terminalMaxCols > 0 &&
-      !COMMON_TERMINAL_WIDTHS.find((w) => w.value === this.terminalMaxCols);
+    const isCustomValue = this.getSelectedWidthValue() === 'custom';
 
     return html`
       <!-- Backdrop to close on outside click -->
@@ -178,7 +175,7 @@ export class TerminalSettingsModal extends LitElement {
                 id="width-select"
                 class="w-full bg-bg-secondary border border-border rounded-md pl-4 pr-10 py-3 text-sm font-mono text-text focus:border-primary focus:shadow-glow-sm cursor-pointer appearance-none"
                 style="background-image: url('data:image/svg+xml;charset=UTF-8,%3csvg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 20 20%22 fill=%22${this.getArrowColor()}%22%3e%3cpath fill-rule=%22evenodd%22 d=%22M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z%22 clip-rule=%22evenodd%22/%3e%3c/svg%3e'); background-position: right 0.75rem center; background-repeat: no-repeat; background-size: 1.25em 1.25em;"
-                .value=${isCustomValue || this.showCustomInput ? 'custom' : String(this.terminalMaxCols)}
+                .value=${this.getSelectedWidthValue()}
                 @click=${(e: Event) => e.stopPropagation()}
                 @mousedown=${(e: Event) => e.stopPropagation()}
                 @change=${(e: Event) => {


### PR DESCRIPTION
## Problem

In Terminal Settings, the Width selector did not reliably reflect the configured value. After selecting a preset such as Classic terminal (80), closing and reopening settings could show Fit to Window instead. Preset-to-preset updates could also leave the native select on a stale value.

## Cause

Lit can apply the select value before its dynamic options are ready, causing the browser to retain the first or previously selected option.

## Fix

- Derive preset, custom, and fit-to-window selection through one helper.
- Reconcile the native select synchronously in `updated()` after Lit renders its options.
- Cover initial render, reopen, preset changes, custom widths, and fit-to-window switching.
- Add the user-facing changelog entry and contributor credit.

## Verification

- Focused Width selector tests: 5 passed.
- Full client Vitest coverage suite: passed.
- Web lint, typecheck, and format checks: passed.
- Live Chrome proof: selected Classic terminal (80), closed settings, reopened, and confirmed the select value was `80` with Classic terminal selected.
- Autoreview: clean, no actionable findings.
