### PR TITLE
fix(web): keep iOS hardware Escape in terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Keep iOS hardware Escape keys inside active terminal sessions (#492)
 - Keep the mobile terminal prompt visible when opening the software keyboard and quick keys (#544)
 - Stop reporting macOS Accessibility permission as granted when VibeTunnel can inspect only its own windows (#337)
 - Open the current macOS app build's notification settings, including debug/ad-hoc bundle variants, and fall back to the general Notifications pane when needed.

--- a/web/src/client/components/session-view/direct-keyboard-manager.test.ts
+++ b/web/src/client/components/session-view/direct-keyboard-manager.test.ts
@@ -7,7 +7,7 @@ import type { InputManager } from './input-manager';
 
 describe('DirectKeyboardManager', () => {
   let manager: DirectKeyboardManager;
-  let mockInputManager: Pick<InputManager, 'sendInputText'>;
+  let mockInputManager: Pick<InputManager, 'sendInput' | 'sendInputText'>;
   let originalRequestAnimationFrame: typeof requestAnimationFrame;
 
   const getManagerState = () =>
@@ -28,7 +28,7 @@ describe('DirectKeyboardManager', () => {
     });
 
     manager = new DirectKeyboardManager('test');
-    mockInputManager = { sendInputText: vi.fn() };
+    mockInputManager = { sendInput: vi.fn(), sendInputText: vi.fn() };
     manager.setInputManager(mockInputManager as InputManager);
 
     // Mock clipboard API using Object.defineProperty
@@ -130,5 +130,28 @@ describe('DirectKeyboardManager', () => {
     hiddenInput.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText' }));
 
     expect(mockInputManager.sendInputText).toHaveBeenCalledWith(expected);
+  });
+
+  it('sends Escape without bubbling to app navigation', () => {
+    const hiddenInput = getManagerState().hiddenInput;
+    expect(hiddenInput).toBeTruthy();
+
+    const documentKeydown = vi.fn();
+    document.addEventListener('keydown', documentKeydown);
+
+    try {
+      const escapeEvent = new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      });
+      hiddenInput?.dispatchEvent(escapeEvent);
+
+      expect(escapeEvent.defaultPrevented).toBe(true);
+      expect(mockInputManager.sendInput).toHaveBeenCalledWith('escape');
+      expect(documentKeydown).not.toHaveBeenCalled();
+    } finally {
+      document.removeEventListener('keydown', documentKeydown);
+    }
   });
 });

--- a/web/src/client/components/session-view/direct-keyboard-manager.ts
+++ b/web/src/client/components/session-view/direct-keyboard-manager.ts
@@ -440,8 +440,9 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
         // DON'T preventDefault - let browser also trigger input event for iOS key repeat
       } else if (e.key === 'Tab' && this.inputManager) {
         this.inputManager.sendInput(e.shiftKey ? 'shift_tab' : 'tab');
-      } else if (e.key === 'Escape' && this.inputManager) {
-        this.inputManager.sendInput('escape');
+      } else if (e.key === 'Escape') {
+        e.stopPropagation();
+        this.inputManager?.sendInput('escape');
       }
     });
 

--- a/web/src/client/components/session-view/lifecycle-event-manager.test.ts
+++ b/web/src/client/components/session-view/lifecycle-event-manager.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as eventUtils from '../../utils/event-utils.js';
 import { LifecycleEventManager } from './lifecycle-event-manager.js';
 
@@ -12,6 +12,10 @@ describe('LifecycleEventManager', () => {
   beforeEach(() => {
     manager = new LifecycleEventManager();
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    manager.cleanup();
   });
 
   describe('consumeEvent usage', () => {
@@ -123,6 +127,72 @@ describe('LifecycleEventManager', () => {
 
       expect(eventUtils.consumeEvent).not.toHaveBeenCalled();
       expect(mockCallbacks.getInputManager).not.toHaveBeenCalled();
+      expect(mockCallbacks.handleKeyboardInput).not.toHaveBeenCalled();
+    });
+
+    it('routes mobile hardware Escape to the running terminal', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        getInputManager: vi.fn().mockReturnValue({
+          isKeyboardShortcut: vi.fn().mockReturnValue(false),
+        }),
+        handleKeyboardInput: vi.fn(),
+      };
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+      manager.setSession({
+        id: 'test-session',
+        status: 'running',
+      } as Parameters<typeof manager.setSession>[0]);
+
+      const escapeEvent = new KeyboardEvent('keydown', { key: 'Escape' });
+      manager.mobileHardwareKeyboardHandler(escapeEvent);
+
+      expect(eventUtils.consumeEvent).toHaveBeenCalledWith(escapeEvent);
+      expect(mockCallbacks.handleKeyboardInput).toHaveBeenCalledWith(escapeEvent);
+    });
+
+    it('ignores other mobile hardware keys outside direct keyboard mode', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        getInputManager: vi.fn(),
+        handleKeyboardInput: vi.fn(),
+      };
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+      manager.mobileHardwareKeyboardHandler(new KeyboardEvent('keydown', { key: 'a' }));
+
+      expect(eventUtils.consumeEvent).not.toHaveBeenCalled();
+      expect(mockCallbacks.getInputManager).not.toHaveBeenCalled();
+      expect(mockCallbacks.handleKeyboardInput).not.toHaveBeenCalled();
+    });
+
+    it('registers and removes the mobile hardware Escape listener', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        getInputManager: vi.fn().mockReturnValue({
+          isKeyboardShortcut: vi.fn().mockReturnValue(false),
+        }),
+        handleKeyboardInput: vi.fn(),
+      };
+      const lifecycle = manager as unknown as {
+        setupEventListeners: (isMobile: boolean) => void;
+      };
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+      manager.setSession({
+        id: 'test-session',
+        status: 'running',
+      } as Parameters<typeof manager.setSession>[0]);
+      lifecycle.setupEventListeners(true);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      expect(mockCallbacks.handleKeyboardInput).toHaveBeenCalledTimes(1);
+
+      manager.cleanup();
+      vi.clearAllMocks();
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
       expect(mockCallbacks.handleKeyboardInput).not.toHaveBeenCalled();
     });
   });

--- a/web/src/client/components/session-view/lifecycle-event-manager.ts
+++ b/web/src/client/components/session-view/lifecycle-event-manager.ts
@@ -37,6 +37,7 @@ export class LifecycleEventManager extends ManagerEventEmitter {
 
   // Event listener tracking
   private keyboardListenerAdded = false;
+  private mobileEscapeListenerAdded = false;
   private touchListenersAdded = false;
   private visualViewportHandler: (() => void) | null = null;
   private viewportTrackingHandler: (() => void) | null = null;
@@ -301,6 +302,12 @@ export class LifecycleEventManager extends ManagerEventEmitter {
     this.callbacks.handleKeyboardInput(e);
   };
 
+  mobileHardwareKeyboardHandler = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') {
+      this.keyboardHandler(e);
+    }
+  };
+
   touchStartHandler = (e: TouchEvent): void => {
     if (!this.callbacks) return;
 
@@ -527,11 +534,17 @@ export class LifecycleEventManager extends ManagerEventEmitter {
       // Don't use capture phase - let browser handle shortcuts naturally
       document.addEventListener('keydown', this.keyboardHandler);
       this.keyboardListenerAdded = true;
-    } else if (isMobile && !this.touchListenersAdded) {
-      // Add touch event listeners for mobile swipe gestures
-      document.addEventListener('touchstart', this.touchStartHandler, { passive: true });
-      document.addEventListener('touchend', this.touchEndHandler, { passive: true });
-      this.touchListenersAdded = true;
+    } else if (isMobile) {
+      if (!this.mobileEscapeListenerAdded) {
+        document.addEventListener('keydown', this.mobileHardwareKeyboardHandler);
+        this.mobileEscapeListenerAdded = true;
+      }
+      if (!this.touchListenersAdded) {
+        // Add touch event listeners for mobile swipe gestures
+        document.addEventListener('touchstart', this.touchStartHandler, { passive: true });
+        document.addEventListener('touchend', this.touchEndHandler, { passive: true });
+        this.touchListenersAdded = true;
+      }
     }
   }
 
@@ -573,10 +586,15 @@ export class LifecycleEventManager extends ManagerEventEmitter {
     }
 
     // Remove global keyboard event listener
-    if (!this.callbacks.getIsMobile() && this.keyboardListenerAdded) {
+    if (this.keyboardListenerAdded) {
       document.removeEventListener('keydown', this.keyboardHandler);
       this.keyboardListenerAdded = false;
-    } else if (this.callbacks.getIsMobile() && this.touchListenersAdded) {
+    }
+    if (this.mobileEscapeListenerAdded) {
+      document.removeEventListener('keydown', this.mobileHardwareKeyboardHandler);
+      this.mobileEscapeListenerAdded = false;
+    }
+    if (this.touchListenersAdded) {
       // Remove touch event listeners
       document.removeEventListener('touchstart', this.touchStartHandler);
       document.removeEventListener('touchend', this.touchEndHandler);
@@ -627,10 +645,15 @@ export class LifecycleEventManager extends ManagerEventEmitter {
     window.removeEventListener('resize', this.handleWindowResize);
 
     // Remove global keyboard event listener
-    if (!this.callbacks?.getIsMobile() && this.keyboardListenerAdded) {
+    if (this.keyboardListenerAdded) {
       document.removeEventListener('keydown', this.keyboardHandler);
       this.keyboardListenerAdded = false;
-    } else if (this.callbacks?.getIsMobile() && this.touchListenersAdded) {
+    }
+    if (this.mobileEscapeListenerAdded) {
+      document.removeEventListener('keydown', this.mobileHardwareKeyboardHandler);
+      this.mobileEscapeListenerAdded = false;
+    }
+    if (this.touchListenersAdded) {
       // Remove touch event listeners
       document.removeEventListener('touchstart', this.touchStartHandler);
       document.removeEventListener('touchend', this.touchEndHandler);


### PR DESCRIPTION
## Summary

- keep hardware Escape inside active mobile terminal sessions
- route mobile Escape through the existing terminal keyboard path without capturing ordinary keys
- stop direct keyboard Escape from bubbling into app-level navigation
- add focused listener, cleanup, and propagation regressions

## Verification

- reproduced the pre-fix navigation-away behavior on an iPhone 17 simulator running iOS 26
- `pnpm check`
- focused Vitest: 17 passed
- client coverage: 669 passed, 14 skipped
- server coverage: 582 passed, 75 skipped
- `pnpm build:ci`
- fast Playwright suite: 24 passed, 3 skipped
- structured autoreview: clean

## Live proof

Tested the exact production binary from `build:ci` on a fresh origin in iOS Safari/WebKit. Hardware Escape stayed in the session and reached the PTY both before and during direct keyboard mode. Ordinary typing still reached the PTY, quick keys remained reachable, and Done dismissed keyboard mode. iOS Chrome was not installable in the simulator without an App Store account; Chrome on iOS uses the same WebKit engine as this reproduced path.

Public Model Identifier Gate: PASS. No model identifiers exist in the diff, tests, workflows, generated candidate, logs, screenshots, or this public proof.

Fixes #492
