### PR TITLE
fix(ci): clear stale failure status after green reruns

### DIFF
--- a/.github/actions/ci-status-comment/report.cjs
+++ b/.github/actions/ci-status-comment/report.cjs
@@ -1,0 +1,87 @@
+const STATUS_MARKER = '<!-- vibetunnel-ci-status -->';
+
+function renderFailureReport(htmlUrl, jobs) {
+  const lines = [
+    STATUS_MARKER,
+    '## ❌ CI Failed',
+    '',
+    `[View failed run](${htmlUrl})`,
+    '',
+    '### Failed Jobs:',
+  ];
+
+  for (const job of jobs.filter((candidate) => candidate.conclusion === 'failure')) {
+    lines.push(`- **${job.name}**`);
+    const failedStep = job.steps?.find((step) => step.conclusion === 'failure');
+    if (failedStep) {
+      lines.push(`  - Failed at: ${failedStep.name}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function renderStatusComment({ conclusion, htmlUrl, jobs = [] }) {
+  if (conclusion === 'failure') {
+    return renderFailureReport(htmlUrl, jobs);
+  }
+
+  if (conclusion === 'success') {
+    return [
+      STATUS_MARKER,
+      '## ✅ CI Passed',
+      '',
+      `[View successful run](${htmlUrl})`,
+    ].join('\n');
+  }
+
+  return null;
+}
+
+async function upsertStatusComment({
+  github,
+  owner,
+  repo,
+  issueNumber,
+  body,
+  createIfMissing = true,
+}) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+  const existingComment = comments.find(
+    (comment) =>
+      comment.user?.login === 'github-actions[bot]' && comment.body?.includes(STATUS_MARKER)
+  );
+
+  if (existingComment) {
+    await github.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existingComment.id,
+      body,
+    });
+    return 'updated';
+  }
+
+  if (!createIfMissing) {
+    return 'unchanged';
+  }
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body,
+  });
+  return 'created';
+}
+
+module.exports = {
+  STATUS_MARKER,
+  renderStatusComment,
+  upsertStatusComment,
+};

--- a/.github/actions/ci-status-comment/report.test.cjs
+++ b/.github/actions/ci-status-comment/report.test.cjs
@@ -1,0 +1,181 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { STATUS_MARKER, renderStatusComment, upsertStatusComment } = require('./report.cjs');
+
+test('renders failed jobs and their failing steps', () => {
+  const comment = renderStatusComment({
+    conclusion: 'failure',
+    htmlUrl: 'https://example.test/runs/1',
+    jobs: [
+      {
+        name: 'Node.js CI',
+        conclusion: 'failure',
+        steps: [
+          { name: 'Install', conclusion: 'success' },
+          { name: 'Test', conclusion: 'failure' },
+        ],
+      },
+      {
+        name: 'Mac CI',
+        conclusion: 'success',
+        steps: [],
+      },
+    ],
+  });
+
+  assert.equal(
+    comment,
+    `${STATUS_MARKER}
+## ❌ CI Failed
+
+[View failed run](https://example.test/runs/1)
+
+### Failed Jobs:
+- **Node.js CI**
+  - Failed at: Test`
+  );
+});
+
+test('renders a passing replacement for a successful rerun', () => {
+  const comment = renderStatusComment({
+    conclusion: 'success',
+    htmlUrl: 'https://example.test/runs/2',
+  });
+
+  assert.equal(
+    comment,
+    `${STATUS_MARKER}
+## ✅ CI Passed
+
+[View successful run](https://example.test/runs/2)`
+  );
+  assert.doesNotMatch(comment, /Failed/);
+});
+
+test('does not replace status for an inconclusive run', () => {
+  assert.equal(
+    renderStatusComment({
+      conclusion: 'cancelled',
+      htmlUrl: 'https://example.test/runs/3',
+    }),
+    null
+  );
+});
+
+test('updates the existing bot status comment after a successful rerun', async () => {
+  const calls = [];
+  const github = {
+    paginate: async () => [
+      {
+        id: 42,
+        user: { login: 'github-actions[bot]' },
+        body: `${STATUS_MARKER}\n## ❌ CI Failed`,
+      },
+    ],
+    rest: {
+      issues: {
+        listComments() {},
+        updateComment: async (request) => calls.push(['update', request]),
+        createComment: async (request) => calls.push(['create', request]),
+      },
+    },
+  };
+  const body = renderStatusComment({
+    conclusion: 'success',
+    htmlUrl: 'https://example.test/runs/4',
+  });
+
+  assert.equal(
+    await upsertStatusComment({
+      github,
+      owner: 'amantus-ai',
+      repo: 'vibetunnel',
+      issueNumber: 123,
+      body,
+    }),
+    'updated'
+  );
+  assert.deepEqual(calls, [
+    [
+      'update',
+      {
+        owner: 'amantus-ai',
+        repo: 'vibetunnel',
+        comment_id: 42,
+        body,
+      },
+    ],
+  ]);
+});
+
+test('creates a status comment when no bot marker exists', async () => {
+  const calls = [];
+  const github = {
+    paginate: async () => [],
+    rest: {
+      issues: {
+        listComments() {},
+        updateComment: async (request) => calls.push(['update', request]),
+        createComment: async (request) => calls.push(['create', request]),
+      },
+    },
+  };
+  const body = renderStatusComment({
+    conclusion: 'failure',
+    htmlUrl: 'https://example.test/runs/5',
+  });
+
+  assert.equal(
+    await upsertStatusComment({
+      github,
+      owner: 'amantus-ai',
+      repo: 'vibetunnel',
+      issueNumber: 123,
+      body,
+    }),
+    'created'
+  );
+  assert.deepEqual(calls, [
+    [
+      'create',
+      {
+        owner: 'amantus-ai',
+        repo: 'vibetunnel',
+        issue_number: 123,
+        body,
+      },
+    ],
+  ]);
+});
+
+test('keeps a first-time successful run silent', async () => {
+  const calls = [];
+  const github = {
+    paginate: async () => [],
+    rest: {
+      issues: {
+        listComments() {},
+        updateComment: async (request) => calls.push(['update', request]),
+        createComment: async (request) => calls.push(['create', request]),
+      },
+    },
+  };
+  const body = renderStatusComment({
+    conclusion: 'success',
+    htmlUrl: 'https://example.test/runs/6',
+  });
+
+  assert.equal(
+    await upsertStatusComment({
+      github,
+      owner: 'amantus-ai',
+      repo: 'vibetunnel',
+      issueNumber: 123,
+      body,
+      createIfMissing: false,
+    }),
+    'unchanged'
+  );
+  assert.deepEqual(calls, []);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
     - name: Test CI helper scripts
-      run: node --test .github/actions/lint-reporter/comment-body.test.cjs
+      run: >-
+        node --test
+        .github/actions/lint-reporter/comment-body.test.cjs
+        .github/actions/ci-status-comment/report.test.cjs
     - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
       id: filter
       with:
@@ -36,8 +39,10 @@ jobs:
           web:
             - 'web/**'
             - '.github/actions/lint-reporter/**'
+            - '.github/actions/ci-status-comment/**'
             - '.github/workflows/node.yml'
             - '.github/workflows/web-ci.yml'
+            - '.github/workflows/monitor-ci.yml'
             - 'package.json'
             - 'pnpm-workspace.yaml'
           mac:

--- a/.github/workflows/monitor-ci.yml
+++ b/.github/workflows/monitor-ci.yml
@@ -17,11 +17,15 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2404-arm
     
     steps:
-    - name: Check CI Status
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+    - name: Report CI Status
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-      id: check-status
       with:
         script: |
+          const path = require('node:path');
+          const { renderStatusComment, upsertStatusComment } = require(
+            path.join(process.env.GITHUB_WORKSPACE, '.github/actions/ci-status-comment/report.cjs')
+          );
           const workflow_run = context.payload.workflow_run;
           
           console.log(`Workflow ${workflow_run.name} completed with status: ${workflow_run.conclusion}`);
@@ -43,47 +47,28 @@ jobs:
             }
           }
           
-          // Report failures in PR comment if applicable
-          if (workflow_run.conclusion === 'failure' && workflow_run.pull_requests.length > 0) {
-            const pr = workflow_run.pull_requests[0];
-            const failedJobs = jobs.data.jobs.filter(j => j.conclusion === 'failure');
-            
-            let comment = '## ❌ CI Failed\n\n';
-            comment += `[View failed run](${workflow_run.html_url})\n\n`;
-            comment += '### Failed Jobs:\n';
-            
-            for (const job of failedJobs) {
-              comment += `- **${job.name}**\n`;
-              const failedStep = job.steps.find(s => s.conclusion === 'failure');
-              if (failedStep) {
-                comment += `  - Failed at: ${failedStep.name}\n`;
-              }
-            }
-            
-            // Store comment body for next step
-            core.setOutput('comment_body', comment);
-            core.setOutput('pr_number', pr.number.toString());
-            core.setOutput('should_comment', 'true');
-          } else {
-            core.setOutput('should_comment', 'false');
+          const pr = workflow_run.pull_requests[0];
+          if (!pr) {
+            console.log('No pull request associated with this run');
+            return;
           }
-    
-    - name: Find Comment
-      if: steps.check-status.outputs.should_comment == 'true'
-      uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
-      id: fc
-      with:
-        issue-number: ${{ steps.check-status.outputs.pr_number }}
-        comment-author: 'github-actions[bot]'
-        body-includes: '<!-- vibetunnel-ci-status -->'
-    
-    - name: Create or Update Comment
-      if: steps.check-status.outputs.should_comment == 'true'
-      uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
-      with:
-        comment-id: ${{ steps.fc.outputs.comment-id }}
-        issue-number: ${{ steps.check-status.outputs.pr_number }}
-        body: |
-          <!-- vibetunnel-ci-status -->
-          ${{ steps.check-status.outputs.comment_body }}
-        edit-mode: replace
+
+          const comment = renderStatusComment({
+            conclusion: workflow_run.conclusion,
+            htmlUrl: workflow_run.html_url,
+            jobs: jobs.data.jobs,
+          });
+          if (!comment) {
+            console.log(`No status update needed for conclusion: ${workflow_run.conclusion}`);
+            return;
+          }
+
+          const operation = await upsertStatusComment({
+            github,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issueNumber: pr.number,
+            body: comment,
+            createIfMissing: workflow_run.conclusion === 'failure',
+          });
+          console.log(`${operation} CI status comment on PR #${pr.number}`);


### PR DESCRIPTION
## Summary

- replace stale CI failure status after a successful rerun
- keep first-time successful runs silent while preserving detailed failure reports
- test rendering plus create/update/no-op comment behavior in the fast Detect changes job
- remove the two external comment actions in favor of a directly tested GitHub API upsert

## Reproduction

The monitor workflow only wrote a status comment when CI failed. A later successful rerun skipped both find and update steps, leaving the prior failure comment visible even though required checks were green.

## Verification

- `node --test .github/actions/lint-reporter/comment-body.test.cjs .github/actions/ci-status-comment/report.test.cjs`
- `actionlint -ignore 'label .* is unknown' .github/workflows/ci.yml .github/workflows/monitor-ci.yml`
- `cd web && pnpm check`
- `$autoreview` clean after addressing the first-pass comment-noise finding

## Safety

The workflow-run checkout resolves the last commit on the default branch, so untrusted pull-request code is not executed with the workflow's write token. No changelog entry: internal CI behavior only.