### PR TITLE
fix(web): raise Terminal Settings modal above the SESSION EXITED badge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### 🐛 Bug Fixes
 - Fix session creation "data couldn't be read" error on Mac app (#500)
+- Keep Terminal Settings and other interactive overlays above the exited-session badge (via [@Nachx639](https://github.com/Nachx639)) (#643)
 - Fix npm and Bun global installs exiting early by recognizing the `vibetunnel` bin entry point (via [@yv-was-taken](https://github.com/yv-was-taken)) (#583)
 - Fix desktop terminal content being clipped at the bottom (via [@ChimeraFlutter](https://github.com/ChimeraFlutter)) (#608)
 - Preserve native terminal link taps by avoiding paste-input focus steal on anchors (via [@nikolasdehor](https://github.com/nikolasdehor)) (#606)
@@ -22,6 +23,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
+- Thanks [@Nachx639](https://github.com/Nachx639) for fixing exited-session overlay layering.
 - Thanks [@sourman](https://github.com/sourman) for documenting the Zig build prerequisite.
 - Thanks [@yv-was-taken](https://github.com/yv-was-taken) for fixing global npm and Bun installs.
 - Thanks [@ChimeraFlutter](https://github.com/ChimeraFlutter) for fixing desktop terminal clipping.

--- a/web/src/client/components/session-view/width-selector.test.ts
+++ b/web/src/client/components/session-view/width-selector.test.ts
@@ -3,6 +3,7 @@
 import { fixture } from '@open-wc/testing';
 import { html } from 'lit';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Z_INDEX } from '../../utils/constants.js';
 import './width-selector.js';
 import type { TerminalSettingsModal } from './width-selector.js';
 
@@ -40,5 +41,17 @@ describe('TerminalSettingsModal', () => {
     await element.updateComplete;
 
     expect(document.querySelector('[role="switch"]')).toBeFalsy();
+  });
+
+  it('should render above the exited-session badge using shared modal layers', async () => {
+    await element.updateComplete;
+
+    const backdrop = element.querySelector('[role="dialog"]') as HTMLElement | null;
+    const modal = element.querySelector('.width-selector-container') as HTMLElement | null;
+
+    expect(Z_INDEX.SESSION_EXITED_OVERLAY).toBeLessThan(Z_INDEX.MODAL_BACKDROP);
+    expect(Z_INDEX.MODAL_BACKDROP).toBeLessThan(Z_INDEX.MODAL);
+    expect(backdrop?.style.zIndex).toBe(String(Z_INDEX.MODAL_BACKDROP));
+    expect(modal?.style.zIndex).toBe(String(Z_INDEX.MODAL));
   });
 });

--- a/web/src/client/components/session-view/width-selector.ts
+++ b/web/src/client/components/session-view/width-selector.ts
@@ -120,18 +120,19 @@ export class TerminalSettingsModal extends LitElement {
 
     return html`
       <!-- Backdrop to close on outside click -->
-      <div 
-        class="fixed inset-0 z-40" 
+      <div
+        class="fixed inset-0"
+        style="z-index: ${Z_INDEX.TERMINAL_SETTINGS_BACKDROP};"
         role="dialog"
         aria-modal="true"
         aria-labelledby="terminal-settings-title"
         @click=${() => this.handleClose()}
       ></div>
-      
+
       <!-- Terminal settings modal -->
       <div
         class="width-selector-container fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-surface border border-border rounded-lg shadow-elevated w-[400px] max-w-[90vw] animate-fade-in"
-        style="z-index: ${Z_INDEX.WIDTH_SELECTOR_DROPDOWN};"
+        style="z-index: ${Z_INDEX.TERMINAL_SETTINGS_MODAL};"
       >
         <div class="p-6">
           <div class="flex items-center justify-between mb-6">

--- a/web/src/client/components/session-view/width-selector.ts
+++ b/web/src/client/components/session-view/width-selector.ts
@@ -122,7 +122,7 @@ export class TerminalSettingsModal extends LitElement {
       <!-- Backdrop to close on outside click -->
       <div
         class="fixed inset-0"
-        style="z-index: ${Z_INDEX.TERMINAL_SETTINGS_BACKDROP};"
+        style="z-index: ${Z_INDEX.MODAL_BACKDROP};"
         role="dialog"
         aria-modal="true"
         aria-labelledby="terminal-settings-title"
@@ -132,7 +132,7 @@ export class TerminalSettingsModal extends LitElement {
       <!-- Terminal settings modal -->
       <div
         class="width-selector-container fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 bg-surface border border-border rounded-lg shadow-elevated w-[400px] max-w-[90vw] animate-fade-in"
-        style="z-index: ${Z_INDEX.TERMINAL_SETTINGS_MODAL};"
+        style="z-index: ${Z_INDEX.MODAL};"
       >
         <div class="p-6">
           <div class="flex items-center justify-between mb-6">

--- a/web/src/client/utils/constants.ts
+++ b/web/src/client/utils/constants.ts
@@ -43,6 +43,7 @@ export const Z_INDEX = {
   MOBILE_INPUT_OVERLAY: 40,
   CTRL_ALPHA_OVERLAY: 45,
   TERMINAL_QUICK_KEYS: 48,
+  SESSION_EXITED_OVERLAY: 49, // Above terminal chrome, below interactive popovers and modals
 
   // Dropdowns and popovers (50-99)
   WIDTH_SELECTOR_DROPDOWN: 60,
@@ -53,11 +54,6 @@ export const Z_INDEX = {
   MODAL_BACKDROP: 100,
   MODAL: 105,
   FILE_PICKER: 110,
-  SESSION_EXITED_OVERLAY: 120,
-  // Terminal Settings is a full modal (with backdrop), so it must sit above the
-  // floating "SESSION EXITED" badge that otherwise overlaps it on exited sessions.
-  TERMINAL_SETTINGS_BACKDROP: 124,
-  TERMINAL_SETTINGS_MODAL: 125,
   NOTIFICATION: 150, // Notifications appear above modals but below file browser
 
   // Special high-priority overlays (200+)

--- a/web/src/client/utils/constants.ts
+++ b/web/src/client/utils/constants.ts
@@ -54,6 +54,10 @@ export const Z_INDEX = {
   MODAL: 105,
   FILE_PICKER: 110,
   SESSION_EXITED_OVERLAY: 120,
+  // Terminal Settings is a full modal (with backdrop), so it must sit above the
+  // floating "SESSION EXITED" badge that otherwise overlaps it on exited sessions.
+  TERMINAL_SETTINGS_BACKDROP: 124,
+  TERMINAL_SETTINGS_MODAL: 125,
   NOTIFICATION: 150, // Notifications appear above modals but below file browser
 
   // Special high-priority overlays (200+)


### PR DESCRIPTION
## Problem

On an exited session, opening Terminal Settings renders the floating `SESSION EXITED` badge above the modal and overlaps its controls.

## Cause

`SESSION_EXITED_OVERLAY` used z-index 120, above every standard modal. Terminal Settings also used a dropdown layer instead of the shared modal layers.

## Fix

- Move the exited-session badge to z-index 49: above terminal chrome, below interactive popovers and modals.
- Use the shared `MODAL_BACKDROP` and `MODAL` layers for Terminal Settings.
- Add regression coverage for the ordering and rendered z-index values.
- Add changelog and contributor credit.

## Proof

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- Client coverage: 31 files passed, 608 tests passed, 14 skipped.
- Server coverage: 47 files passed, 548 tests passed, 75 skipped. Eight forwarder E2E tests require the Zig-built binary and are covered by Linux CI.
- Autoreview: clean, no actionable findings.

Related: #640 touches a separate section of `width-selector.ts`.
