### PR TITLE
fix(web): keep mobile prompt above keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Keep the mobile terminal prompt visible when opening the software keyboard and quick keys (#544)
 - Stop reporting macOS Accessibility permission as granted when VibeTunnel can inspect only its own windows (#337)
 - Open the current macOS app build's notification settings, including debug/ad-hoc bundle variants, and fall back to the general Notifications pane when needed.
 - Show the Accessibility recovery flow when Ghostty or another terminal rejects System Events keystrokes (#625)

--- a/web/src/client/components/session-view.test.ts
+++ b/web/src/client/components/session-view.test.ts
@@ -1068,6 +1068,17 @@ describe('SessionView', () => {
       expect(terminalElement.scrollToBottom).not.toHaveBeenCalled();
     });
 
+    it('should size the mobile grid from the tracked visual viewport height', () => {
+      const styles = Array.from(element.querySelectorAll('style'))
+        .map((style) => style.textContent ?? '')
+        .join('\n');
+
+      expect(styles).toContain('height: var(--app-height, 100dvh) !important;');
+      expect(styles).toContain(
+        'height: calc(var(--app-height, 100dvh) - var(--quickkeys-height, 0px)) !important;'
+      );
+    });
+
     it.skip('should properly calculate terminal height with keyboard and quick keys', {
       timeout: 10000,
     }, async () => {

--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -1237,7 +1237,7 @@ export class SessionView extends LitElement {
             display: flex !important;
             flex-direction: column !important;
             height: 100vh !important;
-            height: 100dvh !important;
+            height: var(--app-height, 100dvh) !important;
             width: 100% !important;
             position: relative !important;
             overflow: hidden !important;
@@ -1250,11 +1250,10 @@ export class SessionView extends LitElement {
           /* Mobile: when the quick keys are up, shrink the grid so the terminal reserves
              space for the fixed quick-keys bar instead of being covered (the bottom rows
              were hidden and the top became unreachable). We subtract ONLY the quick-keys
-             height — NOT the keyboard height — because the viewport uses
-             interactive-widget=resizes-content, so 100dvh already shrinks with the iOS
-             keyboard; subtracting it again double-counted and left a large empty gap. */
+             height — NOT the keyboard height — because --app-height already tracks the
+             visual viewport above the iOS keyboard. */
           .session-view-grid[data-keyboard-visible="true"] {
-            height: calc(100dvh - var(--quickkeys-height, 0px)) !important;
+            height: calc(var(--app-height, 100dvh) - var(--quickkeys-height, 0px)) !important;
           }
 
           .session-header-area {


### PR DESCRIPTION
Closes #544.

## What changed

- Size the mobile session grid from the visual viewport height already tracked in `--app-height`.
- Continue subtracting only the measured quick-key height when quick keys are visible.
- Add regression coverage for both mobile grid sizing states.
- Add an Unreleased changelog entry.

## Root cause

On iOS, opening the software keyboard reduced `visualViewport.height`, but the session grid remained sized from `100dvh`. The terminal could still be following its bottom row correctly while that row was physically covered by the native keyboard. VibeTunnel already tracks the usable visual viewport in `--app-height`; the mobile grid was not consuming it.

## Verification

- Live iOS 26 iPhone 16 Plus Simulator proof with the final built candidate:
  - native software keyboard open
  - all quick-key rows open
  - prompt and cursor visible above both layers after settling
  - typing and Return delivered without moving the prompt behind the keyboard
  - Done dismissed the keyboard and quick keys with the prompt still visible
- `pnpm check`
- pinned Node 24 / Zig 0.15.2 `pnpm build:ci`
- client coverage: 665 passed, 14 skipped
- server coverage: 582 passed, 75 skipped
- fast Playwright suite: 24 passed, 3 skipped
- focused session/terminal tests: 91 passed, 6 skipped
- autoreview: clean, no actionable findings

Public Model Identifier Gate: PASS. No model identifiers are present in the exact diff, changed test, generated proof artifacts, workflow surface, or public PR text.
