### PR TITLE
fix(web): stabilize mobile keyboard and quick-key layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### 🐛 Bug Fixes
 - Fix session creation "data couldn't be read" error on Mac app (#500)
+- Stabilize mobile keyboard reopening and reserve terminal space for quick keys without overlapping the action bar (via [@Nachx639](https://github.com/Nachx639)) (#646)
 - Detach only the VibeTunnel tmux client without assuming the default prefix (via [@Nachx639](https://github.com/Nachx639)) (#644)
 - Update `ws` and `qs` to patched versions for GHSA-58qx-3vcg-4xpx and GHSA-q8mj-m7cp-5q26 (via [@Nachx639](https://github.com/Nachx639)) (#642)
 - Restore the configured terminal width when reopening Terminal Settings (via [@Nachx639](https://github.com/Nachx639)) (#640)
@@ -28,7 +29,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
-- Thanks [@Nachx639](https://github.com/Nachx639) for adding log rotation, improving mobile tap targets, and fixing tmux detach behavior, dependency security, Terminal Settings width sync, and exited-session overlay layering.
+- Thanks [@Nachx639](https://github.com/Nachx639) for adding log rotation, improving mobile keyboard behavior and tap targets, and fixing tmux detach behavior, dependency security, Terminal Settings width sync, and exited-session overlay layering.
 - Thanks [@sourman](https://github.com/sourman) for documenting the Zig build prerequisite.
 - Thanks [@yv-was-taken](https://github.com/yv-was-taken) for fixing global npm and Bun installs.
 - Thanks [@ChimeraFlutter](https://github.com/ChimeraFlutter) for fixing desktop terminal clipping.

--- a/web/src/client/components/session-view.test.ts
+++ b/web/src/client/components/session-view.test.ts
@@ -538,8 +538,24 @@ describe('SessionView', () => {
     it('should render mobile action bar', async () => {
       await element.updateComplete;
 
-      const mobileActionBar = element.querySelector('mobile-action-bar');
+      const mobileActionBar = element.querySelector('mobile-action-bar') as
+        | (HTMLElement & { visible: boolean })
+        | null;
+      const grid = element.querySelector<HTMLElement>('.session-view-grid');
       expect(mobileActionBar).toBeTruthy();
+      expect(mobileActionBar?.visible).toBe(true);
+      expect(grid?.dataset.mobile).toBe('true');
+    });
+
+    it('should hide the mobile action bar while quick keys are visible', async () => {
+      const testElement = element as SessionViewTestInterface;
+      testElement.uiStateManager.setShowQuickKeys(true);
+      await element.updateComplete;
+
+      const mobileActionBar = element.querySelector('mobile-action-bar') as
+        | (HTMLElement & { visible: boolean })
+        | null;
+      expect(mobileActionBar?.visible).toBe(false);
     });
 
     it('should keep floating keyboard button available when quick keys are visible', async () => {
@@ -550,6 +566,20 @@ describe('SessionView', () => {
       const keyboardButton = element.querySelector('.mobile-keyboard-button');
       expect(keyboardButton).toBeTruthy();
       expect(keyboardButton?.classList.contains('quick-keys-visible')).toBe(true);
+    });
+  });
+
+  describe('quick-key layout', () => {
+    it('should keep the desktop terminal inside its grid row', async () => {
+      element.session = createMockSession();
+      const testElement = element as SessionViewTestInterface;
+      testElement.uiStateManager.setIsMobile(false);
+      testElement.uiStateManager.setShowQuickKeys(true);
+      await element.updateComplete;
+
+      const terminalArea = element.querySelector<HTMLElement>('.terminal-area');
+      expect(terminalArea?.dataset.quickkeysVisible).toBe('true');
+      expect(getComputedStyle(terminalArea as HTMLElement).transform).toBe('none');
     });
   });
 
@@ -899,6 +929,9 @@ describe('SessionView', () => {
       fitTerminal: ReturnType<typeof vi.fn>;
       scrollToBottom: ReturnType<typeof vi.fn>;
     };
+    let quickKeysElement: {
+      getBoundingClientRect: ReturnType<typeof vi.fn>;
+    };
 
     beforeEach(async () => {
       // Mock matchMedia to handle all queries properly
@@ -926,11 +959,17 @@ describe('SessionView', () => {
         addEventListener: vi.fn(),
         removeEventListener: vi.fn(),
       };
+      quickKeysElement = {
+        getBoundingClientRect: vi.fn(() => ({ height: 112 })),
+      };
 
       fitTerminalSpy = terminalElement.fitTerminal;
 
       // Override querySelector to return appropriate mocks
       vi.spyOn(element, 'querySelector').mockImplementation((selector: string) => {
+        if (selector === '.terminal-quick-keys-container') {
+          return quickKeysElement as unknown as HTMLElement;
+        }
         if (selector === 'terminal-renderer') {
           // Return a mock terminal-renderer that also has querySelector
           return {
@@ -986,6 +1025,31 @@ describe('SessionView', () => {
       expect(fitTerminalSpy).toHaveBeenCalledTimes(1);
 
       vi.useRealTimers();
+    });
+
+    it('should reserve and reset the measured quick-key height on mobile', async () => {
+      vi.useFakeTimers();
+      const testElement = element as SessionViewTestInterface;
+      testElement.uiStateManager.setIsMobile(true);
+      testElement.uiStateManager.setShowQuickKeys(true);
+
+      testElement.updateTerminalTransform();
+      await vi.advanceTimersByTimeAsync(20);
+      await element.updateComplete;
+
+      const containerElement = HTMLElement.prototype.querySelector.call(
+        element,
+        '.session-view-grid'
+      ) as HTMLElement | null;
+      expect(quickKeysElement.getBoundingClientRect).toHaveBeenCalledOnce();
+      expect(containerElement?.style.getPropertyValue('--quickkeys-height')).toBe('112px');
+
+      testElement.uiStateManager.setShowQuickKeys(false);
+      testElement.updateTerminalTransform();
+      await vi.advanceTimersByTimeAsync(20);
+      await element.updateComplete;
+
+      expect(containerElement?.style.getPropertyValue('--quickkeys-height')).toBe('0px');
     });
 
     it.skip('should properly calculate terminal height with keyboard and quick keys', {

--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -461,6 +461,7 @@ export class SessionView extends LitElement {
     this.checkOrientation();
     // Request update to re-render with new safe area classes
     this.requestUpdate();
+    this.updateTerminalTransform();
   }
 
   private getTerminalElement(): Terminal | null {
@@ -850,23 +851,13 @@ export class SessionView extends LitElement {
               terminalElement.fitTerminal();
             }
 
-            // If keyboard is visible, scroll to keep cursor visible.
-            // Wait for the iOS keyboard show/hide animation (~300ms) + layout reflow,
-            // otherwise the scroll happens before the viewport settles and the cursor
-            // stays hidden behind the keyboard.
+            // If keyboard is visible, scroll to keep cursor visible
             if (state.keyboardHeight > 0 || state.showQuickKeys) {
               setTimeout(() => {
-                // Only pin to the bottom if the user is still following output. If they
-                // scrolled up to read history (e.g. with the keyboard + quick keys open),
-                // don't yank them back down — that was the autoscroll bug.
-                const t = terminal as unknown as {
-                  scrollToBottom?: () => void;
-                  isFollowingCursor?: () => boolean;
-                };
-                if (t.scrollToBottom && (t.isFollowingCursor?.() ?? true)) {
-                  t.scrollToBottom();
+                if ('scrollToBottom' in terminal) {
+                  terminal.scrollToBottom();
                 }
-              }, 350);
+              }, 100);
             }
           }
         });
@@ -895,23 +886,18 @@ export class SessionView extends LitElement {
             terminalElement.fitTerminal();
           }
 
-          // If keyboard is visible, scroll to keep cursor visible — but only if the
-          // user is still following output (don't yank them down if they scrolled up).
+          // If keyboard is visible, scroll to keep cursor visible
           if (state.keyboardHeight > 0 || state.showQuickKeys) {
             // Small delay then scroll to bottom to keep cursor visible
             setTimeout(() => {
-              const t = terminal as unknown as {
-                scrollToBottom?: () => void;
-                isFollowingCursor?: () => boolean;
-              };
-              if (t.scrollToBottom && (t.isFollowingCursor?.() ?? true)) {
-                t.scrollToBottom();
+              if ('scrollToBottom' in terminal) {
+                terminal.scrollToBottom();
+              }
 
-                // Also ensure the terminal content is scrolled within its container
-                const terminalArea = this.querySelector('.terminal-area');
-                if (terminalArea) {
-                  terminalArea.scrollTop = terminalArea.scrollHeight;
-                }
+              // Also ensure the terminal content is scrolled within its container
+              const terminalArea = this.querySelector('.terminal-area');
+              if (terminalArea) {
+                terminalArea.scrollTop = terminalArea.scrollHeight;
               }
             }, 50);
           }
@@ -1205,9 +1191,8 @@ export class SessionView extends LitElement {
             margin-bottom: 0 !important;
           }
           
-          /* Quick keys: the grid now reserves their height via --quickkeys-height, so the
-             old translateY/padding hacks are no longer needed and actually create gaps
-             (a 110px shift + a 70px canvas inset). Keep them neutralized. */
+          /* The grid reserves quick-key height, so legacy transforms and padding would
+             shift the terminal outside its row and clip content. */
           .terminal-area[data-quickkeys-visible="true"] {
             transform: none;
           }
@@ -1305,21 +1290,6 @@ export class SessionView extends LitElement {
             z-index: 10 !important;
           }
 
-          /* Mobile: <mobile-action-bar> renders its content as position:fixed, so the
-             host element must NOT occupy flex space — otherwise it leaves a black gap
-             between the terminal and the quick keys. Collapse the host to zero height
-             while letting its fixed-positioned content still render. (display:contents
-             is avoided here due to unreliable iOS Safari support.) */
-          mobile-action-bar {
-            flex-shrink: 0 !important;
-            height: 0 !important;
-            min-height: 0 !important;
-            padding: 0 !important;
-            margin: 0 !important;
-            border: none !important;
-            overflow: visible !important;
-          }
-
           /* Mobile: Overlay positioning */
           .overlay-container {
             position: absolute !important;
@@ -1330,6 +1300,18 @@ export class SessionView extends LitElement {
             pointer-events: none !important;
             z-index: 20 !important;
           }
+        }
+
+        /* <mobile-action-bar> renders fixed content; its host must not consume grid or
+           flex space, including when a phone is wider than the CSS mobile breakpoint. */
+        .session-view-grid[data-mobile="true"] > mobile-action-bar {
+          flex-shrink: 0 !important;
+          height: 0 !important;
+          min-height: 0 !important;
+          padding: 0 !important;
+          margin: 0 !important;
+          border: none !important;
+          overflow: visible !important;
         }
         
         .overlay-container > * {
@@ -1349,6 +1331,7 @@ export class SessionView extends LitElement {
         <div
           class="session-view-grid"
           style="outline: none !important; box-shadow: none !important; --keyboard-height: ${uiState.keyboardHeight}px; --quickkeys-height: ${uiState.showQuickKeys ? this.quickKeysHeight : 0}px;"
+          data-mobile="${uiState.isMobile ? 'true' : 'false'}"
           data-keyboard-visible="${uiState.keyboardHeight > 0 || uiState.showQuickKeys ? 'true' : 'false'}"
         >
         <!-- Session Header Area -->
@@ -1491,7 +1474,7 @@ export class SessionView extends LitElement {
           uiState.isMobile
             ? html`
           <mobile-action-bar
-            .visible=${false}
+            .visible=${!uiState.showQuickKeys}
             .session=${this.session}
             .keyboardVisible=${uiState.keyboardHeight > 0}
             .keyboardHeight=${uiState.keyboardHeight}
@@ -1604,6 +1587,7 @@ export class SessionView extends LitElement {
         style="position: fixed !important; bottom: 0 !important; left: 0 !important; right: 0 !important; z-index: ${Z_INDEX.TERMINAL_QUICK_KEYS} !important;"
         .visible=${uiState.isMobile && uiState.useDirectKeyboard && uiState.showQuickKeys && !uiState.chatMode}
         .onKeyPress=${(key: string) => this.directKeyboardManager.handleQuickKeyPress(key)}
+        @quick-keys-layout-change=${() => this.updateTerminalTransform()}
       ></terminal-quick-keys>
 
       <!-- Mobile Input Controls (only show when direct keyboard is disabled) -->

--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -99,6 +99,9 @@ export class SessionView extends LitElement {
 
   private instanceId = `session-view-${Math.random().toString(36).substr(2, 9)}`;
   private _updateTerminalTransformTimeout: ReturnType<typeof setTimeout> | null = null;
+  // Measured height of the quick-keys bar; fed into --quickkeys-height so the terminal
+  // reserves space for it instead of letting it cover the bottom rows.
+  private quickKeysHeight = 0;
   private terminalOutputListeners: Set<(data: string) => void> = new Set();
 
   private createLifecycleEventManagerCallbacks(): LifecycleEventManagerCallbacks {
@@ -744,9 +747,11 @@ export class SessionView extends LitElement {
     // Update terminal transform immediately
     this.updateTerminalTransform();
 
-    // Focus the hidden input synchronously - critical for iOS Safari
-    // Must be called directly in the click handler without any delays
-    this.directKeyboardManager.focusHiddenInput();
+    // Focus the hidden input synchronously - critical for iOS Safari.
+    // forceRecreate=true: the user explicitly tapped TAP to (re)open the keyboard, so
+    // recreate the input so iOS reliably reopens it even if the soft keyboard was
+    // dismissed while the quick keys stayed open (avoids the intermittent race).
+    this.directKeyboardManager.focusHiddenInput(true);
 
     // Request update after all synchronous operations
     this.requestUpdate();
@@ -827,6 +832,16 @@ export class SessionView extends LitElement {
 
         // Notify terminal to resize
         requestAnimationFrame(() => {
+          // Reserve space for the quick-keys bar so it stops covering the terminal's
+          // bottom rows (which also made the top unreachable). Measure it and set the
+          // CSS var synchronously before fitTerminal recomputes the row count.
+          const grid = this.querySelector('.session-view-grid') as HTMLElement | null;
+          const qkEl = this.querySelector('.terminal-quick-keys-container') as HTMLElement | null;
+          const qkH =
+            state.showQuickKeys && qkEl ? Math.round(qkEl.getBoundingClientRect().height) : 0;
+          this.quickKeysHeight = qkH;
+          grid?.style.setProperty('--quickkeys-height', `${qkH}px`);
+
           const terminal = this.getTerminalElement();
           if (terminal) {
             // Notify terminal of size change
@@ -835,13 +850,23 @@ export class SessionView extends LitElement {
               terminalElement.fitTerminal();
             }
 
-            // If keyboard is visible, scroll to keep cursor visible
+            // If keyboard is visible, scroll to keep cursor visible.
+            // Wait for the iOS keyboard show/hide animation (~300ms) + layout reflow,
+            // otherwise the scroll happens before the viewport settles and the cursor
+            // stays hidden behind the keyboard.
             if (state.keyboardHeight > 0 || state.showQuickKeys) {
               setTimeout(() => {
-                if ('scrollToBottom' in terminal) {
-                  terminal.scrollToBottom();
+                // Only pin to the bottom if the user is still following output. If they
+                // scrolled up to read history (e.g. with the keyboard + quick keys open),
+                // don't yank them back down — that was the autoscroll bug.
+                const t = terminal as unknown as {
+                  scrollToBottom?: () => void;
+                  isFollowingCursor?: () => boolean;
+                };
+                if (t.scrollToBottom && (t.isFollowingCursor?.() ?? true)) {
+                  t.scrollToBottom();
                 }
-              }, 100);
+              }, 350);
             }
           }
         });
@@ -870,18 +895,23 @@ export class SessionView extends LitElement {
             terminalElement.fitTerminal();
           }
 
-          // If keyboard is visible, scroll to keep cursor visible
+          // If keyboard is visible, scroll to keep cursor visible — but only if the
+          // user is still following output (don't yank them down if they scrolled up).
           if (state.keyboardHeight > 0 || state.showQuickKeys) {
             // Small delay then scroll to bottom to keep cursor visible
             setTimeout(() => {
-              if ('scrollToBottom' in terminal) {
-                terminal.scrollToBottom();
-              }
+              const t = terminal as unknown as {
+                scrollToBottom?: () => void;
+                isFollowingCursor?: () => boolean;
+              };
+              if (t.scrollToBottom && (t.isFollowingCursor?.() ?? true)) {
+                t.scrollToBottom();
 
-              // Also ensure the terminal content is scrolled within its container
-              const terminalArea = this.querySelector('.terminal-area');
-              if (terminalArea) {
-                terminalArea.scrollTop = terminalArea.scrollHeight;
+                // Also ensure the terminal content is scrolled within its container
+                const terminalArea = this.querySelector('.terminal-area');
+                if (terminalArea) {
+                  terminalArea.scrollTop = terminalArea.scrollHeight;
+                }
               }
             }, 50);
           }
@@ -1175,16 +1205,16 @@ export class SessionView extends LitElement {
             margin-bottom: 0 !important;
           }
           
-          /* Desktop: Keep transform for quick keys */
+          /* Quick keys: the grid now reserves their height via --quickkeys-height, so the
+             old translateY/padding hacks are no longer needed and actually create gaps
+             (a 110px shift + a 70px canvas inset). Keep them neutralized. */
           .terminal-area[data-quickkeys-visible="true"] {
-            transform: translateY(-110px);
-            transition: transform 0.2s ease-out;
+            transform: none;
           }
-          
-          /* Desktop: Add padding when keyboard is visible */
+
           .terminal-area[data-quickkeys-visible="true"] vibe-terminal,
           .terminal-area[data-quickkeys-visible="true"] vibe-terminal-binary {
-            padding-bottom: 70px !important;
+            padding-bottom: 0 !important;
             box-sizing: border-box;
           }
           
@@ -1217,7 +1247,17 @@ export class SessionView extends LitElement {
             background-color: rgb(var(--color-bg)) !important;
             font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
           }
-          
+
+          /* Mobile: when the quick keys are up, shrink the grid so the terminal reserves
+             space for the fixed quick-keys bar instead of being covered (the bottom rows
+             were hidden and the top became unreachable). We subtract ONLY the quick-keys
+             height — NOT the keyboard height — because the viewport uses
+             interactive-widget=resizes-content, so 100dvh already shrinks with the iOS
+             keyboard; subtracting it again double-counted and left a large empty gap. */
+          .session-view-grid[data-keyboard-visible="true"] {
+            height: calc(100dvh - var(--quickkeys-height, 0px)) !important;
+          }
+
           .session-header-area {
             /* Use mobile-terminal-header styles */
             flex-shrink: 0 !important;
@@ -1264,7 +1304,22 @@ export class SessionView extends LitElement {
             bottom: 0 !important;
             z-index: 10 !important;
           }
-          
+
+          /* Mobile: <mobile-action-bar> renders its content as position:fixed, so the
+             host element must NOT occupy flex space — otherwise it leaves a black gap
+             between the terminal and the quick keys. Collapse the host to zero height
+             while letting its fixed-positioned content still render. (display:contents
+             is avoided here due to unreliable iOS Safari support.) */
+          mobile-action-bar {
+            flex-shrink: 0 !important;
+            height: 0 !important;
+            min-height: 0 !important;
+            padding: 0 !important;
+            margin: 0 !important;
+            border: none !important;
+            overflow: visible !important;
+          }
+
           /* Mobile: Overlay positioning */
           .overlay-container {
             position: absolute !important;
@@ -1293,7 +1348,7 @@ export class SessionView extends LitElement {
       <div class="bg-bg-secondary" style="padding-top: env(safe-area-inset-top);">
         <div
           class="session-view-grid"
-          style="outline: none !important; box-shadow: none !important; --keyboard-height: ${uiState.keyboardHeight}px; --quickkeys-height: 0px;"
+          style="outline: none !important; box-shadow: none !important; --keyboard-height: ${uiState.keyboardHeight}px; --quickkeys-height: ${uiState.showQuickKeys ? this.quickKeysHeight : 0}px;"
           data-keyboard-visible="${uiState.keyboardHeight > 0 || uiState.showQuickKeys ? 'true' : 'false'}"
         >
         <!-- Session Header Area -->
@@ -1436,7 +1491,7 @@ export class SessionView extends LitElement {
           uiState.isMobile
             ? html`
           <mobile-action-bar
-            .visible=${true}
+            .visible=${false}
             .session=${this.session}
             .keyboardVisible=${uiState.keyboardHeight > 0}
             .keyboardHeight=${uiState.keyboardHeight}

--- a/web/src/client/components/session-view/direct-keyboard-manager.test.ts
+++ b/web/src/client/components/session-view/direct-keyboard-manager.test.ts
@@ -10,6 +10,14 @@ describe('DirectKeyboardManager', () => {
   let mockInputManager: Pick<InputManager, 'sendInputText'>;
   let originalRequestAnimationFrame: typeof requestAnimationFrame;
 
+  const getManagerState = () =>
+    manager as unknown as {
+      hiddenInput: HTMLInputElement | null;
+      focusRetentionInterval: number | null;
+      keyboardReopenTimeout: ReturnType<typeof setTimeout> | null;
+      reopeningKeyboard: boolean;
+    };
+
   beforeEach(() => {
     // Mock requestAnimationFrame
     originalRequestAnimationFrame = global.requestAnimationFrame;
@@ -41,6 +49,8 @@ describe('DirectKeyboardManager', () => {
   });
 
   afterEach(() => {
+    manager.cleanup();
+    vi.useRealTimers();
     // Restore requestAnimationFrame
     global.requestAnimationFrame = originalRequestAnimationFrame;
   });
@@ -49,5 +59,74 @@ describe('DirectKeyboardManager', () => {
     await manager.handleQuickKeyPress('Paste');
     expect(navigator.clipboard.readText).toHaveBeenCalled();
     expect(mockInputManager.sendInputText).toHaveBeenCalledWith('clipboard content');
+  });
+
+  it('recreates the hidden input only for an explicit keyboard reopen', () => {
+    const originalInput = getManagerState().hiddenInput;
+    expect(originalInput).toBeTruthy();
+
+    originalInput?.focus();
+    manager.ensureHiddenInputVisible();
+    expect(getManagerState().hiddenInput).toBe(originalInput);
+
+    vi.useFakeTimers();
+    manager.focusHiddenInput(true);
+
+    expect(getManagerState().hiddenInput).not.toBe(originalInput);
+    expect(getManagerState().reopeningKeyboard).toBe(true);
+    expect(getManagerState().focusRetentionInterval).toBeNull();
+
+    vi.advanceTimersByTime(500);
+
+    expect(getManagerState().reopeningKeyboard).toBe(false);
+    expect(getManagerState().focusRetentionInterval).not.toBeNull();
+  });
+
+  it('restarts the reopen window after repeated TAP presses', () => {
+    vi.useFakeTimers();
+
+    manager.focusHiddenInput(true);
+    vi.advanceTimersByTime(400);
+    manager.focusHiddenInput(true);
+    vi.advanceTimersByTime(100);
+
+    expect(getManagerState().reopeningKeyboard).toBe(true);
+    expect(getManagerState().focusRetentionInterval).toBeNull();
+
+    vi.advanceTimersByTime(400);
+
+    expect(getManagerState().reopeningKeyboard).toBe(false);
+    expect(getManagerState().focusRetentionInterval).not.toBeNull();
+  });
+
+  it('cancels a pending keyboard reopen during cleanup', () => {
+    vi.useFakeTimers();
+
+    manager.focusHiddenInput(true);
+    manager.cleanup();
+    vi.runAllTimers();
+
+    expect(getManagerState().hiddenInput).toBeNull();
+    expect(getManagerState().keyboardReopenTimeout).toBeNull();
+    expect(getManagerState().reopeningKeyboard).toBe(false);
+    expect(getManagerState().focusRetentionInterval).toBeNull();
+  });
+
+  it.each([
+    [' h', 'h'],
+    ['h ', 'h'],
+    ['hello world ', 'hello world'],
+  ])('removes the placeholder space from %j', (inputValue, expected) => {
+    const hiddenInput = getManagerState().hiddenInput;
+    expect(hiddenInput).toBeTruthy();
+
+    if (!hiddenInput) {
+      return;
+    }
+
+    hiddenInput.value = inputValue;
+    hiddenInput.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText' }));
+
+    expect(mockInputManager.sendInputText).toHaveBeenCalledWith(expected);
   });
 });

--- a/web/src/client/components/session-view/direct-keyboard-manager.ts
+++ b/web/src/client/components/session-view/direct-keyboard-manager.ts
@@ -50,6 +50,10 @@ export interface DirectKeyboardCallbacks {
 export class DirectKeyboardManager extends ManagerEventEmitter {
   private hiddenInput: HTMLInputElement | null = null;
   private focusRetentionInterval: number | null = null;
+  // While reopening the keyboard via TAP, suppress all automatic re-focus (interval,
+  // focus handler, blur re-focus) so they don't make iOS think the field is already
+  // focused and refuse to show the keyboard. Cleared shortly after the tap.
+  private reopeningKeyboard = false;
   private inputManager: InputManager | null = null;
   private sessionViewElement: HTMLElement | null = null;
   private callbacks: DirectKeyboardCallbacks | null = null;
@@ -121,7 +125,7 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
     }
   }
 
-  focusHiddenInput(): void {
+  focusHiddenInput(forceRecreate = false): void {
     logger.log('Entering keyboard mode');
 
     // Enter keyboard mode
@@ -171,17 +175,53 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
       document.addEventListener('pointerdown', this.captureClickHandler, true);
     }
 
-    // Start focus retention immediately
+    // Stop any running focus-retention BEFORE focusing. The 100ms interval re-focuses
+    // the input, and when it fires right before the tap iOS thinks the field is already
+    // focused and refuses to show the keyboard — that's the random "TAP doesn't open the
+    // keyboard" behaviour. Restart retention shortly after, once the keyboard is up.
     if (this.focusRetentionInterval) {
       clearInterval(this.focusRetentionInterval);
+      this.focusRetentionInterval = null;
     }
-    this.startFocusRetention();
 
-    // Ensure input is ready and focus it synchronously
-    this.ensureHiddenInputVisible();
+    // Suppress automatic re-focus while iOS is showing the keyboard (TAP path only).
+    if (forceRecreate) {
+      this.reopeningKeyboard = true;
+    }
+
+    // Ensure input is ready and focus it synchronously (recreated when forceRecreate).
+    this.ensureHiddenInputVisible(forceRecreate);
+
+    // Restart focus retention after the keyboard has had time to appear, so it doesn't
+    // steal the moment iOS uses to show the keyboard.
+    if (forceRecreate) {
+      setTimeout(() => {
+        this.reopeningKeyboard = false;
+        if (this.keyboardMode && !this.focusRetentionInterval) {
+          this.startFocusRetention();
+        }
+      }, 500);
+    } else {
+      this.startFocusRetention();
+    }
   }
 
-  ensureHiddenInputVisible(): void {
+  ensureHiddenInputVisible(forceRecreate = false): void {
+    // iOS won't reopen the soft keyboard on a plain focus() of an input it considers
+    // already focused — and our own blur-handler re-focuses the input ~50ms after the
+    // keyboard is dismissed while the quick keys stay open. That race made the TAP
+    // button reopen the keyboard only intermittently. So when the user explicitly taps
+    // TAP (forceRecreate), recreate the input unconditionally: iOS treats a brand-new
+    // field as fresh and reliably shows the keyboard. We also recreate if it happens to
+    // still be the focused element.
+    if (this.hiddenInput && (forceRecreate || document.activeElement === this.hiddenInput)) {
+      const stale = this.hiddenInput;
+      // Null it first so the stale input's blur handler won't refocus it.
+      this.hiddenInput = null;
+      stale.blur();
+      stale.remove();
+    }
+
     if (!this.hiddenInput) {
       this.createHiddenInput();
     } else {
@@ -208,7 +248,9 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
       this.hiddenInput.style.display = 'block';
       this.hiddenInput.style.visibility = 'visible';
 
-      // Focus synchronously - critical for iOS Safari
+      // Focus synchronously - critical for iOS Safari. (When the keyboard needed
+      // reopening with focus retained, the input was already recreated above, so a
+      // plain focus() on the fresh field now reliably shows the keyboard.)
       this.hiddenInput.focus();
 
       // Set a space placeholder and position cursor at end
@@ -343,8 +385,14 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
       }
 
       if (input.value && this.inputManager) {
-        // Filter out the placeholder space before sending
-        const textToSend = input.value.replace(/^ /, '');
+        // Filter out the single placeholder space before sending. On the FIRST keystroke
+        // iOS sometimes leaves the caret before the placeholder, so the typed char lands
+        // ahead of it (value becomes "h " instead of " h"). Strip a leading space if
+        // present, otherwise a trailing one — this fixes the "h ola" (extra space after
+        // the first letter) bug without eating the user's own spaces mid-text.
+        const textToSend = input.value.startsWith(' ')
+          ? input.value.slice(1)
+          : input.value.replace(/ $/, '');
         if (textToSend) {
           // Send each character to terminal (only for non-IME input)
           this.inputManager.sendInputText(textToSend);
@@ -433,8 +481,9 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
         visualViewportHandler();
       }
 
-      // Start focus retention if not already running
-      if (!this.focusRetentionInterval) {
+      // Start focus retention if not already running — but NOT while reopening the
+      // keyboard via TAP (it would re-focus mid-gesture and stop iOS showing it).
+      if (!this.focusRetentionInterval && !this.reopeningKeyboard) {
         this.startFocusRetention();
       }
     });
@@ -454,9 +503,12 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
 
         // Add a small delay to allow Done button to exit keyboard mode first
         setTimeout(() => {
-          // Re-check keyboard mode after delay - Done button might have exited it
+          // Re-check keyboard mode after delay - Done button might have exited it.
+          // Skip while reopening via TAP so this doesn't re-focus the stale input and
+          // make iOS refuse to show the keyboard.
           if (
             this.keyboardMode &&
+            !this.reopeningKeyboard &&
             this.hiddenInput &&
             document.activeElement !== this.hiddenInput
           ) {
@@ -697,6 +749,10 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
 
   private startFocusRetention(): void {
     this.focusRetentionInterval = setInterval(() => {
+      // While reopening via TAP, don't re-focus — let iOS show the keyboard first.
+      if (this.reopeningKeyboard) {
+        return;
+      }
       const disableFocusManagement = this.callbacks?.getDisableFocusManagement() ?? false;
       const showCtrlAlpha = this.callbacks?.getShowCtrlAlpha() ?? false;
 

--- a/web/src/client/components/session-view/direct-keyboard-manager.ts
+++ b/web/src/client/components/session-view/direct-keyboard-manager.ts
@@ -54,6 +54,7 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
   // focus handler, blur re-focus) so they don't make iOS think the field is already
   // focused and refuse to show the keyboard. Cleared shortly after the tap.
   private reopeningKeyboard = false;
+  private keyboardReopenTimeout: ReturnType<typeof setTimeout> | null = null;
   private inputManager: InputManager | null = null;
   private sessionViewElement: HTMLElement | null = null;
   private callbacks: DirectKeyboardCallbacks | null = null;
@@ -184,6 +185,8 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
       this.focusRetentionInterval = null;
     }
 
+    this.cancelKeyboardReopen();
+
     // Suppress automatic re-focus while iOS is showing the keyboard (TAP path only).
     if (forceRecreate) {
       this.reopeningKeyboard = true;
@@ -195,7 +198,8 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
     // Restart focus retention after the keyboard has had time to appear, so it doesn't
     // steal the moment iOS uses to show the keyboard.
     if (forceRecreate) {
-      setTimeout(() => {
+      this.keyboardReopenTimeout = setTimeout(() => {
+        this.keyboardReopenTimeout = null;
         this.reopeningKeyboard = false;
         if (this.keyboardMode && !this.focusRetentionInterval) {
           this.startFocusRetention();
@@ -212,9 +216,8 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
     // keyboard is dismissed while the quick keys stay open. That race made the TAP
     // button reopen the keyboard only intermittently. So when the user explicitly taps
     // TAP (forceRecreate), recreate the input unconditionally: iOS treats a brand-new
-    // field as fresh and reliably shows the keyboard. We also recreate if it happens to
-    // still be the focused element.
-    if (this.hiddenInput && (forceRecreate || document.activeElement === this.hiddenInput)) {
+    // field as fresh and reliably shows the keyboard.
+    if (this.hiddenInput && forceRecreate) {
       const stale = this.hiddenInput;
       // Null it first so the stale input's blur handler won't refocus it.
       this.hiddenInput = null;
@@ -784,6 +787,14 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
     }, 100) as unknown as number; // More frequent checks (100ms instead of 300ms)
   }
 
+  private cancelKeyboardReopen(): void {
+    if (this.keyboardReopenTimeout) {
+      clearTimeout(this.keyboardReopenTimeout);
+      this.keyboardReopenTimeout = null;
+    }
+    this.reopeningKeyboard = false;
+  }
+
   private delayedRefocusHiddenInput(): void {
     setTimeout(() => {
       const disableFocusManagement = this.callbacks?.getDisableFocusManagement() ?? false;
@@ -960,6 +971,7 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
     // Exit keyboard mode
     this.keyboardMode = false;
     this.keyboardModeTimestamp = 0;
+    this.cancelKeyboardReopen();
 
     // Remove capture click handler
     if (this.captureClickHandler) {
@@ -1000,6 +1012,7 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
 
   cleanup(): void {
     // Clear timers
+    this.cancelKeyboardReopen();
     if (this.focusRetentionInterval) {
       clearInterval(this.focusRetentionInterval);
       this.focusRetentionInterval = null;
@@ -1042,6 +1055,7 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
     this.keyboardMode = false;
     this.keyboardModeTimestamp = 0;
     this.showQuickKeys = false;
+    this.cancelKeyboardReopen();
 
     // Stop focus retention interval - critical to prevent refocusing
     if (this.focusRetentionInterval) {

--- a/web/src/client/components/session-view/overlays-container.test.ts
+++ b/web/src/client/components/session-view/overlays-container.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { fixture, html } from '@open-wc/testing';
+import { describe, expect, it, vi } from 'vitest';
+import type { OverlaysCallbacks, OverlaysContainer } from './overlays-container.js';
+import { UIStateManager } from './ui-state-manager.js';
+import './overlays-container.js';
+
+const createCallbacks = (): OverlaysCallbacks => ({
+  onCtrlKey: vi.fn(),
+  onSendCtrlSequence: vi.fn(),
+  onClearCtrlSequence: vi.fn(),
+  onCtrlAlphaCancel: vi.fn(),
+  onQuickKeyPress: vi.fn(),
+  onCloseFileBrowser: vi.fn(),
+  onInsertPath: vi.fn(),
+  onFileSelected: vi.fn(),
+  onFileError: vi.fn(),
+  onCloseFilePicker: vi.fn(),
+  onWidthSelect: vi.fn(),
+  onFontSizeChange: vi.fn(),
+  onThemeChange: vi.fn(),
+  onCloseWidthSelector: vi.fn(),
+  onKeyboardButtonClick: vi.fn(),
+  handleBack: vi.fn(),
+});
+
+describe('OverlaysContainer', () => {
+  it('handles the keyboard pointer event without bubbling the follow-up click', async () => {
+    const uiStateManager = new UIStateManager();
+    uiStateManager.setIsMobile(true);
+    const callbacks = createCallbacks();
+    const element = await fixture<OverlaysContainer>(html`
+      <overlays-container
+        .uiState=${uiStateManager.getState()}
+        .callbacks=${callbacks}
+      ></overlays-container>
+    `);
+    const keyboardButton = element.querySelector<HTMLElement>('.mobile-keyboard-button');
+    const bubbledClick = vi.fn();
+    element.addEventListener('click', bubbledClick);
+
+    expect(keyboardButton).toBeTruthy();
+
+    const pointerDown = new Event('pointerdown', { bubbles: true, cancelable: true });
+    keyboardButton?.dispatchEvent(pointerDown);
+    const click = new Event('click', { bubbles: true, cancelable: true });
+    keyboardButton?.dispatchEvent(click);
+
+    expect(callbacks.onKeyboardButtonClick).toHaveBeenCalledOnce();
+    expect(pointerDown.defaultPrevented).toBe(true);
+    expect(click.defaultPrevented).toBe(true);
+    expect(bubbledClick).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/client/components/session-view/overlays-container.ts
+++ b/web/src/client/components/session-view/overlays-container.ts
@@ -113,6 +113,14 @@ export class OverlaysContainer extends LitElement {
                 e.stopPropagation();
                 this.callbacks?.onKeyboardButtonClick();
               }}
+              @click=${(e: Event) => {
+                // The click that follows the tap must NOT bubble to session-view, whose
+                // click handler calls session-view.focus() and steals focus from the
+                // hidden input — which makes iOS immediately close the keyboard we just
+                // opened. (That was the random "TAP doesn't reopen the keyboard" bug.)
+                e.preventDefault();
+                e.stopPropagation();
+              }}
               title="${this.uiState.showQuickKeys ? 'Hide keyboard' : 'Show keyboard'}"
               role="button"
               aria-label="Toggle mobile keyboard"

--- a/web/src/client/components/terminal-quick-keys.test.ts
+++ b/web/src/client/components/terminal-quick-keys.test.ts
@@ -145,6 +145,20 @@ describe('TerminalQuickKeys', () => {
       component.handleKeyPress('ArrowLeft', false, false, false);
       expect(requestUpdateSpy).toHaveBeenCalled();
     });
+
+    it('notifies the parent when expanded quick-key rows change', async () => {
+      const layoutChangeSpy = vi.fn();
+      component.addEventListener('quick-keys-layout-change', layoutChangeSpy);
+      document.body.append(component);
+      await component.updateComplete;
+      layoutChangeSpy.mockClear();
+
+      component.handleKeyPress('CtrlExpand', false, false, true);
+      await component.updateComplete;
+
+      expect(layoutChangeSpy).toHaveBeenCalledOnce();
+      component.remove();
+    });
   });
 
   describe('Touch target sizing', () => {

--- a/web/src/client/components/terminal-quick-keys.ts
+++ b/web/src/client/components/terminal-quick-keys.ts
@@ -196,6 +196,19 @@ export class TerminalQuickKeys extends LitElement {
 
   updated(changedProperties: PropertyValues) {
     super.updated(changedProperties);
+    if (
+      changedProperties.has('visible') ||
+      changedProperties.has('showFunctionKeys') ||
+      changedProperties.has('showCtrlKeys') ||
+      changedProperties.has('isLandscape')
+    ) {
+      this.dispatchEvent(
+        new CustomEvent('quick-keys-layout-change', {
+          bubbles: true,
+          composed: true,
+        })
+      );
+    }
   }
 
   private handleKeyPress(


### PR DESCRIPTION
Stabilizes the mobile direct-keyboard flow and quick-key layout without changing desktop terminal positioning.

## Changes
- Recreate the hidden input only for an explicit TAP reopen, with an owned 500ms suppression window for automatic refocus.
- Prevent the TAP button's follow-up click from bubbling and stealing hidden-input focus.
- Strip the hidden-input placeholder whether iOS leaves it before or after the first typed character.
- Measure the fixed quick-key bar and reserve its exact height in portrait and landscape.
- Keep the mobile action bar available normally and hide it only while quick keys are open.
- Recalculate layout when quick-key rows or orientation change.
- Add regression coverage for reopen timers, cleanup, placeholder input, click propagation, action-bar visibility, measured spacing, and desktop grid positioning.

## Validation
- Focused client tests: 53 passed, 6 skipped.
- Full client coverage suite: 626 passed, 14 skipped.
- Lint, formatting, and TypeScript checks pass.
- Live Chrome mobile proof at 390x844 and 844x390: quick-key height matched reserved grid space, no terminal overlap or gap, action bar visibility was correct, and repeated TAP presses left exactly one focused hidden input.
- Autoreview: no actionable findings.

## Scope
Cursor-follow and scroll-retention changes remain in #645 and are intentionally excluded here.
