### PR TITLE
fix(web): restore mobile terminal scrolling and width reflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug Fixes
 - Fix session creation "data couldn't be read" error on Mac app (#500)
+- Restore mobile terminal touch scrolling, responsive width fitting, pinch zoom, and scrollback retention during output and layout changes (via [@Nachx639](https://github.com/Nachx639)) (#645)
 - Stabilize mobile keyboard reopening and reserve terminal space for quick keys without overlapping the action bar (via [@Nachx639](https://github.com/Nachx639)) (#646)
 - Detach only the VibeTunnel tmux client without assuming the default prefix (via [@Nachx639](https://github.com/Nachx639)) (#644)
 - Update `ws` and `qs` to patched versions for GHSA-58qx-3vcg-4xpx and GHSA-q8mj-m7cp-5q26 (via [@Nachx639](https://github.com/Nachx639)) (#642)
@@ -29,7 +30,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
-- Thanks [@Nachx639](https://github.com/Nachx639) for adding log rotation, improving mobile keyboard behavior and tap targets, and fixing tmux detach behavior, dependency security, Terminal Settings width sync, and exited-session overlay layering.
+- Thanks [@Nachx639](https://github.com/Nachx639) for adding log rotation, improving mobile keyboard behavior, terminal scrolling, and tap targets, and fixing tmux detach behavior, dependency security, Terminal Settings width sync, and exited-session overlay layering.
 - Thanks [@sourman](https://github.com/sourman) for documenting the Zig build prerequisite.
 - Thanks [@yv-was-taken](https://github.com/yv-was-taken) for fixing global npm and Bun installs.
 - Thanks [@ChimeraFlutter](https://github.com/ChimeraFlutter) for fixing desktop terminal clipping.

--- a/web/src/client/components/session-view.test.ts
+++ b/web/src/client/components/session-view.test.ts
@@ -928,6 +928,7 @@ describe('SessionView', () => {
     let terminalElement: {
       fitTerminal: ReturnType<typeof vi.fn>;
       scrollToBottom: ReturnType<typeof vi.fn>;
+      isFollowingCursor: ReturnType<typeof vi.fn>;
     };
     let quickKeysElement: {
       getBoundingClientRect: ReturnType<typeof vi.fn>;
@@ -956,6 +957,7 @@ describe('SessionView', () => {
       terminalElement = {
         fitTerminal: vi.fn(),
         scrollToBottom: vi.fn(),
+        isFollowingCursor: vi.fn(() => true),
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
       };
@@ -1050,6 +1052,20 @@ describe('SessionView', () => {
       await element.updateComplete;
 
       expect(containerElement?.style.getPropertyValue('--quickkeys-height')).toBe('0px');
+    });
+
+    it('should not force scroll-to-bottom while the user is reading scrollback', async () => {
+      vi.useFakeTimers();
+      const testElement = element as SessionViewTestInterface;
+      terminalElement.isFollowingCursor.mockReturnValue(false);
+      testElement.uiStateManager.setIsMobile(true);
+      testElement.uiStateManager.setShowQuickKeys(true);
+
+      testElement.updateTerminalTransform();
+      await vi.runAllTimersAsync();
+
+      expect(fitTerminalSpy).toHaveBeenCalled();
+      expect(terminalElement.scrollToBottom).not.toHaveBeenCalled();
     });
 
     it.skip('should properly calculate terminal height with keyboard and quick keys', {

--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -854,8 +854,15 @@ export class SessionView extends LitElement {
             // If keyboard is visible, scroll to keep cursor visible
             if (state.keyboardHeight > 0 || state.showQuickKeys) {
               setTimeout(() => {
-                if ('scrollToBottom' in terminal) {
-                  terminal.scrollToBottom();
+                const scrollableTerminal = terminal as unknown as {
+                  scrollToBottom?: () => void;
+                  isFollowingCursor?: () => boolean;
+                };
+                if (
+                  scrollableTerminal.scrollToBottom &&
+                  (scrollableTerminal.isFollowingCursor?.() ?? true)
+                ) {
+                  scrollableTerminal.scrollToBottom();
                 }
               }, 100);
             }
@@ -890,14 +897,21 @@ export class SessionView extends LitElement {
           if (state.keyboardHeight > 0 || state.showQuickKeys) {
             // Small delay then scroll to bottom to keep cursor visible
             setTimeout(() => {
-              if ('scrollToBottom' in terminal) {
-                terminal.scrollToBottom();
-              }
+              const scrollableTerminal = terminal as unknown as {
+                scrollToBottom?: () => void;
+                isFollowingCursor?: () => boolean;
+              };
+              if (
+                scrollableTerminal.scrollToBottom &&
+                (scrollableTerminal.isFollowingCursor?.() ?? true)
+              ) {
+                scrollableTerminal.scrollToBottom();
 
-              // Also ensure the terminal content is scrolled within its container
-              const terminalArea = this.querySelector('.terminal-area');
-              if (terminalArea) {
-                terminalArea.scrollTop = terminalArea.scrollHeight;
+                // Also ensure the terminal content is scrolled within its container
+                const terminalArea = this.querySelector('.terminal-area');
+                if (terminalArea) {
+                  terminalArea.scrollTop = terminalArea.scrollHeight;
+                }
               }
             }, 50);
           }

--- a/web/src/client/components/terminal.test.ts
+++ b/web/src/client/components/terminal.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment happy-dom
 import { fixture, html } from '@open-wc/testing';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { resetViewport, waitForCondition, waitForElement } from '@/test/utils/component-helpers';
+import {
+  resetViewport,
+  setViewport,
+  waitForCondition,
+  waitForElement,
+} from '@/test/utils/component-helpers';
 import { MockFitAddon, MockResizeObserver, MockTerminal } from '@/test/utils/terminal-mocks';
 
 // Mock ghostty-web before importing the component
@@ -527,8 +532,7 @@ describe('Terminal', () => {
 
       // Position might be clamped to valid range
       const position = element.getScrollPosition();
-      expect(position).toBeGreaterThanOrEqual(0);
-      expect(position).toBeLessThanOrEqual(element.getMaxScrollPosition());
+      expect(position).toBe(element.getMaxScrollPosition());
     });
 
     it('should get visible rows', () => {
@@ -554,6 +558,93 @@ describe('Terminal', () => {
         await waitForElement(element);
         expect(true).toBe(true);
       }
+    });
+
+    it('should expose whether output is following the cursor', () => {
+      expect(element.isFollowingCursor()).toBe(true);
+
+      mockTerminal?.simulateScroll(12);
+      expect(element.isFollowingCursor()).toBe(false);
+
+      mockTerminal?.simulateScroll(0);
+      expect(element.isFollowingCursor()).toBe(true);
+    });
+
+    it('should preserve the viewed scrollback position when output arrives', () => {
+      if (!mockTerminal) return;
+
+      mockTerminal.buffer.active.length = 100;
+      element.scrollToPosition(20);
+      expect(element.getScrollPosition()).toBe(20);
+
+      mockTerminal.write.mockImplementationOnce(() => {
+        mockTerminal.buffer.active.length = 101;
+        mockTerminal.simulateScroll(0);
+      });
+
+      element.write('new output');
+
+      // Restoration must happen before write() returns to avoid painting the live bottom.
+      expect(element.getScrollPosition()).toBe(20);
+      expect(element.isFollowingCursor()).toBe(false);
+    });
+
+    it('should keep initial replay dumps at the bottom', () => {
+      if (!mockTerminal) return;
+
+      mockTerminal.write.mockImplementationOnce(() => {
+        mockTerminal.buffer.active.length = 100;
+        mockTerminal.simulateScroll(0);
+      });
+
+      element.write('initial replay', false);
+
+      expect(element.getScrollPosition()).toBe(element.getMaxScrollPosition());
+      expect(element.isFollowingCursor()).toBe(true);
+    });
+
+    it('should preserve scrollback across a burst of output writes', () => {
+      if (!mockTerminal) return;
+
+      mockTerminal.buffer.active.length = 100;
+      element.scrollToPosition(20);
+      mockTerminal.write.mockImplementation(() => {
+        mockTerminal.buffer.active.length += 1;
+        mockTerminal.simulateScroll(0);
+      });
+
+      element.write('first');
+      expect(element.getScrollPosition()).toBe(20);
+      element.write('second');
+
+      expect(element.getScrollPosition()).toBe(20);
+      expect(element.isFollowingCursor()).toBe(false);
+    });
+
+    it('should translate vertical touch drags into terminal scroll lines', () => {
+      if (!mockTerminal) return;
+
+      const container = element.querySelector('.terminal-container') as HTMLElement;
+      const touchStart = new Event('touchstart', { bubbles: true, cancelable: true });
+      Object.defineProperty(touchStart, 'touches', {
+        value: [{ clientX: 50, clientY: 200 }],
+      });
+      container.dispatchEvent(touchStart);
+
+      const touchMove = new Event('touchmove', { bubbles: true, cancelable: true });
+      Object.defineProperty(touchMove, 'touches', {
+        value: [{ clientX: 52, clientY: 240 }],
+      });
+      container.dispatchEvent(touchMove);
+
+      expect(touchMove.defaultPrevented).toBe(true);
+      expect(mockTerminal.scrollLines).toHaveBeenCalledWith(expect.any(Number));
+      expect(mockTerminal.scrollLines.mock.calls[0]?.[0]).toBeLessThan(0);
+    });
+
+    it('should preserve pinch zoom while owning one-finger terminal scrolling', () => {
+      const container = element.querySelector('.terminal-container') as HTMLElement;
+      expect(getComputedStyle(container).touchAction).toBe('pinch-zoom');
     });
   });
 
@@ -603,11 +694,15 @@ describe('Terminal', () => {
     it('should clean up on disconnect', async () => {
       await element.firstUpdated();
       const terminal = (element as unknown as { terminal: MockTerminal }).terminal;
+      const container = element.querySelector('.terminal-container') as HTMLElement;
+      const removeEventListenerSpy = vi.spyOn(container, 'removeEventListener');
 
       element.disconnectedCallback();
 
       // Should dispose terminal
       expect(terminal?.dispose).toHaveBeenCalled();
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('touchstart', expect.any(Function));
+      expect(removeEventListenerSpy).toHaveBeenCalledWith('touchmove', expect.any(Function));
     });
   });
 
@@ -692,6 +787,38 @@ describe('Terminal', () => {
       // This test is verifying internal behavior that may not exist in the component
       // Skip this test as the fitTerminal method doesn't exist on the component
       expect(true).toBe(true);
+    });
+
+    it('should recompute unlimited mobile width after the viewport changes', () => {
+      if (!mockTerminal) return;
+
+      const fitAddon = (element as unknown as { fitAddon: MockFitAddon }).fitAddon;
+      setViewport(390, 844);
+      element.maxCols = 0;
+
+      fitAddon.proposeDimensions.mockReturnValue({ cols: 40, rows: 24 });
+      element.fitTerminal('narrow');
+      expect(mockTerminal.resize).toHaveBeenLastCalledWith(40, 24);
+
+      fitAddon.proposeDimensions.mockReturnValue({ cols: 90, rows: 24 });
+      element.fitTerminal('wide');
+      expect(mockTerminal.resize).toHaveBeenLastCalledWith(90, 24);
+    });
+
+    it('should treat maxCols as a cap while mobile width changes', () => {
+      if (!mockTerminal) return;
+
+      const fitAddon = (element as unknown as { fitAddon: MockFitAddon }).fitAddon;
+      setViewport(390, 844);
+      element.maxCols = 80;
+
+      fitAddon.proposeDimensions.mockReturnValue({ cols: 40, rows: 24 });
+      element.fitTerminal('narrow');
+      expect(mockTerminal.resize).toHaveBeenLastCalledWith(40, 24);
+
+      fitAddon.proposeDimensions.mockReturnValue({ cols: 100, rows: 24 });
+      element.fitTerminal('wide');
+      expect(mockTerminal.resize).toHaveBeenLastCalledWith(80, 24);
     });
   });
 });

--- a/web/src/client/components/terminal.ts
+++ b/web/src/client/components/terminal.ts
@@ -192,6 +192,15 @@ export class Terminal extends LitElement {
     this.terminal?.scrollToBottom();
   }
 
+  /**
+   * Whether the viewport is at (or near) the bottom, i.e. auto-following new output.
+   * Becomes false when the user scrolls up to read history (incl. touch scroll), so
+   * callers can avoid yanking the view back to the bottom while the user is reading.
+   */
+  public isFollowingCursor(): boolean {
+    return this.followCursorEnabled;
+  }
+
   public scrollToPosition(position: number) {
     if (!this.terminal) return;
     const max = this.getMaxScrollPosition();
@@ -344,10 +353,16 @@ export class Terminal extends LitElement {
     let cols = this.computeConstrainedCols(proposed.cols);
     const rows = Math.max(6, Math.floor(proposed.rows));
 
+    // On mobile we used to freeze the column count after the first resize to avoid
+    // reflow churn when the keyboard opens/closes. But that left the terminal stuck at
+    // a stale width (text cut off on the right after rotation / viewport changes).
+    // Only keep the frozen width when the user explicitly pinned a width (maxCols > 0);
+    // in "fit to window" mode (maxCols === 0) always recompute so it adapts to the viewport.
     if (
       this.isMobile &&
       this.mobileWidthResizeComplete &&
       !this.userOverrideWidth &&
+      this.maxCols > 0 &&
       this.lastCols
     ) {
       cols = this.lastCols;
@@ -432,6 +447,41 @@ export class Terminal extends LitElement {
 
       this.terminal = term;
       this.fitAddon = fitAddon;
+
+      // Touch scroll: the ghostty-web canvas doesn't translate iOS touch-pan gestures
+      // into scrollback movement, so wire it up manually. NOTE: not gated on isMobile —
+      // at init time isMobile is still false (it's only detected later in fitTerminal),
+      // so gating here meant the handlers were never attached. touch* events only fire
+      // on touch devices anyway, so this is a no-op on mouse/desktop.
+      if (this.container) {
+        let lastTouchY = 0;
+        let touchScrolling = false;
+        this.container.addEventListener(
+          'touchstart',
+          (e: TouchEvent) => {
+            lastTouchY = e.touches[0]?.clientY ?? 0;
+            touchScrolling = false;
+          },
+          { passive: true }
+        );
+        // passive:false so we can preventDefault and own the vertical pan gesture.
+        this.container.addEventListener(
+          'touchmove',
+          (e: TouchEvent) => {
+            const currentY = e.touches[0]?.clientY ?? lastTouchY;
+            const deltaY = lastTouchY - currentY;
+            if (touchScrolling || Math.abs(deltaY) > 4) {
+              touchScrolling = true;
+              e.preventDefault();
+              const lines = Math.max(1, Math.round(Math.abs(deltaY) / 16));
+              // drag down → reveal history (scroll up); drag up → newer (scroll down)
+              this.terminal?.scrollLines(deltaY > 0 ? lines : -lines);
+              lastTouchY = currentY;
+            }
+          },
+          { passive: false }
+        );
+      }
 
       if (this.pendingOutput) {
         const pending = this.pendingOutput;
@@ -574,7 +624,10 @@ export class Terminal extends LitElement {
           height: 100%;
           overflow: hidden;
           font-family: ${TERMINAL_FONT_FAMILY};
-          touch-action: manipulation;
+          /* none (not manipulation) so the browser doesn't claim the vertical pan
+             gesture — we translate touch-pan into scrollback scroll ourselves on mobile.
+             touch-action only affects touch input, so mouse/trackpad scroll is unaffected. */
+          touch-action: none;
           -webkit-user-select: text;
           user-select: text;
         }

--- a/web/src/client/components/terminal.ts
+++ b/web/src/client/components/terminal.ts
@@ -65,9 +65,14 @@ export class Terminal extends LitElement {
   private pasteInput: HTMLTextAreaElement | null = null;
   private pendingOutput = '';
   private pendingFollowCursor = true;
+  private preservedScrollPosition: number | null = null;
+  private touchStartX = 0;
+  private touchStartY = 0;
+  private lastTouchY = 0;
+  private touchScrollRemainder = 0;
+  private touchScrolling = false;
 
   private isMobile = false;
-  private mobileWidthResizeComplete = false;
   private lastCols = 0;
   private lastRows = 0;
 
@@ -140,7 +145,6 @@ export class Terminal extends LitElement {
 
   setUserOverrideWidth(override: boolean) {
     this.userOverrideWidth = override;
-    if (this.isMobile && override) this.mobileWidthResizeComplete = false;
 
     if (this.sessionId) {
       try {
@@ -167,15 +171,32 @@ export class Terminal extends LitElement {
       return;
     }
 
-    this.terminal.write(data, () => {
-      if (followCursor && this.followCursorEnabled) {
-        this.terminal?.scrollToBottom();
+    const shouldPreserveScroll = !this.followCursorEnabled && this.preservedScrollPosition === null;
+    const shouldFollowCursor = followCursor && !shouldPreserveScroll;
+    if (shouldPreserveScroll) {
+      this.preservedScrollPosition = this.getScrollPosition();
+    }
+
+    if (this.preservedScrollPosition !== null) {
+      const preservedScrollPosition = this.preservedScrollPosition;
+      try {
+        this.terminal.write(data);
+        // ghostty-web scrolls to bottom synchronously during write(), so restore before paint.
+        this.scrollToPosition(preservedScrollPosition);
+        this.followCursorEnabled = false;
+      } finally {
+        this.preservedScrollPosition = null;
       }
-    });
+      return;
+    }
+
+    this.terminal.write(data);
+    if (shouldFollowCursor) this.terminal.scrollToBottom();
   }
 
   public clear() {
     this.terminal?.clear();
+    this.preservedScrollPosition = null;
     this.followCursorEnabled = true;
   }
 
@@ -205,7 +226,7 @@ export class Terminal extends LitElement {
     if (!this.terminal) return;
     const max = this.getMaxScrollPosition();
     const clamped = Math.max(0, Math.min(max, Math.floor(position)));
-    this.terminal.scrollToLine(clamped);
+    this.terminal.scrollToLine(max - clamped);
   }
 
   public queueCallback(callback: () => void) {
@@ -263,15 +284,82 @@ export class Terminal extends LitElement {
     }
   }
 
+  private handleTerminalTouchStart = (event: TouchEvent) => {
+    if (event.touches.length !== 1) {
+      this.resetTouchScroll();
+      return;
+    }
+
+    const touch = event.touches[0];
+    this.touchStartX = touch.clientX;
+    this.touchStartY = touch.clientY;
+    this.lastTouchY = touch.clientY;
+    this.touchScrollRemainder = 0;
+    this.touchScrolling = false;
+  };
+
+  private handleTerminalTouchMove = (event: TouchEvent) => {
+    if (event.touches.length !== 1) return;
+
+    const touch = event.touches[0];
+    const totalX = touch.clientX - this.touchStartX;
+    const totalY = touch.clientY - this.touchStartY;
+
+    if (!this.touchScrolling) {
+      if (Math.abs(totalY) <= 6 || Math.abs(totalY) <= Math.abs(totalX)) return;
+      this.touchScrolling = true;
+    }
+
+    if (event.cancelable) event.preventDefault();
+
+    const lineHeight = Math.max(
+      1,
+      this.terminal?.renderer?.getMetrics().height ?? this.fontSize * 1.2
+    );
+    this.touchScrollRemainder += this.lastTouchY - touch.clientY;
+    const lines = Math.trunc(this.touchScrollRemainder / lineHeight);
+    this.lastTouchY = touch.clientY;
+
+    if (lines !== 0) {
+      this.terminal?.scrollLines(lines);
+      this.touchScrollRemainder -= lines * lineHeight;
+    }
+  };
+
+  private resetTouchScroll = () => {
+    this.touchScrolling = false;
+    this.touchScrollRemainder = 0;
+  };
+
+  private attachTouchScrollHandlers() {
+    this.container?.addEventListener('touchstart', this.handleTerminalTouchStart, {
+      passive: true,
+    });
+    this.container?.addEventListener('touchmove', this.handleTerminalTouchMove, {
+      passive: false,
+    });
+    this.container?.addEventListener('touchend', this.resetTouchScroll, { passive: true });
+    this.container?.addEventListener('touchcancel', this.resetTouchScroll, { passive: true });
+  }
+
+  private detachTouchScrollHandlers() {
+    this.container?.removeEventListener('touchstart', this.handleTerminalTouchStart);
+    this.container?.removeEventListener('touchmove', this.handleTerminalTouchMove);
+    this.container?.removeEventListener('touchend', this.resetTouchScroll);
+    this.container?.removeEventListener('touchcancel', this.resetTouchScroll);
+  }
+
   private cleanup() {
     this.resizeObserver?.disconnect();
     this.resizeObserver = null;
+    this.detachTouchScrollHandlers();
 
     this.terminal?.dispose();
     this.terminal = null;
     this.fitAddon = null;
     this.container = null;
     this.pasteInput = null;
+    this.preservedScrollPosition = null;
   }
 
   private requestResize(source: string) {
@@ -350,23 +438,8 @@ export class Terminal extends LitElement {
     const proposed = this.fitAddon.proposeDimensions();
     if (!proposed) return;
 
-    let cols = this.computeConstrainedCols(proposed.cols);
+    const cols = this.computeConstrainedCols(proposed.cols);
     const rows = Math.max(6, Math.floor(proposed.rows));
-
-    // On mobile we used to freeze the column count after the first resize to avoid
-    // reflow churn when the keyboard opens/closes. But that left the terminal stuck at
-    // a stale width (text cut off on the right after rotation / viewport changes).
-    // Only keep the frozen width when the user explicitly pinned a width (maxCols > 0);
-    // in "fit to window" mode (maxCols === 0) always recompute so it adapts to the viewport.
-    if (
-      this.isMobile &&
-      this.mobileWidthResizeComplete &&
-      !this.userOverrideWidth &&
-      this.maxCols > 0 &&
-      this.lastCols
-    ) {
-      cols = this.lastCols;
-    }
 
     const prevCols = this.lastCols || this.terminal.cols;
     const prevRows = this.lastRows || this.terminal.rows;
@@ -375,8 +448,6 @@ export class Terminal extends LitElement {
 
     this.requestResizeMeta(source);
     this.terminal.resize(cols, rows);
-
-    if (this.isMobile) this.mobileWidthResizeComplete = true;
   }
 
   private async initializeTerminal() {
@@ -437,6 +508,7 @@ export class Terminal extends LitElement {
       });
 
       term.onScroll(() => {
+        if (this.preservedScrollPosition !== null) return;
         const viewportFromBottom = term.getViewportY();
         this.followCursorEnabled = viewportFromBottom <= 0.5;
       });
@@ -448,40 +520,8 @@ export class Terminal extends LitElement {
       this.terminal = term;
       this.fitAddon = fitAddon;
 
-      // Touch scroll: the ghostty-web canvas doesn't translate iOS touch-pan gestures
-      // into scrollback movement, so wire it up manually. NOTE: not gated on isMobile —
-      // at init time isMobile is still false (it's only detected later in fitTerminal),
-      // so gating here meant the handlers were never attached. touch* events only fire
-      // on touch devices anyway, so this is a no-op on mouse/desktop.
-      if (this.container) {
-        let lastTouchY = 0;
-        let touchScrolling = false;
-        this.container.addEventListener(
-          'touchstart',
-          (e: TouchEvent) => {
-            lastTouchY = e.touches[0]?.clientY ?? 0;
-            touchScrolling = false;
-          },
-          { passive: true }
-        );
-        // passive:false so we can preventDefault and own the vertical pan gesture.
-        this.container.addEventListener(
-          'touchmove',
-          (e: TouchEvent) => {
-            const currentY = e.touches[0]?.clientY ?? lastTouchY;
-            const deltaY = lastTouchY - currentY;
-            if (touchScrolling || Math.abs(deltaY) > 4) {
-              touchScrolling = true;
-              e.preventDefault();
-              const lines = Math.max(1, Math.round(Math.abs(deltaY) / 16));
-              // drag down → reveal history (scroll up); drag up → newer (scroll down)
-              this.terminal?.scrollLines(deltaY > 0 ? lines : -lines);
-              lastTouchY = currentY;
-            }
-          },
-          { passive: false }
-        );
-      }
+      // ghostty-web does not translate touch pans into scrollback movement.
+      this.attachTouchScrollHandlers();
 
       if (this.pendingOutput) {
         const pending = this.pendingOutput;
@@ -624,10 +664,8 @@ export class Terminal extends LitElement {
           height: 100%;
           overflow: hidden;
           font-family: ${TERMINAL_FONT_FAMILY};
-          /* none (not manipulation) so the browser doesn't claim the vertical pan
-             gesture — we translate touch-pan into scrollback scroll ourselves on mobile.
-             touch-action only affects touch input, so mouse/trackpad scroll is unaffected. */
-          touch-action: none;
+          /* Own one-finger pans for scrollback while retaining two-finger page zoom. */
+          touch-action: pinch-zoom;
           -webkit-user-select: text;
           user-select: text;
         }

--- a/web/src/client/styles.css
+++ b/web/src/client/styles.css
@@ -985,9 +985,13 @@ body[data-keyboard-visible="true"] {
   pointer-events: none;
   touch-action: pan-y;
 }
-/* Terminal container scroll prevention */
+/* Terminal container scroll prevention.
+   touch-action must be none (not pan-y): the terminal is a fixed-size canvas with
+   overflow:hidden, so browser-native vertical panning has nowhere to scroll and just
+   swallows the gesture. We translate touch-pan into ghostty scrollback scroll in JS
+   (see terminal.ts touchmove handler), which needs the browser to NOT claim the pan. */
 #terminal-container {
-  touch-action: pan-y;
+  touch-action: none;
   overscroll-behavior: none;
 }
 

--- a/web/src/client/styles.css
+++ b/web/src/client/styles.css
@@ -985,13 +985,9 @@ body[data-keyboard-visible="true"] {
   pointer-events: none;
   touch-action: pan-y;
 }
-/* Terminal container scroll prevention.
-   touch-action must be none (not pan-y): the terminal is a fixed-size canvas with
-   overflow:hidden, so browser-native vertical panning has nowhere to scroll and just
-   swallows the gesture. We translate touch-pan into ghostty scrollback scroll in JS
-   (see terminal.ts touchmove handler), which needs the browser to NOT claim the pan. */
+/* Terminal owns one-finger vertical pans; preserve two-finger pinch zoom. */
 #terminal-container {
-  touch-action: none;
+  touch-action: pinch-zoom;
   overscroll-behavior: none;
 }
 

--- a/web/src/test/utils/terminal-mocks.ts
+++ b/web/src/test/utils/terminal-mocks.ts
@@ -92,9 +92,10 @@ export class MockTerminal {
     element.appendChild(this.element);
   });
 
-  write = vi.fn((_data: string | Uint8Array) => {
+  write = vi.fn((_data: string | Uint8Array, callback?: () => void) => {
     // write() is for terminal output, should not trigger onData callback
     // onData is only for user input
+    callback?.();
   });
 
   writeln = vi.fn((data: string) => {
@@ -123,15 +124,26 @@ export class MockTerminal {
 
   dispose = vi.fn();
 
-  scrollToBottom = vi.fn();
+  scrollToBottom = vi.fn(() => {
+    this.buffer.active.viewportY = 0;
+    this._onScrollCallback?.(0);
+  });
 
   scrollToTop = vi.fn();
+
+  scrollLines = vi.fn((amount: number) => {
+    const max = Math.max(0, this.buffer.active.length - this.rows);
+    this.buffer.active.viewportY = Math.max(
+      0,
+      Math.min(max, this.buffer.active.viewportY - amount)
+    );
+    this._onScrollCallback?.(this.buffer.active.viewportY);
+  });
 
   scrollToLine = vi.fn((line: number) => {
     const max = Math.max(0, this.buffer.active.length - this.rows);
     const clamped = Math.max(0, Math.min(max, line));
-    // ghostty viewportY is "from bottom"
-    this.buffer.active.viewportY = max - clamped;
+    this.buffer.active.viewportY = clamped;
     if (this._onScrollCallback) this._onScrollCallback(this.buffer.active.viewportY);
   });
 
@@ -172,6 +184,11 @@ export class MockTerminal {
   // Simulate resize event
   simulateResize(cols: number, rows: number) {
     this.resize(cols, rows);
+  }
+
+  simulateScroll(viewportY: number) {
+    this.buffer.active.viewportY = viewportY;
+    this._onScrollCallback?.(viewportY);
   }
 }
 


### PR DESCRIPTION
## Summary

- restore one-finger terminal scrollback while retaining two-finger pinch zoom
- recompute mobile fit-to-window columns after viewport changes and treat `maxCols` as a cap
- preserve a user's scrollback position synchronously during new output and layout changes
- correct VibeTunnel's absolute scroll position adapter for ghostty-web's distance-from-bottom API
- keep initial replay dumps at the live bottom and clean up touch listeners on disconnect

## Verification

- Existing Chrome profile, real ghostty terminal:
  - portrait touch drag moved scrollback from 251 to 237
  - new output increased max scroll from 251 to 253 while position remained 237
  - quick-key layout change preserved the same 16-line distance from bottom
  - rotation reflowed columns 46 to 62 to 46
  - with `maxCols=50`, landscape grew from 46 to the capped 50 columns
- `pnpm exec vitest run src/client/components/terminal.test.ts src/client/components/session-view.test.ts` (87 passed, 6 skipped)
- `pnpm exec vitest run --mode=client --coverage --maxWorkers=4` (635 passed, 14 skipped)
- `pnpm run test:server:coverage` (558 passed, 75 skipped)
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`
- `bash -x scripts/test-vt-syntax.sh`
- autoreview clean
