### PR TITLE
fix(mac): decode session response timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Decode macOS session-creation timestamps in the server's ISO 8601 wire format, preventing a false error after the terminal opens (via [@apex-skyner](https://github.com/apex-skyner) and [@yashiels](https://github.com/yashiels)) (#635)
 - Allow the macOS app to bind the server to validated custom IPv4 or IPv6 addresses, including dual-stack `::`, with correct IPv6 dashboard URLs (via [@waxzce](https://github.com/waxzce)) (#576)
 - Restore iOS terminal rendering, preserve output received during Ghostty startup, and stream stdout for immediate input echo (via [@waxzce](https://github.com/waxzce)) (#577)
 - Keep Korean and other CJK IME composition events intact and position desktop candidate windows at the terminal cursor (via [@jiangwenhan](https://github.com/jiangwenhan)) (#617)
@@ -44,6 +45,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
+- Thanks [@apex-skyner](https://github.com/apex-skyner) and [@yashiels](https://github.com/yashiels) for identifying the macOS session-creation timestamp decoding failure.
 - Thanks [@waxzce](https://github.com/waxzce) for adding configurable IPv4/IPv6 server binding and restoring reliable iOS terminal rendering and input echo.
 - Thanks [@jiangwenhan](https://github.com/jiangwenhan) for improving Korean and CJK terminal input.
 - Thanks [@Tyoneva](https://github.com/Tyoneva) for improving web app installation and icon support.

--- a/mac/VibeTunnel/Core/Models/TunnelSession.swift
+++ b/mac/VibeTunnel/Core/Models/TunnelSession.swift
@@ -52,6 +52,39 @@ public struct CreateSessionResponse: Codable, Sendable {
         self.sessionId = sessionId
         self.createdAt = createdAt
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionId
+        case createdAt
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.sessionId = try container.decode(String.self, forKey: .sessionId)
+
+        let createdAtValue = try container.decode(String.self, forKey: .createdAt)
+        let fractionalFormat = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
+        let wholeSecondFormat = Date.ISO8601FormatStyle(includingFractionalSeconds: false)
+
+        if let date = try? fractionalFormat.parse(createdAtValue) {
+            self.createdAt = date
+        } else if let date = try? wholeSecondFormat.parse(createdAtValue) {
+            self.createdAt = date
+        } else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .createdAt,
+                in: container,
+                debugDescription: "Expected an ISO 8601 timestamp")
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.sessionId, forKey: .sessionId)
+        try container.encode(
+            self.createdAt.formatted(Date.ISO8601FormatStyle(includingFractionalSeconds: true)),
+            forKey: .createdAt)
+    }
 }
 
 /// Command execution request.

--- a/mac/VibeTunnelTests/TunnelSessionTests.swift
+++ b/mac/VibeTunnelTests/TunnelSessionTests.swift
@@ -91,19 +91,48 @@ struct TunnelSessionTests {
 
     // MARK: - CreateSessionResponse Tests
 
-    // Simple type but worth testing Codable with Date precision
+    @Test
+    func createSessionResponseDecodesServerTimestampWithFractionalSeconds() throws {
+        let data = Data(#"{"sessionId":"response-test-456","createdAt":"2026-06-12T06:04:18.721Z"}"#.utf8)
+        let response = try JSONDecoder().decode(CreateSessionResponse.self, from: data)
+        let expectedDate = try Date.ISO8601FormatStyle(includingFractionalSeconds: true)
+            .parse("2026-06-12T06:04:18.721Z")
+
+        #expect(response.sessionId == "response-test-456")
+        #expect(response.createdAt == expectedDate)
+    }
 
     @Test
-    func createsessionresponseHandlesDateEncodingCorrectly() throws {
-        let originalResponse = CreateSessionResponse(
-            sessionId: "response-test-456",
-            createdAt: Date())
+    func createSessionResponseDecodesServerTimestampWithoutFractionalSeconds() throws {
+        let data = Data(#"{"sessionId":"response-test-456","createdAt":"2026-06-12T06:04:18Z"}"#.utf8)
+        let response = try JSONDecoder().decode(CreateSessionResponse.self, from: data)
+        let expectedDate = try Date.ISO8601FormatStyle(includingFractionalSeconds: false)
+            .parse("2026-06-12T06:04:18Z")
 
-        let data = try JSONEncoder().encode(originalResponse)
-        let decodedResponse = try JSONDecoder().decode(CreateSessionResponse.self, from: data)
+        #expect(response.createdAt == expectedDate)
+    }
 
-        #expect(originalResponse.sessionId == decodedResponse.sessionId)
-        // Date encoding/decoding can lose some precision
-        #expect(abs(originalResponse.createdAt.timeIntervalSince(decodedResponse.createdAt)) < 0.001)
+    @Test
+    func createSessionResponseRejectsInvalidTimestamp() {
+        let data = Data(#"{"sessionId":"response-test-456","createdAt":"not-a-date"}"#.utf8)
+
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(CreateSessionResponse.self, from: data)
+        }
+    }
+
+    @Test
+    func createSessionResponseEncodesServerTimestampFormat() throws {
+        let date = try Date.ISO8601FormatStyle(includingFractionalSeconds: true)
+            .parse("2026-06-12T06:04:18.721Z")
+        let response = CreateSessionResponse(sessionId: "response-test-456", createdAt: date)
+        let data = try JSONEncoder().encode(response)
+        let payload = try #require(JSONSerialization.jsonObject(with: data) as? [String: String])
+        let createdAtValue = try #require(payload["createdAt"])
+        let encodedDate = try Date.ISO8601FormatStyle(includingFractionalSeconds: true).parse(createdAtValue)
+
+        #expect(payload["sessionId"] == "response-test-456")
+        #expect(createdAtValue.contains("."))
+        #expect(abs(date.timeIntervalSince(encodedDate)) < 0.002)
     }
 }


### PR DESCRIPTION
## Summary

- decode session-creation timestamps using the server response model's ISO 8601 wire format
- accept fractional-second and whole-second timestamps while rejecting malformed values
- keep the generic `ServerManager.performRequest` decoder unchanged
- add focused Codable regression coverage and contributor credit

Closes #635.

This follows up the incomplete earlier fix in #500 and preserves credit from #636.

## Proof

- reproduced on current main with the exact CI-built macOS app/server: native Terminal session creation returned a millisecond ISO timestamp that the existing bare decoder rejected
- exact patched Xcode-built app opened a native Terminal window, completed the harmless session, consumed the fractional timestamp, and dismissed the form without an error alert
- malformed timestamps remain decoding errors in focused tests

## Validation

- focused `TunnelSessionTests`
- full macOS test suite
- macOS SwiftFormat and SwiftLint
- documentation validation
- Zig 0.15.2 build
- web build, lint, TypeScript checks, formatting, client coverage, and server coverage
- autoreview: no actionable findings
- Public Model Identifier Gate: PASS