### PR TITLE
test(web): cover large paste backpressure

### DIFF
--- a/web/src/test/playwright/specs/keyboard-input.spec.ts
+++ b/web/src/test/playwright/specs/keyboard-input.spec.ts
@@ -94,6 +94,7 @@ test.describe('Keyboard Input Tests', () => {
       { length: 600 },
       (_, index) => `line-${String(index + 1).padStart(4, '0')}`
     ).join('\n')}\n`;
+    // Dispatch on the rendered paste target to exercise the app handler deterministically.
     await page.evaluate((text) => {
       const pasteInput = document.querySelector(
         'vibe-terminal .terminal-paste-input'

--- a/web/src/test/playwright/specs/keyboard-input.spec.ts
+++ b/web/src/test/playwright/specs/keyboard-input.spec.ts
@@ -78,6 +78,46 @@ test.describe('Keyboard Input Tests', () => {
     await sessionViewPage.sendInterrupt();
   });
 
+  test('should handle a 600-line paste without hanging', async ({ page, sessionViewPage }) => {
+    await sessionManager.createTrackedSession(
+      sessionManager.generateSessionName('keyboard-large-paste'),
+      false,
+      'bash --noprofile --norc'
+    );
+
+    await sessionViewPage.waitForTerminalReady();
+    await sessionViewPage.typeCommand(
+      `python3 -c 'import sys; data=sys.stdin.read(); print("VT_PASTE_LINES="+str(len(data.splitlines())), flush=True)'`
+    );
+
+    const pastedText = `${Array.from(
+      { length: 600 },
+      (_, index) => `line-${String(index + 1).padStart(4, '0')}`
+    ).join('\n')}\n`;
+    await page.evaluate((text) => {
+      const pasteInput = document.querySelector(
+        'vibe-terminal .terminal-paste-input'
+      ) as HTMLTextAreaElement | null;
+      if (!pasteInput) throw new Error('Terminal paste input is unavailable');
+
+      const clipboardData = new DataTransfer();
+      clipboardData.setData('text/plain', text);
+      pasteInput.dispatchEvent(
+        new ClipboardEvent('paste', {
+          clipboardData,
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    }, pastedText);
+    await page.keyboard.press('Control+d');
+
+    await sessionViewPage.waitForOutput('VT_PASTE_LINES=600', { timeout: 15000 });
+    await sessionViewPage.typeCommand('echo "VT_STILL_RESPONSIVE"');
+    await sessionViewPage.waitForOutput('VT_STILL_RESPONSIVE', { timeout: 5000 });
+    await sessionViewPage.typeCommand('exit');
+  });
+
   test('should handle arrow key editing', async ({ page, sessionViewPage }) => {
     await sessionManager.createTrackedSession(
       sessionManager.generateSessionName('keyboard-arrows'),


### PR DESCRIPTION
## Summary

- add a deterministic Playwright regression for pasting 600 lines into a live terminal
- verify the PTY receives the exact line count
- verify the same shell accepts a follow-up command after the large paste

## Proof

- live existing-Chrome test against the exact built server: 600 lines received, follow-up command succeeded, server remained healthy
- `pnpm run check`
- focused Playwright regression: 1 passed
- structured autoreview: no actionable findings

Test-only change; no changelog entry required.

Closes #76
