### PR TITLE
fix(mac): recover from Ghostty permission failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Show the Accessibility recovery flow when Ghostty or another terminal rejects System Events keystrokes (#625)
 - Decode macOS session-creation timestamps in the server's ISO 8601 wire format, preventing a false error after the terminal opens (via [@apex-skyner](https://github.com/apex-skyner) and [@yashiels](https://github.com/yashiels)) (#635)
 - Allow the macOS app to bind the server to validated custom IPv4 or IPv6 addresses, including dual-stack `::`, with correct IPv6 dashboard URLs (via [@waxzce](https://github.com/waxzce)) (#576)
 - Restore iOS terminal rendering, preserve output received during Ghostty startup, and stream stdout for immediate input echo (via [@waxzce](https://github.com/waxzce)) (#577)

--- a/mac/VibeTunnel/Core/Services/AppleScriptExecutor.swift
+++ b/mac/VibeTunnel/Core/Services/AppleScriptExecutor.swift
@@ -234,6 +234,8 @@ enum AppleScriptError: LocalizedError {
                 switch code {
                 case -1743:
                     return "User permission is required to control other applications."
+                case 1002, -25211, -1719:
+                    return "Accessibility permission is required to send keystrokes."
                 case -1728:
                     return "The application is not running or cannot be controlled."
                 case -1708:
@@ -262,8 +264,20 @@ enum AppleScriptError: LocalizedError {
         }
     }
 
+    /// Checks if this error represents a denied System Events keystroke.
+    var isAccessibilityPermissionError: Bool {
+        guard case let .executionFailed(_, errorCode) = self else {
+            return false
+        }
+        return errorCode == 1002 || errorCode == -25211 || errorCode == -1719
+    }
+
     /// Converts this error to a TerminalLauncherError if appropriate
     func toTerminalLauncherError() -> TerminalLauncherError {
+        if self.isAccessibilityPermissionError {
+            return .accessibilityPermissionDenied
+        }
+
         if self.isPermissionError {
             return .appleScriptPermissionDenied
         }

--- a/mac/VibeTunnel/Utilities/TerminalLauncher.swift
+++ b/mac/VibeTunnel/Utilities/TerminalLauncher.swift
@@ -221,16 +221,8 @@ enum Terminal: String, CaseIterable {
             return """
             tell application "\(self.processName)"
                 activate
-                -- Wait longer if Ghostty wasn't already running
-                delay 0.2
-                set windowCount to 0
-                try
-                    set windowCount to count of windows
-                end try
-                if windowCount = 0 then
-                    -- No windows open, need extra time for UI initialization
-                    delay \(startupDelay)
-                end if
+                -- Ghostty's AppleScript window query can hang, so use process state for startup timing.
+                delay \(startupDelay)
                 tell application "System Events"
                     tell process "\(self.processName)"
                         -- Create new window

--- a/mac/VibeTunnelTests/TerminalLaunchTests.swift
+++ b/mac/VibeTunnelTests/TerminalLaunchTests.swift
@@ -126,6 +126,51 @@ struct TerminalLaunchTests {
         #expect(Bool(true)) // No-throw test
     }
 
+    @Test(arguments: [1002, -25211, -1719])
+    func keystrokePermissionErrorsRequireAccessibility(errorCode: Int) {
+        let error = AppleScriptError.executionFailed(
+            message: "System Events is not allowed to send keystrokes",
+            errorCode: errorCode)
+
+        #expect(error.isAccessibilityPermissionError)
+        #expect(error.failureReason == "Accessibility permission is required to send keystrokes.")
+
+        guard case .accessibilityPermissionDenied = error.toTerminalLauncherError() else {
+            Issue.record("Expected accessibility permission error for AppleScript code \(errorCode)")
+            return
+        }
+    }
+
+    @Test
+    func automationPermissionErrorRemainsDistinct() {
+        let error = AppleScriptError.executionFailed(
+            message: "Not authorized to send Apple events",
+            errorCode: -1743)
+
+        #expect(error.isPermissionError)
+        #expect(!error.isAccessibilityPermissionError)
+
+        guard case .appleScriptPermissionDenied = error.toTerminalLauncherError() else {
+            Issue.record("Expected automation permission error")
+            return
+        }
+    }
+
+    @Test
+    func ghosttyLaunchDoesNotQueryAppleScriptWindows() {
+        let config = TerminalLaunchConfig(
+            command: "printf 'VibeTunnel Ghostty test'",
+            workingDirectory: nil,
+            terminal: .ghostty)
+        let script = Terminal.ghostty.unifiedAppleScript(for: config)
+
+        #expect(!script.contains("count of windows"))
+        #expect(script.contains("tell application \"System Events\""))
+        #expect(script.contains("keystroke \"n\" using {command down}"))
+        #expect(script.contains("keystroke \"v\" using {command down}"))
+        #expect(script.contains("key code 36"))
+    }
+
     // MARK: - Script File Tests
 
     @Test


### PR DESCRIPTION
Fixes #625

## Summary

- avoid Ghostty's non-responsive AppleScript window-count query while retaining warm/cold startup timing
- classify System Events keystroke denials as Accessibility failures
- preserve the distinct Automation permission recovery path

## Verification

- SwiftFormat and SwiftLint: clean
- focused macOS tests: 10 passed, 0 failed
- full macOS tests: 242 passed, 16 skipped, 0 failed
- exact built macOS app: selected Ghostty, reproduced the reported keystroke permission failure, and confirmed the request returns promptly instead of hanging
- exact built macOS app UI: Advanced > Test shows the Accessibility Permission Required alert with Ghostty-specific System Settings guidance
- autoreview: no actionable findings

## Public Model Identifier Gate

PASS. The exact diff, changed tests, focused/full test output, and public proof contain no model identifiers. No workflows, fixtures, snapshots, or generated repository artifacts changed.