### PR TITLE
ci: stabilize Node test result reporting

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -75,61 +75,77 @@ jobs:
       run: |
         # Create a temporary directory for outputs
         mkdir -p ci-outputs
-        
+
+        run_check() {
+          local label="$1"
+          local output_file="$2"
+          local exit_file="$3"
+          shift 3
+
+          echo "Starting ${label}..."
+          local result=0
+          "$@" > "$output_file" 2>&1 || result=$?
+          echo "$result" > "$exit_file"
+          echo "${label} completed"
+        }
+
         # Run format, lint, typecheck, and audit in parallel (these don't depend on build)
-        (
-          echo "Starting format check..."
-          pnpm run format:check > ci-outputs/format-output.txt 2>&1
-          echo $? > ci-outputs/format-exit-code.txt
-          echo "Format check completed"
-        ) &
-        
-        (
-          echo "Starting lint..."
-          pnpm run lint:biome > ci-outputs/lint-output.txt 2>&1
-          echo $? > ci-outputs/lint-exit-code.txt
-          echo "Lint completed"
-        ) &
-        
-        (
-          echo "Starting type check..."
-          pnpm run typecheck > ci-outputs/typecheck-output.txt 2>&1
-          echo $? > ci-outputs/typecheck-exit-code.txt
-          echo "Type check completed"
-        ) &
-        
+        run_check \
+          "format check" \
+          ci-outputs/format-output.txt \
+          ci-outputs/format-exit-code.txt \
+          pnpm run format:check &
+        run_check \
+          "lint" \
+          ci-outputs/lint-output.txt \
+          ci-outputs/lint-exit-code.txt \
+          pnpm run lint:biome &
+        run_check \
+          "type check" \
+          ci-outputs/typecheck-output.txt \
+          ci-outputs/typecheck-exit-code.txt \
+          pnpm run typecheck &
+
+        # Security audit is informational until the repository adopts an enforcement policy.
         (
           echo "Starting security audit..."
           pnpm audit --audit-level=moderate > ci-outputs/audit-output.txt 2>&1 || true
-          echo 0 > ci-outputs/audit-exit-code.txt  # Don't fail on audit
-          echo "Audit completed"
+          echo 0 > ci-outputs/audit-exit-code.txt
+          echo "Security audit completed"
         ) &
-        
+
         # Wait for parallel checks
         wait
-        
+
         # Run build (must complete before tests)
         echo "Starting build..."
-        export ESBUILD_MAX_WORKERS=$(nproc)
-        pnpm run build:ci > ci-outputs/build-output.txt 2>&1
-        echo $? > ci-outputs/build-exit-code.txt
+        ESBUILD_MAX_WORKERS=$(nproc)
+        export ESBUILD_MAX_WORKERS
+        BUILD_EXIT=0
+        pnpm run build:ci > ci-outputs/build-output.txt 2>&1 || BUILD_EXIT=$?
+        echo "$BUILD_EXIT" > ci-outputs/build-exit-code.txt
         echo "Build completed"
-        
-        # Run tests after build completes
-        echo "Starting tests..."
-        # Run client and server tests sequentially to avoid conflicts
-        pnpm run test:client:coverage > ci-outputs/test-client-output.txt 2>&1
-        CLIENT_EXIT=$?
-        pnpm run test:server:coverage > ci-outputs/test-server-output.txt 2>&1
-        SERVER_EXIT=$?
-        # Return non-zero if either test failed
-        if [ $CLIENT_EXIT -ne 0 ] || [ $SERVER_EXIT -ne 0 ]; then
+
+        if [ "$BUILD_EXIT" -ne 0 ]; then
+          echo "Client tests skipped because the build failed." > ci-outputs/test-client-output.txt
+          echo "Server tests skipped because the build failed." > ci-outputs/test-server-output.txt
           echo 1 > ci-outputs/test-exit-code.txt
         else
-          echo 0 > ci-outputs/test-exit-code.txt
+          # Run client and server tests sequentially to avoid conflicts.
+          echo "Starting tests..."
+          CLIENT_EXIT=0
+          SERVER_EXIT=0
+          pnpm run test:client:coverage > ci-outputs/test-client-output.txt 2>&1 || CLIENT_EXIT=$?
+          pnpm run test:server:coverage > ci-outputs/test-server-output.txt 2>&1 || SERVER_EXIT=$?
+
+          if [ "$CLIENT_EXIT" -ne 0 ] || [ "$SERVER_EXIT" -ne 0 ]; then
+            echo 1 > ci-outputs/test-exit-code.txt
+          else
+            echo 0 > ci-outputs/test-exit-code.txt
+          fi
+          echo "Tests completed"
         fi
-        echo "Tests completed"
-        
+
         echo "All checks completed"
 
     # Process results

--- a/web/src/test/e2e/vt-wrapper-extra.e2e.test.ts
+++ b/web/src/test/e2e/vt-wrapper-extra.e2e.test.ts
@@ -128,7 +128,11 @@ describe('vt wrapper extra flows', () => {
     const marker = `vt-alias-ok-${Date.now()}`;
     const vtPath = path.join(process.cwd(), 'bin', 'vt');
 
-    writeFileSync(path.join(homeDir, '.bashrc'), `alias vttest='printf "${marker}\\n"'\n`, 'utf-8');
+    writeFileSync(
+      path.join(homeDir, '.bashrc'),
+      `alias vttest='printf "${marker}\\n"; sleep 1'\n`,
+      'utf-8'
+    );
 
     const before = new Set(listSessionDirs(controlDir));
 
@@ -147,7 +151,7 @@ describe('vt wrapper extra flows', () => {
     const stderr: string[] = [];
     child.stderr?.on('data', (data) => stderr.push(data.toString()));
 
-    await new Promise<void>((resolve, reject) => {
+    const exitPromise = new Promise<void>((resolve, reject) => {
       child.on('error', (error) =>
         reject(error instanceof Error ? error : new Error(String(error)))
       );
@@ -165,7 +169,7 @@ describe('vt wrapper extra flows', () => {
     }
 
     const sessionId = await waitForNewSessionDir(controlDir, before);
-    await waitForSessionText(server.port, sessionId, marker);
+    await Promise.all([waitForSessionText(server.port, sessionId, marker), exitPromise]);
   }, 20000);
 
   it('prefers client-resolved binary paths over server PATH', async () => {


### PR DESCRIPTION
## Summary
- preserve every Node CI check result under GitHub Actions `bash -e` semantics
- skip coverage tests cleanly when the prerequisite build fails while retaining diagnostics
- keep the Bash alias E2E session alive long enough to verify output before wrapper exit

## Verification
- 20 consecutive real server/wrapper alias E2E runs passed
- server coverage suite with the CI runner shape: 582 passed, 75 skipped
- client coverage suite with the CI runner shape: 678 passed
- CI-pinned Zig build completed successfully
- format, lint, typecheck, workflow syntax, and shell checks passed
- exact workflow harness passed success, server-test failure, and build-failure cases under `bash -e -o pipefail`
- autoreview clean with no actionable findings

Fixes the Node failure exposed by [main run 27410756923](https://github.com/amantus-ai/vibetunnel/actions/runs/27410756923).
