### PR TITLE
fix(server): rotate oversized log files safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### ✨ Improvements
+- Rotate server logs at 50 MB while retaining one backup file (via [@Nachx639](https://github.com/Nachx639)) (#641)
 - Require Node.js 22.12+ for npm/native builds and generate maintained Node 22/24 prebuilds only.
 - Improve mobile session UI with action bar, clipboard manager, and quick keys (via [@Jerome2332](https://github.com/Jerome2332)) (#518)
 - Document Zig 0.15.2 as the `vt-fwd` build prerequisite (via [@sourman](https://github.com/sourman)) (#611)
@@ -25,7 +26,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
-- Thanks [@Nachx639](https://github.com/Nachx639) for fixing dependency security, Terminal Settings width sync, and exited-session overlay layering.
+- Thanks [@Nachx639](https://github.com/Nachx639) for adding log rotation and fixing dependency security, Terminal Settings width sync, and exited-session overlay layering.
 - Thanks [@sourman](https://github.com/sourman) for documenting the Zig build prerequisite.
 - Thanks [@yv-was-taken](https://github.com/yv-was-taken) for fixing global npm and Bun installs.
 - Thanks [@ChimeraFlutter](https://github.com/ChimeraFlutter) for fixing desktop terminal clipping.

--- a/web/src/server/utils/logger.ts
+++ b/web/src/server/utils/logger.ts
@@ -11,11 +11,11 @@ let LOG_FILE = path.join(LOG_DIR, 'log.txt');
  * Set custom log file path
  */
 export function setLogFilePath(filePath: string): void {
-  // Close existing file handle if open
-  if (logFileHandle) {
-    logFileHandle.end();
-    logFileHandle = null;
-  }
+  closeLogFile();
+  loggerClosing = false;
+  closeAfterRotation = false;
+  pendingFileWrites = [];
+  rotationPromise = null;
 
   LOG_FILE = filePath;
 
@@ -25,12 +25,7 @@ export function setLogFilePath(filePath: string): void {
     fs.mkdirSync(dir, { recursive: true });
   }
 
-  // Re-open log file at new location
-  try {
-    logFileHandle = fs.createWriteStream(LOG_FILE, { flags: 'a' });
-  } catch (error) {
-    console.error('Failed to open log file at new location:', error);
-  }
+  openLogFile();
 }
 
 // Verbosity levels
@@ -80,29 +75,147 @@ export function parseVerbosityLevel(value: string): VerbosityLevel | undefined {
 // File handle for log file
 let logFileHandle: fs.WriteStream | null = null;
 let bytesWritten = 0;
-const MAX_LOG_SIZE = 50 * 1024 * 1024; // 50MB
+let loggerGeneration = 0;
+let loggerClosing = false;
+let closeAfterRotation = false;
+let pendingFileWrites: string[] = [];
+let rotationPromise: Promise<void> | null = null;
+let closePromise: Promise<void> | null = null;
+const MAX_LOG_SIZE = 50 * 1024 * 1024;
 
-function rotateLogFile(): void {
-  if (logFileHandle) {
-    logFileHandle.end();
+function getLogFileSize(filePath: string): number {
+  try {
+    return fs.statSync(filePath).size;
+  } catch {
+    return 0;
+  }
+}
+
+function openLogFile(
+  filePath: string = LOG_FILE,
+  generation: number = loggerGeneration,
+  initialSize: number = getLogFileSize(filePath)
+): void {
+  try {
+    const handle = fs.createWriteStream(filePath, { flags: 'a' });
+    handle.on('error', () => {
+      if (generation === loggerGeneration && logFileHandle === handle) {
+        logFileHandle = null;
+      }
+    });
+
+    if (generation !== loggerGeneration || loggerClosing) {
+      handle.end();
+      return;
+    }
+
+    logFileHandle = handle;
+    bytesWritten = initialSize;
+  } catch {
     logFileHandle = null;
   }
-  try {
-    const backupPath = `${LOG_FILE}.1`;
-    if (fs.existsSync(backupPath)) {
-      fs.unlinkSync(backupPath);
-    }
-    if (fs.existsSync(LOG_FILE)) {
-      fs.renameSync(LOG_FILE, backupPath);
-    }
-  } catch {
-    // Ignore rotation errors
+}
+
+function rotateLogFile(): void {
+  if (!logFileHandle || rotationPromise || loggerClosing) {
+    return;
   }
-  bytesWritten = 0;
+
+  const handle = logFileHandle;
+  const logPath = LOG_FILE;
+  const generation = loggerGeneration;
+  logFileHandle = null;
+
+  const rotation = new Promise<void>((resolve) => {
+    handle.once('close', () => {
+      try {
+        const backupPath = `${logPath}.1`;
+        if (fs.existsSync(backupPath)) {
+          fs.unlinkSync(backupPath);
+        }
+        if (fs.existsSync(logPath)) {
+          fs.renameSync(logPath, backupPath);
+        }
+      } catch {
+        // Retry after another 50 MB rather than interrupting logging.
+      }
+      resolve();
+    });
+    handle.end();
+  });
+
+  rotationPromise = rotation;
+  void rotation.finally(() => {
+    if (rotationPromise === rotation) {
+      rotationPromise = null;
+    }
+    if (generation !== loggerGeneration || loggerClosing) {
+      return;
+    }
+
+    openLogFile(logPath, generation, 0);
+    const queuedWrites = pendingFileWrites;
+    pendingFileWrites = [];
+    for (const output of queuedWrites) {
+      writeOutput(output, true);
+    }
+
+    if (closeAfterRotation && !rotationPromise) {
+      closeAfterRotation = false;
+      closeLogFile();
+    }
+  });
+}
+
+function writeOutput(output: string, allowWhileClosing: boolean = false): void {
+  if (loggerClosing || (closeAfterRotation && !allowWhileClosing)) {
+    return;
+  }
+
+  if (rotationPromise) {
+    pendingFileWrites.push(output);
+    return;
+  }
+  if (!logFileHandle) {
+    return;
+  }
+
+  const outputBytes = Buffer.byteLength(output, 'utf8');
   try {
-    logFileHandle = fs.createWriteStream(LOG_FILE, { flags: 'a' });
+    logFileHandle.write(output);
+    bytesWritten += outputBytes;
+    if (bytesWritten >= MAX_LOG_SIZE) {
+      rotateLogFile();
+    }
   } catch {
-    // Ignore errors
+    // Silently ignore file write errors.
+  }
+}
+
+function closeLogFile(): void {
+  loggerClosing = true;
+  loggerGeneration += 1;
+  closeAfterRotation = false;
+  pendingFileWrites = [];
+  rotationPromise = null;
+  bytesWritten = 0;
+  if (logFileHandle) {
+    const handle = logFileHandle;
+    logFileHandle = null;
+    const closing = new Promise<void>((resolve) => {
+      if (handle.closed) {
+        resolve();
+        return;
+      }
+      handle.once('close', resolve);
+      handle.end();
+    });
+    closePromise = closing;
+    void closing.finally(() => {
+      if (closePromise === closing) {
+        closePromise = null;
+      }
+    });
   }
 }
 
@@ -115,6 +228,8 @@ const ANSI_PATTERN = /\x1b\[[0-9;]*m/g;
  */
 export function initLogger(debug: boolean = false, verbosity?: VerbosityLevel): void {
   _debugMode = debug;
+  loggerClosing = false;
+  closeAfterRotation = false;
 
   // Set verbosity level
   if (verbosity !== undefined) {
@@ -145,8 +260,7 @@ export function initLogger(debug: boolean = false, verbosity?: VerbosityLevel): 
       // Don't log here as logger isn't fully initialized yet
     }
 
-    // Create new log file write stream
-    logFileHandle = fs.createWriteStream(LOG_FILE, { flags: 'a' });
+    openLogFile(LOG_FILE, loggerGeneration, 0);
   } catch (error) {
     // Don't throw, just log to console
     console.error('Failed to initialize log file:', error);
@@ -157,6 +271,13 @@ export function initLogger(debug: boolean = false, verbosity?: VerbosityLevel): 
  * Flush the log file buffer
  */
 export function flushLogger(): Promise<void> {
+  if (rotationPromise) {
+    return rotationPromise.then(() => flushLogger());
+  }
+  if (closePromise) {
+    return closePromise.then(() => flushLogger());
+  }
+
   return new Promise((resolve) => {
     if (logFileHandle && !logFileHandle.destroyed) {
       // Force a write of any buffered data
@@ -173,10 +294,11 @@ export function flushLogger(): Promise<void> {
  * Close the logger
  */
 export function closeLogger(): void {
-  if (logFileHandle) {
-    logFileHandle.end();
-    logFileHandle = null;
+  if (rotationPromise) {
+    closeAfterRotation = true;
+    return;
   }
+  closeLogFile();
 }
 
 /**
@@ -233,20 +355,8 @@ function formatMessage(
  * Write to log file
  */
 function writeToFile(message: string): void {
-  if (logFileHandle) {
-    try {
-      // Strip ANSI color codes from message
-      const cleanMessage = message.replace(ANSI_PATTERN, '');
-      const output = `${cleanMessage}\n`;
-      logFileHandle.write(output);
-      bytesWritten += Buffer.byteLength(output, 'utf8');
-      if (bytesWritten > MAX_LOG_SIZE) {
-        rotateLogFile();
-      }
-    } catch {
-      // Silently ignore file write errors
-    }
-  }
+  const cleanMessage = message.replace(ANSI_PATTERN, '');
+  writeOutput(`${cleanMessage}\n`);
 }
 
 /**

--- a/web/src/server/utils/logger.ts
+++ b/web/src/server/utils/logger.ts
@@ -79,6 +79,32 @@ export function parseVerbosityLevel(value: string): VerbosityLevel | undefined {
 
 // File handle for log file
 let logFileHandle: fs.WriteStream | null = null;
+let bytesWritten = 0;
+const MAX_LOG_SIZE = 50 * 1024 * 1024; // 50MB
+
+function rotateLogFile(): void {
+  if (logFileHandle) {
+    logFileHandle.end();
+    logFileHandle = null;
+  }
+  try {
+    const backupPath = `${LOG_FILE}.1`;
+    if (fs.existsSync(backupPath)) {
+      fs.unlinkSync(backupPath);
+    }
+    if (fs.existsSync(LOG_FILE)) {
+      fs.renameSync(LOG_FILE, backupPath);
+    }
+  } catch {
+    // Ignore rotation errors
+  }
+  bytesWritten = 0;
+  try {
+    logFileHandle = fs.createWriteStream(LOG_FILE, { flags: 'a' });
+  } catch {
+    // Ignore errors
+  }
+}
 
 // ANSI color codes for stripping from file output
 // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape sequences require control characters
@@ -211,7 +237,12 @@ function writeToFile(message: string): void {
     try {
       // Strip ANSI color codes from message
       const cleanMessage = message.replace(ANSI_PATTERN, '');
-      logFileHandle.write(`${cleanMessage}\n`);
+      const output = `${cleanMessage}\n`;
+      logFileHandle.write(output);
+      bytesWritten += Buffer.byteLength(output, 'utf8');
+      if (bytesWritten > MAX_LOG_SIZE) {
+        rotateLogFile();
+      }
     } catch {
       // Silently ignore file write errors
     }

--- a/web/src/test/unit/logger-rotation.test.ts
+++ b/web/src/test/unit/logger-rotation.test.ts
@@ -1,0 +1,75 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  closeLogger,
+  createLogger,
+  flushLogger,
+  setLogFilePath,
+  setVerbosityLevel,
+  VerbosityLevel,
+} from '../../server/utils/logger';
+
+const MAX_LOG_SIZE = 50 * 1024 * 1024;
+
+function readFileTail(filePath: string, length: number = 1024): string {
+  const fileSize = fs.statSync(filePath).size;
+  const buffer = Buffer.alloc(Math.min(fileSize, length));
+  const descriptor = fs.openSync(filePath, 'r');
+  try {
+    fs.readSync(descriptor, buffer, 0, buffer.length, fileSize - buffer.length);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  return buffer.toString('utf8');
+}
+
+describe('logger rotation', () => {
+  let tempDir: string;
+  let logPath: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vibetunnel-logger-'));
+    logPath = path.join(tempDir, 'server.log');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    setVerbosityLevel(VerbosityLevel.INFO);
+  });
+
+  afterEach(async () => {
+    await flushLogger();
+    closeLogger();
+    vi.restoreAllMocks();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes the threshold-crossing message before rotating and preserves queued messages', async () => {
+    fs.writeFileSync(logPath, '');
+    fs.truncateSync(logPath, MAX_LOG_SIZE);
+    fs.writeFileSync(`${logPath}.1`, 'stale backup');
+    setLogFilePath(logPath);
+
+    const logger = createLogger('rotation-test');
+    logger.info('first message after rotation');
+    logger.info('second queued message');
+    await flushLogger();
+
+    expect(fs.statSync(`${logPath}.1`).size).toBeGreaterThan(MAX_LOG_SIZE);
+    expect(readFileTail(`${logPath}.1`)).toContain('first message after rotation');
+    const currentLog = fs.readFileSync(logPath, 'utf8');
+    expect(currentLog).toContain('second queued message');
+  });
+
+  it('flushes queued messages when closed during rotation', async () => {
+    fs.writeFileSync(logPath, '');
+    fs.truncateSync(logPath, MAX_LOG_SIZE);
+    setLogFilePath(logPath);
+
+    const logger = createLogger('rotation-test');
+    logger.info('message before close');
+    closeLogger();
+    await flushLogger();
+
+    expect(readFileTail(`${logPath}.1`)).toContain('message before close');
+  });
+});


### PR DESCRIPTION
## Problem

The server log grows without a bound on long-running installations.

## Fix

- Rotate the active log after it reaches 50 MB and retain one `.1` backup.
- Track an existing custom log file's size before appending.
- Write the threshold-crossing entry before rotation, then wait for the stream to close before renaming it.
- Queue writes during rotation and drain them into the new active file.
- Flush queued writes before closing the logger.
- Add sparse-file regression coverage for rotation, queued writes, and shutdown during rotation.

No configuration or public API changes.

## Verification

- Logger rotation and verbosity suites: 24 passed.
- Full client coverage suite: 610 passed, 14 skipped.
- Full server coverage suite: 550 passed, 75 skipped; the 8 local failures require the missing `vibetunnel-fwd` binary and are covered by CI's documented Zig 0.15.2 toolchain.
- Lint, typecheck, and format checks pass.
- Structured autoreview: no actionable findings.
