### PR TITLE
fix(ios): restore Xcode 26 CI compatibility

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '26.1'
+        xcode-version: '26.3'
     
     - name: Verify Xcode
       run: |
@@ -202,41 +202,46 @@ jobs:
         echo "Available runtimes:"
         xcrun simctl list runtimes available
 
+        SDK_VERSION=$(xcrun --sdk iphonesimulator --show-sdk-version)
+        RUNTIME_ID="com.apple.CoreSimulator.SimRuntime.iOS-${SDK_VERSION//./-}"
+        echo "Selecting a simulator for the active iOS $SDK_VERSION SDK"
+
         SIMULATOR=$(
-          xcrun simctl list devices available -j | jq -r '
+          xcrun simctl list devices available -j | jq -r --arg runtime "$RUNTIME_ID" '
             [
               .devices
               | to_entries[]
-              | select(.key | startswith("com.apple.CoreSimulator.SimRuntime.iOS-"))
-              | .key as $runtime
+              | select(.key == $runtime)
               | .value[]
               | select(.isAvailable == true and (.name | startswith("iPhone")))
               | {
                   udid,
                   name,
-                  runtime: $runtime,
-                  version: (
-                    $runtime
-                    | sub("com.apple.CoreSimulator.SimRuntime.iOS-"; "")
-                    | split("-")
-                    | map(tonumber)
+                  priority: (
+                    if .name == "iPhone 17 Pro" then 0
+                    elif .name == "iPhone 17" then 1
+                    elif .name == "iPhone 16 Pro" then 2
+                    elif .name == "iPhone 16" then 3
+                    elif (.name | contains("SE")) then 99
+                    else 10
+                    end
                   )
                 }
             ]
-            | sort_by(.version)
-            | (last // empty)
-            | [.udid, .name, .runtime]
+            | sort_by(.priority, .name)
+            | (first // empty)
+            | [.udid, .name]
             | @tsv
           '
         )
 
         if [ -z "$SIMULATOR" ]; then
-          echo "::error::No available iPhone simulator found"
+          echo "::error::No available iPhone simulator found for iOS $SDK_VERSION"
           exit 1
         fi
 
-        IFS=$'\t' read -r SIMULATOR_ID SIMULATOR_NAME RUNTIME <<< "$SIMULATOR"
-        echo "Using $SIMULATOR_NAME ($RUNTIME): $SIMULATOR_ID"
+        IFS=$'\t' read -r SIMULATOR_ID SIMULATOR_NAME <<< "$SIMULATOR"
+        echo "Using $SIMULATOR_NAME ($RUNTIME_ID): $SIMULATOR_ID"
 
         xcrun simctl boot "$SIMULATOR_ID" 2>/dev/null || true
         xcrun simctl bootstatus "$SIMULATOR_ID" -b
@@ -245,6 +250,7 @@ jobs:
         echo "simulator_id=$SIMULATOR_ID" >> "$GITHUB_OUTPUT"
     
     - name: Run iOS tests
+      timeout-minutes: 15
       env:
         # Workaround for Xcode beta actool version info issues
         ACTOOL_IGNORE_VERSION_CHECK: "1"
@@ -296,23 +302,30 @@ jobs:
         fi
 
         echo "Running tests on iOS Simulator..."
+        rm -rf TestResults.xcresult xcodebuild-test.log
+
+        set +e
         xcodebuild test \
           -workspace ../VibeTunnel.xcworkspace \
           -scheme VibeTunnel-iOS \
           -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
           -resultBundlePath TestResults.xcresult \
           -enableCodeCoverage $ENABLE_COVERAGE \
+          -parallel-testing-enabled NO \
           CODE_SIGN_IDENTITY="" \
           CODE_SIGNING_REQUIRED=NO \
           CODE_SIGNING_ALLOWED=NO \
           COMPILER_INDEX_STORE_ENABLE=NO \
           ACTOOL_IGNORE_VERSION_CHECK=1 \
           IBTOOL_IGNORE_VERSION_CHECK=1 \
-          -quiet \
-          2>&1 || {
-            echo "::error::iOS simulator tests failed"
-            exit 1
-          }
+          2>&1 | tee xcodebuild-test.log | xcbeautify
+        TEST_STATUS=${PIPESTATUS[0]}
+        set -e
+
+        if [ "$TEST_STATUS" -ne 0 ]; then
+          echo "::error::iOS simulator tests failed with exit code $TEST_STATUS"
+          exit "$TEST_STATUS"
+        fi
         
         echo "Tests completed successfully"
 
@@ -330,7 +343,7 @@ jobs:
       run: |
         cd ios
         echo "=== Checking TestResults.xcresult ==="
-        if [ -f TestResults.xcresult ]; then
+        if [ -d TestResults.xcresult ]; then
           echo "TestResults.xcresult exists"
           ls -la TestResults.xcresult
           
@@ -349,7 +362,7 @@ jobs:
       id: coverage
       run: |
         cd ios
-        if [ -f TestResults.xcresult ]; then
+        if [ -d TestResults.xcresult ]; then
           # Try multiple extraction methods
           echo "=== Method 1: Standard extraction ==="
           COVERAGE_PCT=$(xcrun xccov view --report TestResults.xcresult --json 2>/dev/null | jq -r '.lineCoverage // 0' | awk '{printf "%.1f", $1 * 100}') || COVERAGE_PCT="0"
@@ -412,6 +425,7 @@ jobs:
         path: |
           ios/coverage-summary.json
           ios/TestResults.xcresult
+          ios/xcodebuild-test.log
         retention-days: 1
     
     # LINT REPORTING

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -8,43 +8,26 @@ permissions:
   pull-requests: write
   issues: write
 
-# Single job for efficient execution on shared runner
+# Single job for efficient execution on a GitHub-hosted macOS runner
 jobs:
   build-lint-test:
     name: Build, Lint, and Test iOS
-    runs-on: [self-hosted, macOS, ARM64]
+    runs-on: macos-latest
     timeout-minutes: 30
     env:
       GITHUB_REPO_NAME: ${{ github.repository }}
     
     steps:
-    - name: Clean workspace
-      run: |
-        # Clean workspace for self-hosted runner
-        # Clean workspace but preserve .git directory
-        find . -maxdepth 1 -name '.*' -not -name '.git' -not -name '.' -not -name '..' -exec rm -rf {} + || true
-        rm -rf * || true
-        
     - name: Checkout code
       uses: actions/checkout@v4
+
+    - name: Setup Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '26.1'
     
     - name: Verify Xcode
       run: |
-        # Check available Xcode versions
-        echo "Available Xcode versions:"
-        ls -la /Applications/ | grep -i xcode || true
-        
-        # Check if stable Xcode is available
-        if [ -d "/Applications/Xcode.app" ]; then
-          echo "Stable Xcode found, switching to it..."
-          sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
-        elif [ -d "/Applications/Xcode-15.app" ]; then
-          echo "Xcode 15 found, switching to it..."
-          sudo xcode-select -s /Applications/Xcode-15.app/Contents/Developer
-        else
-          echo "Using current Xcode installation with actool workaround..."
-        fi
-        
         xcodebuild -version
         swift --version
     

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -83,8 +83,7 @@ jobs:
             break
           else
             if [ $attempt -eq $MAX_ATTEMPTS ]; then
-              echo "Failed to install tools after $MAX_ATTEMPTS attempts, continuing without them"
-              # Don't exit 1, continue with build (tools may already be installed)
+              echo "Failed to install tools after $MAX_ATTEMPTS attempts"
               break
             fi
             echo "Command failed, waiting ${WAIT_TIME}s before retry..."
@@ -92,12 +91,21 @@ jobs:
             WAIT_TIME=$((WAIT_TIME * 2))  # Exponential backoff
           fi
         done
+
+        for tool in swiftlint swiftformat xcbeautify; do
+          if brew list --versions "$tool" >/dev/null; then
+            brew link --overwrite "$tool" || true
+          fi
+        done
         
-        # Verify which tools are available
+        # Verify all required tools are available
         echo "Tool availability check:"
-        which swiftlint || echo "swiftlint not available (linting will be skipped)"
-        which swiftformat || echo "swiftformat not available (formatting will be skipped)"  
-        which xcbeautify || echo "xcbeautify not available (output formatting will be basic)"
+        for tool in swiftlint swiftformat xcbeautify; do
+          if ! command -v "$tool"; then
+            echo "::error::$tool is not available after installation"
+            exit 1
+          fi
+        done
         
         # Show versions
         echo "SwiftLint: $(swiftlint --version || echo 'not found')"
@@ -187,116 +195,54 @@ jobs:
         echo "result=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT
     
     # TEST PHASE
-    - name: Check iOS simulator availability
+    - name: Select iOS simulator
       id: simulator
+      shell: bash
       run: |
-        echo "Checking iOS simulator availability..."
-        
-        # Debug: Show available runtimes
         echo "Available runtimes:"
-        xcrun simctl list runtimes | grep -E "(iOS|watch|tv)" || echo "No iOS/watchOS/tvOS runtimes found"
-        
-        # Check if iOS runtimes are available and working
-        if xcrun simctl list runtimes | grep -q "iOS.*ready" && xcrun simctl list runtimes | grep -q "iOS.*18\."; then
-          echo "iOS runtimes found and ready, testing simulator creation..."
-          
-          # Generate unique simulator name to avoid conflicts
-          SIMULATOR_NAME="VibeTunnel-iOS-${GITHUB_RUN_ID}-${GITHUB_JOB}-${RANDOM}"
-          echo "Simulator name: $SIMULATOR_NAME"
-          
-          # Cleanup function
-          cleanup_simulator() {
-            local sim_id="$1"
-            if [ -n "$sim_id" ]; then
-              echo "Cleaning up simulator $sim_id..."
-              xcrun simctl shutdown "$sim_id" 2>/dev/null || true
-              xcrun simctl delete "$sim_id" 2>/dev/null || true
-            fi
-          }
-          
-          # Pre-cleanup: Remove old VibeTunnel test simulators from previous runs
-          echo "Cleaning up old test simulators..."
-          xcrun simctl list devices | grep "VibeTunnel-iOS-" | grep -E "\(.*\)" | \
-            sed -n 's/.*(\(.*\)).*/\1/p' | while read -r old_sim_id; do
-            cleanup_simulator "$old_sim_id"
-          done
-          
-          # Get the latest iOS runtime
-          RUNTIME=$(xcrun simctl list runtimes | grep "iOS" | tail -1 | awk '{print $NF}')
-          echo "Using runtime: $RUNTIME"
-        
-          # Try to create and boot a simulator - if this fails, fall back to Mac Catalyst
-          SIMULATOR_ID=""
-          SIMULATOR_SUCCESS=false
-          
-          for attempt in 1 2 3; do
-            echo "Testing simulator creation (attempt $attempt)..."
-            SIMULATOR_ID=$(xcrun simctl create "$SIMULATOR_NAME" "iPhone 15" "$RUNTIME" 2>/dev/null || \
-                          xcrun simctl create "$SIMULATOR_NAME" "com.apple.CoreSimulator.SimDeviceType.iPhone-15" "$RUNTIME" 2>/dev/null)
-            
-            if [ -n "$SIMULATOR_ID" ]; then
-              echo "Simulator created: $SIMULATOR_ID"
-              # Try to boot it
-              if xcrun simctl boot "$SIMULATOR_ID" 2>/dev/null; then
-                echo "Simulator booted successfully"
-                SIMULATOR_SUCCESS=true
-                break
-              else
-                echo "Simulator boot failed, cleaning up..."
-                cleanup_simulator "$SIMULATOR_ID"
-                SIMULATOR_ID=""
-              fi
-            fi
-            
-            echo "Simulator creation/boot failed, waiting before retry..."
-            sleep $((attempt * 2))
-          done
-          
-          if [ "$SIMULATOR_SUCCESS" = true ]; then
-            # Wait for simulator to be ready
-            echo "Waiting for simulator to be ready..."
-            for i in {1..30}; do
-              if xcrun simctl list devices | grep "$SIMULATOR_ID" | grep -q "Booted"; then
-                echo "Simulator is ready"
-                break
-              fi
-              sleep 1
-            done
-            
-            # Test if xcodebuild can actually use this simulator
-            echo "Testing xcodebuild with simulator..."
-            if xcodebuild -workspace ../VibeTunnel.xcworkspace \
-                -scheme VibeTunnel-iOS \
-                -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
-                -showdestinations 2>&1 | grep -q "iOS Simulator.*$SIMULATOR_ID"; then
-              echo "iOS simulator is working with xcodebuild, proceeding with simulator tests"
-              echo "SIMULATOR_ID=$SIMULATOR_ID" >> $GITHUB_ENV
-              echo "simulator_id=$SIMULATOR_ID" >> $GITHUB_OUTPUT
-              echo "test_platform=ios_simulator" >> $GITHUB_OUTPUT
-            else
-              echo "xcodebuild cannot use iOS simulator, falling back to Mac Catalyst"
-              echo "xcodebuild destination check output:"
-              xcodebuild -workspace ../VibeTunnel.xcworkspace \
-                -scheme VibeTunnel-iOS \
-                -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
-                -showdestinations 2>&1 | head -20
-              cleanup_simulator "$SIMULATOR_ID"
-              echo "SIMULATOR_ID=" >> $GITHUB_ENV
-              echo "simulator_id=" >> $GITHUB_OUTPUT
-              echo "test_platform=mac_catalyst" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "iOS simulator not working properly, will use Mac Catalyst for testing"
-            echo "SIMULATOR_ID=" >> $GITHUB_ENV
-            echo "simulator_id=" >> $GITHUB_OUTPUT
-            echo "test_platform=mac_catalyst" >> $GITHUB_OUTPUT
-          fi
-        else
-          echo "No iOS simulators available, will use Mac Catalyst for testing"
-          echo "SIMULATOR_ID=" >> $GITHUB_ENV
-          echo "simulator_id=" >> $GITHUB_OUTPUT
-          echo "test_platform=mac_catalyst" >> $GITHUB_OUTPUT
+        xcrun simctl list runtimes available
+
+        SIMULATOR=$(
+          xcrun simctl list devices available -j | jq -r '
+            [
+              .devices
+              | to_entries[]
+              | select(.key | startswith("com.apple.CoreSimulator.SimRuntime.iOS-"))
+              | .key as $runtime
+              | .value[]
+              | select(.isAvailable == true and (.name | startswith("iPhone")))
+              | {
+                  udid,
+                  name,
+                  runtime: $runtime,
+                  version: (
+                    $runtime
+                    | sub("com.apple.CoreSimulator.SimRuntime.iOS-"; "")
+                    | split("-")
+                    | map(tonumber)
+                  )
+                }
+            ]
+            | sort_by(.version)
+            | (last // empty)
+            | [.udid, .name, .runtime]
+            | @tsv
+          '
+        )
+
+        if [ -z "$SIMULATOR" ]; then
+          echo "::error::No available iPhone simulator found"
+          exit 1
         fi
+
+        IFS=$'\t' read -r SIMULATOR_ID SIMULATOR_NAME RUNTIME <<< "$SIMULATOR"
+        echo "Using $SIMULATOR_NAME ($RUNTIME): $SIMULATOR_ID"
+
+        xcrun simctl boot "$SIMULATOR_ID" 2>/dev/null || true
+        xcrun simctl bootstatus "$SIMULATOR_ID" -b
+
+        echo "SIMULATOR_ID=$SIMULATOR_ID" >> "$GITHUB_ENV"
+        echo "simulator_id=$SIMULATOR_ID" >> "$GITHUB_OUTPUT"
     
     - name: Run iOS tests
       env:
@@ -333,7 +279,6 @@ jobs:
         trap cleanup_and_exit EXIT
         
         echo "Running iOS tests using Swift Testing framework..."
-        echo "Test platform: ${{ steps.simulator.outputs.test_platform }}"
         echo "Simulator ID: $SIMULATOR_ID"
         
         # Only enable coverage on main branch
@@ -345,71 +290,38 @@ jobs:
         
         set -o pipefail
         
-        # Run tests based on available platform
-        if [[ "${{ steps.simulator.outputs.test_platform }}" == "ios_simulator" ]]; then
-          # Verify simulator is still booted
-          if ! xcrun simctl list devices | grep "$SIMULATOR_ID" | grep -q "Booted"; then
-            echo "::error::Simulator is not in booted state"
-            exit 1
-          fi
-          
-          echo "Running tests on iOS Simulator..."
-          xcodebuild test \
-            -workspace ../VibeTunnel.xcworkspace \
-            -scheme VibeTunnel-iOS \
-            -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
-            -resultBundlePath TestResults.xcresult \
-            -enableCodeCoverage $ENABLE_COVERAGE \
-            CODE_SIGN_IDENTITY="" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
-            COMPILER_INDEX_STORE_ENABLE=NO \
-            ACTOOL_IGNORE_VERSION_CHECK=1 \
-            IBTOOL_IGNORE_VERSION_CHECK=1 \
-            -quiet \
-            2>&1 || {
-              echo "::error::iOS simulator tests failed"
-              exit 1
-            }
-        else
-          echo "Running tests on Mac Catalyst..."
-          xcodebuild test \
-            -workspace ../VibeTunnel.xcworkspace \
-            -scheme VibeTunnel-iOS \
-            -destination "platform=macOS,variant=Mac Catalyst" \
-            -resultBundlePath TestResults.xcresult \
-            -enableCodeCoverage $ENABLE_COVERAGE \
-            CODE_SIGN_IDENTITY="" \
-            CODE_SIGNING_REQUIRED=NO \
-            CODE_SIGNING_ALLOWED=NO \
-            COMPILER_INDEX_STORE_ENABLE=NO \
-            ACTOOL_IGNORE_VERSION_CHECK=1 \
-            IBTOOL_IGNORE_VERSION_CHECK=1 \
-            -quiet \
-            2>&1 || {
-              echo "::error::Mac Catalyst tests failed"
-              exit 1
-            }
+        if ! xcrun simctl list devices | grep "$SIMULATOR_ID" | grep -q "Booted"; then
+          echo "::error::Simulator is not in booted state"
+          exit 1
         fi
+
+        echo "Running tests on iOS Simulator..."
+        xcodebuild test \
+          -workspace ../VibeTunnel.xcworkspace \
+          -scheme VibeTunnel-iOS \
+          -destination "platform=iOS Simulator,id=$SIMULATOR_ID" \
+          -resultBundlePath TestResults.xcresult \
+          -enableCodeCoverage $ENABLE_COVERAGE \
+          CODE_SIGN_IDENTITY="" \
+          CODE_SIGNING_REQUIRED=NO \
+          CODE_SIGNING_ALLOWED=NO \
+          COMPILER_INDEX_STORE_ENABLE=NO \
+          ACTOOL_IGNORE_VERSION_CHECK=1 \
+          IBTOOL_IGNORE_VERSION_CHECK=1 \
+          -quiet \
+          2>&1 || {
+            echo "::error::iOS simulator tests failed"
+            exit 1
+          }
         
         echo "Tests completed successfully"
 
-    # Add cleanup step that always runs
     - name: Cleanup simulator
       if: always() && steps.simulator.outputs.simulator_id != ''
       run: |
         SIMULATOR_ID="${{ steps.simulator.outputs.simulator_id }}"
         echo "Cleaning up simulator $SIMULATOR_ID..."
-        
-        # Shutdown simulator
         xcrun simctl shutdown "$SIMULATOR_ID" 2>/dev/null || true
-        
-        # Wait a bit for shutdown
-        sleep 2
-        
-        # Delete simulator
-        xcrun simctl delete "$SIMULATOR_ID" 2>/dev/null || true
-        
         echo "Simulator cleanup completed"
     
     # COVERAGE EXTRACTION

--- a/ios/VibeTunnel/Services/LivePreviewManager.swift
+++ b/ios/VibeTunnel/Services/LivePreviewManager.swift
@@ -1,6 +1,12 @@
 import Observation
 import SwiftUI
 
+@MainActor
+private final class LivePreviewThrottleState {
+    var lastUpdateTime: Date = .distantPast
+    var pendingSnapshot: BufferSnapshot?
+}
+
 /// Manages live terminal preview subscriptions for session cards.
 ///
 /// This service efficiently handles multiple WebSocket subscriptions
@@ -48,8 +54,7 @@ final class LivePreviewManager {
         }
 
         // Set up WebSocket subscription with throttling
-        var lastUpdateTime: Date = .distantPast
-        var pendingSnapshot: BufferSnapshot?
+        let throttleState = LivePreviewThrottleState()
 
         self.bufferClient.subscribe(to: sessionId) { [weak self, weak subscription] event in
             guard let self, let subscription else { return }
@@ -59,24 +64,24 @@ final class LivePreviewManager {
                 case let .bufferUpdate(snapshot):
                     // Throttle updates to prevent overwhelming the UI
                     let now = Date()
-                    if now.timeIntervalSince(lastUpdateTime) >= self.updateInterval {
+                    if now.timeIntervalSince(throttleState.lastUpdateTime) >= self.updateInterval {
                         subscription.latestSnapshot = snapshot
                         subscription.lastUpdate = now
-                        lastUpdateTime = now
-                        pendingSnapshot = nil
+                        throttleState.lastUpdateTime = now
+                        throttleState.pendingSnapshot = nil
                     } else {
                         // Store pending update
-                        pendingSnapshot = snapshot
+                        throttleState.pendingSnapshot = snapshot
 
                         // Schedule delayed update if not already scheduled
                         if self.updateTimers[sessionId] == nil {
                             let timer = Timer
                                 .scheduledTimer(withTimeInterval: self.updateInterval, repeats: false) { _ in
                                     Task { @MainActor in
-                                        if let pending = pendingSnapshot {
+                                        if let pending = throttleState.pendingSnapshot {
                                             subscription.latestSnapshot = pending
                                             subscription.lastUpdate = Date()
-                                            pendingSnapshot = nil
+                                            throttleState.pendingSnapshot = nil
                                         }
                                         self.updateTimers.removeValue(forKey: sessionId)
                                     }

--- a/ios/VibeTunnel/Services/TailscaleService.swift
+++ b/ios/VibeTunnel/Services/TailscaleService.swift
@@ -34,7 +34,8 @@ final class TailscaleService {
     private let logger = Logger(category: "TailscaleService")
 
     /// Keychain service for secure storage
-    private let keychainService = KeychainService()
+    private let keychainService: any KeychainServiceProtocol
+    private let automaticallyRefresh: Bool
 
     /// OAuth Client ID (stored securely in Keychain)
     var clientId: String? {
@@ -55,8 +56,10 @@ final class TailscaleService {
                 }
                 // Clear cached token when credentials change
                 clearCachedToken()
-                Task {
-                    await refreshStatus()
+                if automaticallyRefresh {
+                    Task {
+                        await refreshStatus()
+                    }
                 }
             } catch {
                 logger.error("Failed to save client ID to Keychain: \(error)")
@@ -83,8 +86,10 @@ final class TailscaleService {
                 }
                 // Clear cached token when credentials change
                 clearCachedToken()
-                Task {
-                    await refreshStatus()
+                if automaticallyRefresh {
+                    Task {
+                        await refreshStatus()
+                    }
                 }
             } catch {
                 logger.error("Failed to save client secret to Keychain: \(error)")
@@ -204,10 +209,18 @@ final class TailscaleService {
 
     // MARK: - Initialization
 
-    private init() {
-        setupNotifications()
-        Task {
-            await refreshStatus()
+    init(
+        keychainService: any KeychainServiceProtocol = KeychainService(),
+        automaticallyRefresh: Bool = true
+    ) {
+        self.keychainService = keychainService
+        self.automaticallyRefresh = automaticallyRefresh
+
+        if automaticallyRefresh {
+            setupNotifications()
+            Task {
+                await refreshStatus()
+            }
         }
     }
 

--- a/ios/VibeTunnelTests/Services/TailscaleDiscoveryServiceTests.swift
+++ b/ios/VibeTunnelTests/Services/TailscaleDiscoveryServiceTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import Testing
 @testable import VibeTunnel
 
-@Suite("TailscaleDiscoveryService Tests", .tags(.networking))
+@Suite("TailscaleDiscoveryService Tests", .serialized, .tags(.networking))
 struct TailscaleDiscoveryServiceTests {
     // MARK: - Discovery Process Tests
 

--- a/ios/VibeTunnelTests/Services/TailscaleServiceTests.swift
+++ b/ios/VibeTunnelTests/Services/TailscaleServiceTests.swift
@@ -4,13 +4,59 @@ import Testing
 
 @Suite("TailscaleService Tests", .tags(.networking))
 struct TailscaleServiceTests {
+    private final class InMemoryKeychainService: KeychainServiceProtocol {
+        private var storage: [String: String] = [:]
+
+        func savePassword(_ password: String, for profileId: UUID) throws {
+            self.storage[profileId.uuidString] = password
+        }
+
+        func getPassword(for profileId: UUID) throws -> String {
+            guard let password = storage[profileId.uuidString] else {
+                throw KeychainService.KeychainError.itemNotFound
+            }
+            return password
+        }
+
+        func deletePassword(for profileId: UUID) throws {
+            self.storage.removeValue(forKey: profileId.uuidString)
+        }
+
+        func deleteAllPasswords() throws {
+            self.storage.removeAll()
+        }
+
+        func savePassword(_ password: String, for key: String) throws {
+            self.storage[key] = password
+        }
+
+        func loadPassword(for key: String) throws -> String {
+            guard let password = storage[key] else {
+                throw KeychainService.KeychainError.itemNotFound
+            }
+            return password
+        }
+
+        func deletePassword(for key: String) throws {
+            self.storage.removeValue(forKey: key)
+        }
+    }
+
+    @MainActor
+    private func makeService() -> TailscaleService {
+        TailscaleService(
+            keychainService: InMemoryKeychainService(),
+            automaticallyRefresh: false
+        )
+    }
+
     // MARK: - Credential Management Tests
 
     @Test("Save and load OAuth credentials")
     @MainActor
     func saveAndLoadCredentials() async {
         // Arrange
-        let service = TailscaleService.shared
+        let service = self.makeService()
         service.clearCredentials()
 
         let testClientId = "k4cdcxxxxxxxx"
@@ -33,7 +79,7 @@ struct TailscaleServiceTests {
     @MainActor
     func testClearCredentials() async {
         // Arrange
-        let service = TailscaleService.shared
+        let service = self.makeService()
         service.organization = "k4cdcxxxxxxxx" // clientId
         service.apiKey = "tskey-client-k4cdcSQfcc11CNTRL-xxx" // clientSecret
 
@@ -52,7 +98,7 @@ struct TailscaleServiceTests {
     @MainActor
     func isConfiguredRequiresBothCredentials() {
         // Arrange
-        let service = TailscaleService.shared
+        let service = self.makeService()
         service.clearCredentials()
 
         // Assert - No credentials
@@ -80,7 +126,7 @@ struct TailscaleServiceTests {
     @MainActor
     func validClientCredentialFormats() async {
         // Arrange
-        let service = TailscaleService.shared
+        let service = self.makeService()
         service.clearCredentials()
 
         service.organization = "k4cdcxxxxxxxx" // Valid client ID
@@ -108,7 +154,7 @@ struct TailscaleServiceTests {
     @MainActor
     func invalidClientCredentialFormats(clientId: String, clientSecret: String) async {
         // Arrange
-        let service = TailscaleService.shared
+        let service = self.makeService()
         service.clearCredentials()
 
         service.organization = clientId
@@ -133,7 +179,7 @@ struct TailscaleServiceTests {
     @MainActor
     func missingClientIdError() async {
         // Arrange
-        let service = TailscaleService.shared
+        let service = self.makeService()
         service.clearCredentials()
 
         service.organization = nil // Missing client ID

--- a/ios/VibeTunnelTests/SessionListViewModelTests.swift
+++ b/ios/VibeTunnelTests/SessionListViewModelTests.swift
@@ -56,10 +56,12 @@ struct SessionListViewModelTests {
     }
 
     func createViewModel(
-        mockSessionService: MockSessionService = MockSessionService(),
-        mockNetworkMonitor: MockNetworkMonitor = MockNetworkMonitor())
+        mockSessionService: MockSessionService? = nil,
+        mockNetworkMonitor: MockNetworkMonitor? = nil)
         -> (SessionListViewModel, MockConnectionManager)
     {
+        let mockSessionService = mockSessionService ?? MockSessionService()
+        let mockNetworkMonitor = mockNetworkMonitor ?? MockNetworkMonitor()
         let mockConnectionManager = MockConnectionManager()
         let viewModel = TestableSessionListViewModel(
             sessionService: mockSessionService,


### PR DESCRIPTION
## Summary

- make live-preview throttling state explicitly main-actor isolated for Swift 6
- isolate Tailscale credential tests from the shared keychain and serialize tests that intentionally mutate shared discovery state
- move iOS CI from the unavailable self-hosted runner to GitHub-hosted macOS
- select Xcode 26.3 and a simulator runtime matching its active SDK
- cap the full job at 30 minutes and the test step at 15 minutes

This restores the iOS build and test path under Xcode 26 and prevents jobs from waiting indefinitely on the retired self-hosted runner. It is a prerequisite discovered while validating #593; the contributor change remains separate.

## Verification

- generic iOS Release build: passed with Swift 6
- full local simulator suite: 318 tests, 303 passed, 15 skipped, 0 failed
- hosted iOS CI: passed in 9m3s
- hosted test execution: passed in approximately 4m26s
- focused SwiftLint: 0 violations
- `git diff --check`: passed
- autoreview: no actionable findings

Hosted proof: https://github.com/amantus-ai/vibetunnel/actions/runs/27373186724/job/80890551254

SwiftFormat still reports the repository's existing baseline drift in unchanged code; the workflow records that check without failing the job.
