### PR TITLE
fix(ci): update existing lint report sections

### DIFF
--- a/.github/actions/lint-reporter/action.yml
+++ b/.github/actions/lint-reporter/action.yml
@@ -52,27 +52,10 @@ runs:
           const result = ${{ toJSON(inputs.lint-result) }};
           const output = ${{ toJSON(inputs.lint-output) }};
           const existingCommentId = '${{ steps.fc.outputs.comment-id }}';
-          
-          const icon = result === 'success' ? '✅' : '❌';
-          const status = result === 'success' ? 'Passed' : 'Failed';
-          
-          // Create section content
-          let sectionContent = `### ${title} ${icon} **Status**: ${status}\n`;
-          
-          // Special formatting for coverage reports
-          if (title.includes('Coverage')) {
-            if (result === 'success' || (output && output.includes('%'))) {
-              // Show coverage metrics directly (not in details)
-              sectionContent += `\n${output}\n`;
-            } else if (output && output !== 'No output') {
-              sectionContent += `\n<details>\n<summary>Click to see details</summary>\n\n\`\`\`\n${output}\n\`\`\`\n\n</details>\n`;
-            }
-          } else {
-            // Regular lint output
-            if (result !== 'success' && output && output !== 'No output') {
-              sectionContent += `\n<details>\n<summary>Click to see details</summary>\n\n\`\`\`\n${output}\n\`\`\`\n\n</details>\n`;
-            }
-          }
+          const { renderSection, upsertSection } = require(
+            `${process.env.GITHUB_WORKSPACE}/.github/actions/lint-reporter/comment-body.cjs`
+          );
+          const sectionContent = renderSection({ title, result, output });
           
           let body;
           if (existingCommentId) {
@@ -84,37 +67,7 @@ runs:
             });
             
             const existingBody = comment.body;
-            const sectionHeader = `### ${title}`;
-            const nextSectionRegex = /^###\s/m;
-            
-            if (existingBody.includes(sectionHeader)) {
-              // Replace existing section
-              const lines = existingBody.split('\n');
-              let inSection = false;
-              let newLines = [];
-              
-              for (let i = 0; i < lines.length; i++) {
-                if (lines[i] === sectionHeader) {
-                  inSection = true;
-                  // Add the new section content
-                  newLines.push(...sectionContent.trim().split('\n'));
-                  continue;
-                }
-                
-                if (inSection && lines[i].match(nextSectionRegex)) {
-                  inSection = false;
-                }
-                
-                if (!inSection) {
-                  newLines.push(lines[i]);
-                }
-              }
-              
-              body = newLines.join('\n');
-            } else {
-              // Add new section at the end
-              body = existingBody + '\n\n' + sectionContent;
-            }
+            body = upsertSection(existingBody, title, sectionContent);
           } else {
             // Create new comment
             body = `## 🔍 Code Quality Report\n<!-- lint-results -->\n\nThis comment is automatically updated with linting results from CI.\n\n${sectionContent}`;

--- a/.github/actions/lint-reporter/comment-body.cjs
+++ b/.github/actions/lint-reporter/comment-body.cjs
@@ -1,0 +1,69 @@
+function renderDetails(output) {
+  return `<details>
+<summary>Click to see details</summary>
+
+\`\`\`
+${output}
+\`\`\`
+
+</details>`;
+}
+
+function renderSection({ title, result, output }) {
+  const icon = result === 'success' ? '✅' : '❌';
+  const status = result === 'success' ? 'Passed' : 'Failed';
+  let section = `### ${title} ${icon} **Status**: ${status}`;
+
+  if (title.includes('Coverage')) {
+    if (result === 'success' || (output && output.includes('%'))) {
+      section += `\n\n${output}`;
+    } else if (output && output !== 'No output') {
+      section += `\n\n${renderDetails(output)}`;
+    }
+  } else if (result !== 'success' && output && output !== 'No output') {
+    section += `\n\n${renderDetails(output)}`;
+  }
+
+  return section;
+}
+
+function isSectionHeading(line, title) {
+  const sectionHeader = `### ${title}`;
+  return (
+    line === sectionHeader ||
+    line.replace(/ [✅❌] \*\*Status\*\*: (Passed|Failed)$/, '') === sectionHeader
+  );
+}
+
+function isReporterHeading(line) {
+  return /^### .+ [✅❌] \*\*Status\*\*: (Passed|Failed)$/.test(line);
+}
+
+function upsertSection(existingBody, title, sectionContent) {
+  const lines = existingBody.split('\n');
+  const sectionStart = lines.findIndex((line) => isSectionHeading(line, title));
+
+  if (sectionStart === -1) {
+    return `${existingBody.trimEnd()}\n\n${sectionContent}`;
+  }
+
+  let sectionEnd = lines.length;
+  for (let index = sectionStart + 1; index < lines.length; index += 1) {
+    if (isReporterHeading(lines[index])) {
+      sectionEnd = index;
+      break;
+    }
+  }
+
+  const replacement = sectionContent.trimEnd().split('\n');
+  if (sectionEnd < lines.length) {
+    replacement.push('');
+  }
+
+  return [...lines.slice(0, sectionStart), ...replacement, ...lines.slice(sectionEnd)].join('\n');
+}
+
+module.exports = {
+  renderSection,
+  upsertSection,
+};

--- a/.github/actions/lint-reporter/comment-body.test.cjs
+++ b/.github/actions/lint-reporter/comment-body.test.cjs
@@ -1,0 +1,134 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { renderSection, upsertSection } = require('./comment-body.cjs');
+
+test('replaces a failed section with a passing result', () => {
+  const existingBody = `## Code Quality Report
+<!-- lint-results -->
+
+### Node.js Build ✅ **Status**: Passed
+
+### Node.js Tests ❌ **Status**: Failed
+
+<details>
+<summary>Click to see details</summary>
+
+\`\`\`
+test failure
+\`\`\`
+
+</details>
+
+### Node.js Security Audit ✅ **Status**: Passed`;
+
+  const section = renderSection({
+    title: 'Node.js Tests',
+    result: 'success',
+    output: 'No output',
+  });
+
+  assert.equal(
+    upsertSection(existingBody, 'Node.js Tests', section),
+    `## Code Quality Report
+<!-- lint-results -->
+
+### Node.js Build ✅ **Status**: Passed
+
+### Node.js Tests ✅ **Status**: Passed
+
+### Node.js Security Audit ✅ **Status**: Passed`
+  );
+});
+
+test('replaces a passing section with failure details', () => {
+  const existingBody = `Header
+
+### Node.js Tests ✅ **Status**: Passed`;
+  const section = renderSection({
+    title: 'Node.js Tests',
+    result: 'failure',
+    output: 'one test failed',
+  });
+
+  const updatedBody = upsertSection(existingBody, 'Node.js Tests', section);
+
+  assert.match(updatedBody, /### Node\.js Tests ❌ \*\*Status\*\*: Failed/);
+  assert.match(updatedBody, /one test failed/);
+  assert.doesNotMatch(updatedBody, /Passed/);
+});
+
+test('keeps Markdown headings contained in failure output', () => {
+  const existingBody = `Header
+
+### Node.js Tests ❌ **Status**: Failed
+
+<details>
+<summary>Click to see details</summary>
+
+\`\`\`
+### diagnostic heading
+\`\`\`
+
+</details>
+
+### Node.js Security Audit ✅ **Status**: Passed`;
+  const section = renderSection({
+    title: 'Node.js Tests',
+    result: 'success',
+    output: 'No output',
+  });
+
+  assert.equal(
+    upsertSection(existingBody, 'Node.js Tests', section),
+    `Header
+
+### Node.js Tests ✅ **Status**: Passed
+
+### Node.js Security Audit ✅ **Status**: Passed`
+  );
+});
+
+test('does not replace a section whose title only shares a prefix', () => {
+  const existingBody = `Header
+
+### Node.js Tests Extended ✅ **Status**: Passed`;
+  const section = renderSection({
+    title: 'Node.js Tests',
+    result: 'success',
+    output: 'No output',
+  });
+
+  const updatedBody = upsertSection(existingBody, 'Node.js Tests', section);
+
+  assert.match(updatedBody, /### Node\.js Tests Extended ✅/);
+  assert.match(updatedBody, /### Node\.js Tests ✅/);
+});
+
+test('appends a missing section', () => {
+  const section = renderSection({
+    title: 'Mac Linting',
+    result: 'success',
+    output: 'No output',
+  });
+
+  assert.equal(
+    upsertSection('Header\n', 'Mac Linting', section),
+    'Header\n\n### Mac Linting ✅ **Status**: Passed'
+  );
+});
+
+test('renders successful coverage output without details', () => {
+  const section = renderSection({
+    title: 'Node.js Test Coverage',
+    result: 'success',
+    output: 'Lines: 42%',
+  });
+
+  assert.equal(
+    section,
+    `### Node.js Test Coverage ✅ **Status**: Passed
+
+Lines: 42%`
+  );
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,15 @@ jobs:
       ios: ${{ steps.filter.outputs.ios }}
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+    - name: Test CI helper scripts
+      run: node --test .github/actions/lint-reporter/comment-body.test.cjs
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
       id: filter
       with:
         filters: |
           web:
             - 'web/**'
+            - '.github/actions/lint-reporter/**'
             - '.github/workflows/node.yml'
             - '.github/workflows/web-ci.yml'
             - 'package.json'


### PR DESCRIPTION
## Summary

Fix CI quality-report comments that kept stale failed sections after a successful rerun.

The reporter started rendering status on the section heading, but its replacement logic still searched for an exact bare heading. This extracts the renderer/updater into a tested helper and replaces the complete matching section without confusing headings inside diagnostic output.

Shared reporter changes now trigger Node and macOS CI, and the helper regression runs in the change-detection job.

## Verification

- `node --test .github/actions/lint-reporter/comment-body.test.cjs` (6 passed)
- `actionlint .github/workflows/ci.yml`
- Composite action metadata YAML validation
- `cd web && pnpm check`
- `$autoreview` clean
