### PR TITLE
fix(server): detach only the active tmux client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### 🐛 Bug Fixes
 - Fix session creation "data couldn't be read" error on Mac app (#500)
+- Detach only the VibeTunnel tmux client without assuming the default prefix (via [@Nachx639](https://github.com/Nachx639)) (#644)
 - Update `ws` and `qs` to patched versions for GHSA-58qx-3vcg-4xpx and GHSA-q8mj-m7cp-5q26 (via [@Nachx639](https://github.com/Nachx639)) (#642)
 - Restore the configured terminal width when reopening Terminal Settings (via [@Nachx639](https://github.com/Nachx639)) (#640)
 - Keep Terminal Settings and other interactive overlays above the exited-session badge (via [@Nachx639](https://github.com/Nachx639)) (#643)
@@ -26,7 +27,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
-- Thanks [@Nachx639](https://github.com/Nachx639) for adding log rotation and fixing dependency security, Terminal Settings width sync, and exited-session overlay layering.
+- Thanks [@Nachx639](https://github.com/Nachx639) for adding log rotation and fixing tmux detach behavior, dependency security, Terminal Settings width sync, and exited-session overlay layering.
 - Thanks [@sourman](https://github.com/sourman) for documenting the Zig build prerequisite.
 - Thanks [@yv-was-taken](https://github.com/yv-was-taken) for fixing global npm and Bun installs.
 - Thanks [@ChimeraFlutter](https://github.com/ChimeraFlutter) for fixing desktop terminal clipping.

--- a/web/src/server/pty/pty-manager.ts
+++ b/web/src/server/pty/pty-manager.ts
@@ -6,7 +6,7 @@
  */
 
 import chalk from 'chalk';
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { EventEmitter, once } from 'events';
 import * as fs from 'fs';
 import * as net from 'net';
@@ -513,6 +513,17 @@ export class PtyManager extends EventEmitter {
             resolvedCommand.includes('a'))) ||
         sessionName.startsWith('tmux:');
 
+      // Capture the tmux session name (the value after `-t`) so we can detach later
+      // via `tmux detach-client -s <name>`, which is independent of the user's prefix key.
+      let tmuxSessionName: string | undefined;
+      if (isTmuxAttachment) {
+        const targetIndex = resolvedCommand.indexOf('-t');
+        if (targetIndex !== -1 && resolvedCommand[targetIndex + 1]) {
+          // Target may be "session" or "session:window[.pane]"; detach-client needs the session name
+          tmuxSessionName = resolvedCommand[targetIndex + 1].split(':')[0];
+        }
+      }
+
       const session: PtySession = {
         id: sessionId,
         sessionInfo,
@@ -528,6 +539,7 @@ export class PtyManager extends EventEmitter {
         currentWorkingDir: workingDir,
         titleFilter: new TitleSequenceFilter(),
         isTmuxAttachment,
+        tmuxSessionName,
       };
 
       this.sessions.set(sessionId, session);
@@ -1402,7 +1414,24 @@ export class PtyManager extends EventEmitter {
     try {
       logger.log(chalk.cyan(`Detaching from tmux session (${sessionId})`));
 
-      // Try the standard detach sequence first (Ctrl-B, d)
+      // Preferred: detach via the tmux server directly. This is independent of the
+      // user's prefix key (e.g. a remapped C-a) and never leaks keystrokes such as
+      // "d" or ":detach-client" into the underlying shell.
+      if (session.tmuxSessionName) {
+        try {
+          await this.execFileAsync('tmux', ['detach-client', '-s', session.tmuxSessionName]);
+          await new Promise((resolve) => setTimeout(resolve, 300));
+          if (!ProcessUtils.isProcessRunning(session.ptyProcess.pid)) {
+            logger.log(chalk.green(`Successfully detached from tmux (${sessionId})`));
+            return true;
+          }
+        } catch (error) {
+          logger.debug(`tmux detach-client failed, falling back to key sequence: ${error}`);
+        }
+      }
+
+      // Fallback: standard prefix sequence (Ctrl-B, d) for default-prefix setups
+      // where the session name could not be determined.
       await this.sendInput(sessionId, { text: '\x02d' }); // \x02 is Ctrl-B
 
       // Wait for detachment
@@ -1411,21 +1440,6 @@ export class PtyManager extends EventEmitter {
       // Check if the process is still running
       if (!ProcessUtils.isProcessRunning(session.ptyProcess.pid)) {
         logger.log(chalk.green(`Successfully detached from tmux (${sessionId})`));
-        return true;
-      }
-
-      // If still running, try sending the detach-client command
-      logger.debug('First detach attempt failed, trying detach-client command');
-      await this.sendInput(sessionId, { text: ':detach-client\n' });
-
-      // Wait a bit longer
-      await new Promise((resolve) => setTimeout(resolve, 500));
-
-      // Final check
-      if (!ProcessUtils.isProcessRunning(session.ptyProcess.pid)) {
-        logger.log(
-          chalk.green(`Successfully detached from tmux using detach-client (${sessionId})`)
-        );
         return true;
       }
 
@@ -2496,4 +2510,5 @@ export class PtyManager extends EventEmitter {
    * Import necessary exec function
    */
   private execAsync = promisify(exec);
+  private execFileAsync = promisify(execFile);
 }

--- a/web/src/server/pty/pty-manager.ts
+++ b/web/src/server/pty/pty-manager.ts
@@ -513,17 +513,6 @@ export class PtyManager extends EventEmitter {
             resolvedCommand.includes('a'))) ||
         sessionName.startsWith('tmux:');
 
-      // Capture the tmux session name (the value after `-t`) so we can detach later
-      // via `tmux detach-client -s <name>`, which is independent of the user's prefix key.
-      let tmuxSessionName: string | undefined;
-      if (isTmuxAttachment) {
-        const targetIndex = resolvedCommand.indexOf('-t');
-        if (targetIndex !== -1 && resolvedCommand[targetIndex + 1]) {
-          // Target may be "session" or "session:window[.pane]"; detach-client needs the session name
-          tmuxSessionName = resolvedCommand[targetIndex + 1].split(':')[0];
-        }
-      }
-
       const session: PtySession = {
         id: sessionId,
         sessionInfo,
@@ -539,7 +528,6 @@ export class PtyManager extends EventEmitter {
         currentWorkingDir: workingDir,
         titleFilter: new TitleSequenceFilter(),
         isTmuxAttachment,
-        tmuxSessionName,
       };
 
       this.sessions.set(sessionId, session);
@@ -1414,40 +1402,45 @@ export class PtyManager extends EventEmitter {
     try {
       logger.log(chalk.cyan(`Detaching from tmux session (${sessionId})`));
 
-      // Preferred: detach via the tmux server directly. This is independent of the
-      // user's prefix key (e.g. a remapped C-a) and never leaks keystrokes such as
-      // "d" or ":detach-client" into the underlying shell.
-      if (session.tmuxSessionName) {
-        try {
-          await this.execFileAsync('tmux', ['detach-client', '-s', session.tmuxSessionName]);
-          await new Promise((resolve) => setTimeout(resolve, 300));
-          if (!ProcessUtils.isProcessRunning(session.ptyProcess.pid)) {
-            logger.log(chalk.green(`Successfully detached from tmux (${sessionId})`));
-            return true;
-          }
-        } catch (error) {
-          logger.debug(`tmux detach-client failed, falling back to key sequence: ${error}`);
-        }
+      const clientTty = await this.findTmuxClientTty(session.ptyProcess.pid);
+      if (!clientTty) {
+        logger.debug(`Could not find tmux client for PTY process ${session.ptyProcess.pid}`);
+        return false;
       }
 
-      // Fallback: standard prefix sequence (Ctrl-B, d) for default-prefix setups
-      // where the session name could not be determined.
-      await this.sendInput(sessionId, { text: '\x02d' }); // \x02 is Ctrl-B
+      // Target the VibeTunnel client only. Using `-s` would detach every client
+      // attached to the same tmux session.
+      await this.execFileAsync('tmux', ['detach-client', '-t', clientTty]);
 
-      // Wait for detachment
       await new Promise((resolve) => setTimeout(resolve, 300));
-
-      // Check if the process is still running
       if (!ProcessUtils.isProcessRunning(session.ptyProcess.pid)) {
         logger.log(chalk.green(`Successfully detached from tmux (${sessionId})`));
         return true;
       }
 
+      logger.debug(`tmux client ${clientTty} remained attached after detach-client`);
       return false;
     } catch (error) {
       logger.error(`Error detaching from tmux: ${error}`);
       return false;
     }
+  }
+
+  private async findTmuxClientTty(pid: number): Promise<string | undefined> {
+    const { stdout } = await this.execFileAsync('tmux', [
+      'list-clients',
+      '-F',
+      '#{client_pid}\t#{client_tty}',
+    ]);
+
+    for (const line of String(stdout).split(/\r?\n/)) {
+      const [clientPid, clientTty] = line.split('\t');
+      if (Number(clientPid) === pid && clientTty) {
+        return clientTty;
+      }
+    }
+
+    return undefined;
   }
 
   /**

--- a/web/src/server/pty/types.ts
+++ b/web/src/server/pty/types.ts
@@ -108,6 +108,7 @@ export interface PtySession {
   processPollingInterval?: NodeJS.Timeout; // Interval for checking process state
   // Tmux attachment tracking
   isTmuxAttachment?: boolean; // True if this session is attached to tmux
+  tmuxSessionName?: string; // Name of the attached tmux session (for prefix-independent detach)
 }
 
 export class PtyError extends Error {

--- a/web/src/server/pty/types.ts
+++ b/web/src/server/pty/types.ts
@@ -108,7 +108,6 @@ export interface PtySession {
   processPollingInterval?: NodeJS.Timeout; // Interval for checking process state
   // Tmux attachment tracking
   isTmuxAttachment?: boolean; // True if this session is attached to tmux
-  tmuxSessionName?: string; // Name of the attached tmux session (for prefix-independent detach)
 }
 
 export class PtyError extends Error {

--- a/web/src/test/e2e/tmux-integration.e2e.test.ts
+++ b/web/src/test/e2e/tmux-integration.e2e.test.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from 'child_process';
 import { mkdtempSync } from 'fs';
+import * as pty from 'node-pty';
 import path from 'path';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
   cleanupTestDirectories,
   type ServerInstance,
@@ -10,12 +11,14 @@ import {
   stopServer,
 } from '../utils/server-utils';
 
+vi.unmock('node-pty');
+
 function isTmuxAvailable(): boolean {
   const result = spawnSync('tmux', ['-V'], { stdio: 'ignore' });
   return result.status === 0;
 }
 
-function tmux(args: string[], env: NodeJS.ProcessEnv): void {
+function runTmux(args: string[], env: NodeJS.ProcessEnv): string {
   const result = spawnSync('tmux', args, {
     env,
     encoding: 'utf-8',
@@ -23,12 +26,43 @@ function tmux(args: string[], env: NodeJS.ProcessEnv): void {
   });
 
   if (result.status === 0) {
-    return;
+    return result.stdout;
   }
 
   throw new Error(
     `tmux ${args.join(' ')} failed with code ${result.status ?? 'null'}:\n${String(result.stderr)}`
   );
+}
+
+function tmux(args: string[], env: NodeJS.ProcessEnv): void {
+  runTmux(args, env);
+}
+
+function getTmuxClientPids(sessionName: string, env: NodeJS.ProcessEnv): number[] {
+  const output = runTmux(['list-clients', '-t', sessionName, '-F', '#{client_pid}'], env).trim();
+  return output
+    ? output
+        .split(/\r?\n/)
+        .map(Number)
+        .filter((pid) => Number.isInteger(pid))
+    : [];
+}
+
+async function waitForTmuxClientCount(
+  sessionName: string,
+  env: NodeJS.ProcessEnv,
+  expectedCount: number,
+  timeoutMs = 10000
+): Promise<number[]> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const clientPids = getTmuxClientPids(sessionName, env);
+    if (clientPids.length === expectedCount) {
+      return clientPids;
+    }
+    await sleep(100);
+  }
+  throw new Error(`Tmux session ${sessionName} did not reach ${expectedCount} clients`);
 }
 
 async function waitForSessionText(
@@ -88,7 +122,7 @@ describeTmux('Tmux integration (E2E)', () => {
     await cleanupTestDirectories([homeDir, tmuxTmpDir]);
   });
 
-  it('lists and attaches to a tmux session via API', async () => {
+  it('detaches only the API client with a remapped tmux prefix', async () => {
     if (!server) {
       throw new Error('Server not started');
     }
@@ -96,49 +130,91 @@ describeTmux('Tmux integration (E2E)', () => {
     const sessionName = `vt_tmux_${Date.now()}`;
     const marker = `tmux-ok-${Date.now()}`;
     const tmuxEnv = { ...process.env, TMUX_TMPDIR: tmuxTmpDir };
+    let externalClient: pty.IPty | null = null;
+    let externalClientOutput = '';
+    let externalClientExit: { exitCode: number; signal?: number } | null = null;
 
-    tmux(['new-session', '-d', '-s', sessionName], tmuxEnv);
+    try {
+      tmux(['new-session', '-d', '-s', sessionName], tmuxEnv);
+      tmux(['set-option', '-g', 'prefix', 'C-a'], tmuxEnv);
+      tmux(['unbind-key', 'C-b'], tmuxEnv);
 
-    const statusResponse = await fetch(`http://localhost:${server.port}/api/multiplexer/status`);
-    expect(statusResponse.ok).toBe(true);
-    const status = (await statusResponse.json()) as {
-      tmux?: { available: boolean; sessions: Array<{ name: string }> };
-    };
-
-    expect(status.tmux?.available).toBe(true);
-    expect(status.tmux?.sessions.map((item) => item.name)).toContain(sessionName);
-
-    const attachResponse = await fetch(`http://localhost:${server.port}/api/multiplexer/attach`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        type: 'tmux',
-        sessionName,
+      externalClient = pty.spawn('tmux', ['attach-session', '-t', sessionName], {
+        name: 'xterm-256color',
         cols: 80,
         rows: 24,
-      }),
-    });
+        cwd: homeDir,
+        env: tmuxEnv,
+      });
+      externalClient.onData((data) => {
+        externalClientOutput += data;
+      });
+      externalClient.onExit((event) => {
+        externalClientExit = event;
+      });
+      try {
+        await waitForTmuxClientCount(sessionName, tmuxEnv, 1);
+      } catch (error) {
+        throw new Error(
+          `${String(error)}; external client exit=${JSON.stringify(externalClientExit)} output=${JSON.stringify(externalClientOutput)}`
+        );
+      }
 
-    expect(attachResponse.ok).toBe(true);
-    const attachJson = (await attachResponse.json()) as { sessionId: string };
-    expect(attachJson.sessionId).toBeTruthy();
+      const statusResponse = await fetch(`http://localhost:${server.port}/api/multiplexer/status`);
+      expect(statusResponse.ok).toBe(true);
+      const status = (await statusResponse.json()) as {
+        tmux?: { available: boolean; sessions: Array<{ name: string }> };
+      };
 
-    const inputResponse = await fetch(
-      `http://localhost:${server.port}/api/sessions/${attachJson.sessionId}/input`,
-      {
+      expect(status.tmux?.available).toBe(true);
+      expect(status.tmux?.sessions.map((item) => item.name)).toContain(sessionName);
+
+      const attachResponse = await fetch(`http://localhost:${server.port}/api/multiplexer/attach`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text: `echo ${marker}\n` }),
+        body: JSON.stringify({
+          type: 'tmux',
+          sessionName,
+          cols: 80,
+          rows: 24,
+        }),
+      });
+
+      expect(attachResponse.ok).toBe(true);
+      const attachJson = (await attachResponse.json()) as { sessionId: string };
+      expect(attachJson.sessionId).toBeTruthy();
+      await waitForTmuxClientCount(sessionName, tmuxEnv, 2);
+
+      const inputResponse = await fetch(
+        `http://localhost:${server.port}/api/sessions/${attachJson.sessionId}/input`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text: `echo ${marker}\n` }),
+        }
+      );
+      expect(inputResponse.ok).toBe(true);
+
+      await waitForSessionText(server.port, attachJson.sessionId, marker, 15000);
+
+      const deleteResponse = await fetch(
+        `http://localhost:${server.port}/api/sessions/${attachJson.sessionId}`,
+        { method: 'DELETE' }
+      );
+      expect(deleteResponse.ok).toBe(true);
+
+      const remainingClientPids = await waitForTmuxClientCount(sessionName, tmuxEnv, 1);
+      expect(remainingClientPids).toEqual([externalClient.pid]);
+      expect(runTmux(['capture-pane', '-p', '-t', sessionName], tmuxEnv)).not.toContain(
+        'd:detach-client'
+      );
+    } finally {
+      externalClient?.kill();
+      try {
+        tmux(['kill-session', '-t', sessionName], tmuxEnv);
+      } catch {
+        // Ignore cleanup if the test already removed the session.
       }
-    );
-    expect(inputResponse.ok).toBe(true);
-
-    await waitForSessionText(server.port, attachJson.sessionId, marker, 15000);
-
-    await fetch(`http://localhost:${server.port}/api/sessions/${attachJson.sessionId}`, {
-      method: 'DELETE',
-    });
-
-    tmux(['kill-session', '-t', sessionName], tmuxEnv);
+    }
   }, 20000);
 });


### PR DESCRIPTION
## Problem

VibeTunnel detached tmux by injecting `Ctrl-B d` and then `:detach-client`. Remapped tmux prefixes caused those bytes to leak into the shell as `d:detach-client` instead of detaching.

The original direct-command approach used `tmux detach-client -s <session>`, but `-s` detaches every client attached to that tmux session.

## Fix

- Resolve the VibeTunnel tmux client TTY by matching the node-pty process PID against `tmux list-clients`.
- Run `tmux detach-client -t <client-tty>` so only that client detaches.
- Remove all key-injection fallbacks; normal PTY termination remains the safe fallback when client lookup or detach fails.
- Add regression coverage with a remapped `C-a` prefix and a second attached client.

## Verification

- Live tmux E2E: custom prefix, two clients, API deletion detaches only VibeTunnel, no leaked `d:detach-client` text.
- Focused E2E repeated and passed.
- `pnpm run lint`, `pnpm run typecheck`, and `pnpm run format:check` passed.
- Full build passed with the repository-pinned Zig 0.15.2 toolchain.
- Client coverage: 610 passed, 14 skipped.
- Server coverage: 558 passed, 75 skipped.
- Structured autoreview: no actionable findings.