### PR TITLE
fix(mac): open current app notification settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Open the current macOS app build's notification settings, including debug/ad-hoc bundle variants, and fall back to the general Notifications pane when needed.
 - Show the Accessibility recovery flow when Ghostty or another terminal rejects System Events keystrokes (#625)
 - Decode macOS session-creation timestamps in the server's ISO 8601 wire format, preventing a false error after the terminal opens (via [@apex-skyner](https://github.com/apex-skyner) and [@yashiels](https://github.com/yashiels)) (#635)
 - Allow the macOS app to bind the server to validated custom IPv4 or IPv6 addresses, including dual-stack `::`, with correct IPv6 dashboard URLs (via [@waxzce](https://github.com/waxzce)) (#576)

--- a/mac/VibeTunnel/Core/Services/NotificationService.swift
+++ b/mac/VibeTunnel/Core/Services/NotificationService.swift
@@ -390,15 +390,40 @@ final class NotificationService: NSObject, @preconcurrency UNUserNotificationCen
 
     /// Open System Settings to the Notifications pane
     func openNotificationSettings() {
-        // Try to open directly to the app's settings
-        if let url =
-            URL(
-                string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension?id=sh.vibetunnel.vibetunnel")
-        {
-            NSWorkspace.shared.open(url)
-        } else if let url = URL(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension") {
-            NSWorkspace.shared.open(url)
+        Self.openNotificationSettings(bundleIdentifier: Bundle.main.bundleIdentifier) {
+            NSWorkspace.shared.open($0)
         }
+    }
+
+    static func openNotificationSettings(
+        bundleIdentifier: String?,
+        openURL: (URL) -> Bool)
+    {
+        if let bundleIdentifier,
+           !bundleIdentifier.isEmpty,
+           let appURL = notificationSettingsURL(bundleIdentifier: bundleIdentifier),
+           openURL(appURL)
+        {
+            return
+        }
+
+        if let settingsURL = Self.notificationSettingsURL(bundleIdentifier: nil) {
+            _ = openURL(settingsURL)
+        }
+    }
+
+    static func notificationSettingsURL(bundleIdentifier: String?) -> URL? {
+        guard var components =
+            URLComponents(string: "x-apple.systempreferences:com.apple.Notifications-Settings.extension")
+        else {
+            return nil
+        }
+
+        if let bundleIdentifier, !bundleIdentifier.isEmpty {
+            components.queryItems = [URLQueryItem(name: "id", value: bundleIdentifier)]
+        }
+
+        return components.url
     }
 
     /// Update notification preferences

--- a/mac/VibeTunnelTests/NotificationServiceTests.swift
+++ b/mac/VibeTunnelTests/NotificationServiceTests.swift
@@ -24,8 +24,14 @@ struct NotificationServiceTests {
             return openedURLs.count == 2
         }
 
+        let appURLComponents = openedURLs.first.flatMap {
+            URLComponents(url: $0, resolvingAgainstBaseURL: false)
+        }
+
         #expect(openedURLs.count == 2)
-        #expect(openedURLs.first?.query?.contains("id=sh.vibetunnel.vibetunnel.debug") == true)
+        #expect(
+            appURLComponents?.queryItems?.first(where: { $0.name == "id" })?.value ==
+                "sh.vibetunnel.vibetunnel.debug")
         #expect(openedURLs.last?.query == nil)
     }
 
@@ -39,8 +45,14 @@ struct NotificationServiceTests {
             return true
         }
 
+        let appURLComponents = openedURLs.first.flatMap {
+            URLComponents(url: $0, resolvingAgainstBaseURL: false)
+        }
+
         #expect(openedURLs.count == 1)
-        #expect(openedURLs.first?.query?.contains("id=sh.vibetunnel.vibetunnel") == true)
+        #expect(
+            appURLComponents?.queryItems?.first(where: { $0.name == "id" })?.value ==
+                "sh.vibetunnel.vibetunnel")
     }
 
     @Test

--- a/mac/VibeTunnelTests/NotificationServiceTests.swift
+++ b/mac/VibeTunnelTests/NotificationServiceTests.swift
@@ -6,6 +6,45 @@ import UserNotifications
 struct NotificationServiceTests {
     @Test
     @MainActor
+    func notificationSettingsURLUsesCurrentBundleIdentifier() {
+        let bundleIdentifier = "sh.vibetunnel.vibetunnel.debug"
+        let url = NotificationService.notificationSettingsURL(bundleIdentifier: bundleIdentifier)
+        let components = url.flatMap { URLComponents(url: $0, resolvingAgainstBaseURL: false) }
+
+        #expect(components?.queryItems?.first(where: { $0.name == "id" })?.value == bundleIdentifier)
+    }
+
+    @Test
+    @MainActor
+    func notificationSettingsOpenFallsBackToGeneralPane() {
+        var openedURLs = [URL]()
+
+        NotificationService.openNotificationSettings(bundleIdentifier: "sh.vibetunnel.vibetunnel.debug") { url in
+            openedURLs.append(url)
+            return openedURLs.count == 2
+        }
+
+        #expect(openedURLs.count == 2)
+        #expect(openedURLs.first?.query?.contains("id=sh.vibetunnel.vibetunnel.debug") == true)
+        #expect(openedURLs.last?.query == nil)
+    }
+
+    @Test
+    @MainActor
+    func notificationSettingsOpenStopsAfterDirectSuccess() {
+        var openedURLs = [URL]()
+
+        NotificationService.openNotificationSettings(bundleIdentifier: "sh.vibetunnel.vibetunnel") { url in
+            openedURLs.append(url)
+            return true
+        }
+
+        #expect(openedURLs.count == 1)
+        #expect(openedURLs.first?.query?.contains("id=sh.vibetunnel.vibetunnel") == true)
+    }
+
+    @Test
+    @MainActor
     func notificationPreferencesAreLoadedCorrectlyFromConfigmanager() {
         // This test verifies that NotificationPreferences correctly loads values from ConfigManager
         let configManager = ConfigManager.shared


### PR DESCRIPTION
## Summary

- derive the macOS Notifications settings URL from the running app's bundle identifier instead of the release bundle identifier
- encode the bundle identifier with `URLComponents`
- fall back to the general Notifications pane when the app-specific deep link is unavailable or rejected
- add focused regression coverage and a changelog entry

## Verification

- focused `NotificationServiceTests`: 13 passed
- full macOS test suite: 245 passed, 16 skipped, 0 failed
- SwiftFormat: clean for app and test sources
- SwiftLint: clean for changed files; full lint has only three pre-existing warnings in an unrelated file
- `git diff --check`: clean
- local autoreview: no actionable findings

## Live proof

Built the exact branch as a signed debug app and used its Notifications UI to invoke **Open System Settings**. macOS accepted the action and opened the Notifications settings pane. This host did not create an app-specific notification entry for the out-of-tree debug bundle, so the dynamic identifier path and failed-open fallback are additionally covered by focused tests.
