### PR TITLE
fix(deps): update ws and qs security patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug Fixes
 - Fix session creation "data couldn't be read" error on Mac app (#500)
+- Update `ws` and `qs` to patched versions for GHSA-58qx-3vcg-4xpx and GHSA-q8mj-m7cp-5q26 (via [@Nachx639](https://github.com/Nachx639)) (#642)
 - Restore the configured terminal width when reopening Terminal Settings (via [@Nachx639](https://github.com/Nachx639)) (#640)
 - Keep Terminal Settings and other interactive overlays above the exited-session badge (via [@Nachx639](https://github.com/Nachx639)) (#643)
 - Fix npm and Bun global installs exiting early by recognizing the `vibetunnel` bin entry point (via [@yv-was-taken](https://github.com/yv-was-taken)) (#583)
@@ -24,7 +25,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
-- Thanks [@Nachx639](https://github.com/Nachx639) for fixing Terminal Settings width sync and exited-session overlay layering.
+- Thanks [@Nachx639](https://github.com/Nachx639) for fixing dependency security, Terminal Settings width sync, and exited-session overlay layering.
 - Thanks [@sourman](https://github.com/sourman) for documenting the Zig build prerequisite.
 - Thanks [@yv-was-taken](https://github.com/yv-was-taken) for fixing global npm and Bun installs.
 - Thanks [@ChimeraFlutter](https://github.com/ChimeraFlutter) for fixing desktop terminal clipping.

--- a/web/package.json
+++ b/web/package.json
@@ -87,7 +87,9 @@
   },
   "pnpm": {
     "overrides": {
-      "dompurify": "^3.4.2"
+      "dompurify": "^3.4.2",
+      "ws": ">=8.20.1",
+      "qs": ">=6.15.2"
     },
     "onlyBuiltDependencies": [
       "authenticate-pam",

--- a/web/package.json
+++ b/web/package.json
@@ -88,8 +88,7 @@
   "pnpm": {
     "overrides": {
       "dompurify": "^3.4.2",
-      "ws": ">=8.20.1",
-      "qs": ">=6.15.2"
+      "qs": "^6.15.2"
     },
     "onlyBuiltDependencies": [
       "authenticate-pam",
@@ -126,7 +125,7 @@
     "postject": "1.0.0-alpha.6",
     "signal-exit": "^4.1.0",
     "web-push": "^3.6.7",
-    "ws": "^8.20.0",
+    "ws": "^8.21.0",
     "zod": "^4.4.3"
   },
   "optionalDependencies": {

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -6,8 +6,7 @@ settings:
 
 overrides:
   dompurify: ^3.4.2
-  ws: '>=8.20.1'
-  qs: '>=6.15.2'
+  qs: ^6.15.2
 
 importers:
 
@@ -95,7 +94,7 @@ importers:
         specifier: ^3.6.7
         version: 3.6.7
       ws:
-        specifier: '>=8.20.1'
+        specifier: ^8.21.0
         version: 8.21.0
       zod:
         specifier: ^4.4.3
@@ -3598,6 +3597,18 @@ packages:
   ws-mock@0.1.0:
     resolution: {integrity: sha512-mdw+vk3GRP9qW/Kh8V6U+ai2tkkS3oAH6tqYQrnxBxP6MKWU5ryJhWOzm5tFcXfaxfL8Cf8ssA0wRZzE3LgTvw==}
 
+  ws@7.5.11:
+    resolution: {integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==}
+    engines: {node: '>=8.3.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
@@ -4730,7 +4741,7 @@ snapshots:
       mime-types: 2.1.35
       parse5: 6.0.1
       picomatch: 2.3.2
-      ws: 8.21.0
+      ws: 7.5.11
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -6969,6 +6980,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws-mock@0.1.0: {}
+
+  ws@7.5.11: {}
 
   ws@8.21.0: {}
 

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   dompurify: ^3.4.2
+  ws: '>=8.20.1'
+  qs: '>=6.15.2'
 
 importers:
 
@@ -93,8 +95,8 @@ importers:
         specifier: ^3.6.7
         version: 3.6.7
       ws:
-        specifier: ^8.20.0
-        version: 8.20.0
+        specifier: '>=8.20.1'
+        version: 8.21.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -3049,8 +3051,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -3596,20 +3598,8 @@ packages:
   ws-mock@0.1.0:
     resolution: {integrity: sha512-mdw+vk3GRP9qW/Kh8V6U+ai2tkkS3oAH6tqYQrnxBxP6MKWU5ryJhWOzm5tFcXfaxfL8Cf8ssA0wRZzE3LgTvw==}
 
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4740,7 +4730,7 @@ snapshots:
       mime-types: 2.1.35
       parse5: 6.0.1
       picomatch: 2.3.2
-      ws: 7.5.10
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -4937,7 +4927,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -5070,7 +5060,7 @@ snapshots:
     dependencies:
       '@hapi/bourne': 3.0.0
       inflation: 2.1.0
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 2.5.3
       type-is: 1.6.18
 
@@ -5429,7 +5419,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -5612,7 +5602,7 @@ snapshots:
       '@types/ws': 8.18.1
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6398,7 +6388,7 @@ snapshots:
       devtools-protocol: 0.0.1608973
       typed-query-selector: 2.12.2
       webdriver-bidi-protocol: 0.4.1
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -6424,7 +6414,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 
@@ -6739,7 +6729,7 @@ snapshots:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.15.1
+      qs: 6.15.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6980,9 +6970,7 @@ snapshots:
 
   ws-mock@0.1.0: {}
 
-  ws@7.5.10: {}
-
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   y18n@4.0.3: {}
 


### PR DESCRIPTION
## Problem

`pnpm audit --prod` reports two moderate production advisories:

| Package | Vulnerable | Patched | Advisory |
|---|---|---|---|
| `ws` | `<8.20.1` | `>=8.20.1` | [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) |
| `qs` | `<=6.15.1` | `>=6.15.2` | [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26) |

## Fix

- Bump the direct `ws` dependency to `^8.21.0`.
- Add a major-bounded `qs` override at `^6.15.2` for Express and body-parser.
- Preserve `ws-mock`'s compatible `ws` 7.x dependency, resolving it to patched `7.5.11` instead of forcing a major upgrade.
- Refresh the lockfile and add changelog/contributor credit.

## Verification

- `pnpm audit --prod`: no known vulnerabilities
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- Client coverage: 31 files passed; 610 tests passed, 14 skipped
- Server coverage: 47 files passed, 6 skipped; 548 tests passed, 75 skipped. Eight forwarder tests require the generated `vibetunnel-fwd` binary, which cannot be built locally with Zig 0.16; CI uses the repository's documented Zig 0.15.2 toolchain for full proof.
- Structured autoreview: no actionable findings
