### PR TITLE
fix(web): enable iOS hardware keyboard input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Accept iOS hardware keyboard input without first opening the software keyboard (#491)
 - Keep iOS hardware Escape keys inside active terminal sessions (#492)
 - Keep the mobile terminal prompt visible when opening the software keyboard and quick keys (#544)
 - Stop reporting macOS Accessibility permission as granted when VibeTunnel can inspect only its own windows (#337)

--- a/web/src/client/components/session-view.test.ts
+++ b/web/src/client/components/session-view.test.ts
@@ -214,6 +214,25 @@ describe('SessionView', () => {
       const mobileTestElement = mobileElement as SessionViewTestInterface;
       const uiState = mobileTestElement.uiStateManager.getState();
       expect(uiState.isMobile).toBe(true);
+      expect(document.activeElement).not.toBe(mobileElement);
+
+      const mockSession = createMockSession({
+        id: 'mobile-hardware-keyboard-session',
+        status: 'running',
+      });
+      mobileElement.session = mockSession;
+      await mobileElement.updateComplete;
+      const terminal = mobileElement.querySelector('vibe-terminal');
+      await vi.waitFor(() => expect(terminal?.getAttribute('data-ready')).toBe('true'));
+      await vi.waitFor(() => expect(document.activeElement).toBe(mobileElement));
+
+      const terminalContainer = terminal?.querySelector('#terminal-container') as HTMLElement;
+      terminalContainer.focus();
+      terminalContainer.dispatchEvent(
+        new Event('touchend', { bubbles: true, composed: true, cancelable: true })
+      );
+      await vi.waitFor(() => expect(document.activeElement).toBe(mobileElement));
+      mobileElement.remove();
 
       // Restore original values
       Object.defineProperty(navigator, 'maxTouchPoints', {

--- a/web/src/client/components/session-view.test.ts
+++ b/web/src/client/components/session-view.test.ts
@@ -238,18 +238,22 @@ describe('SessionView', () => {
         await vi.waitFor(() => expect(document.activeElement).toBe(mobileElement));
 
         const terminalContainer = terminal?.querySelector('#terminal-container') as HTMLElement;
-        terminalContainer.focus();
+        const pasteInput = terminal?.querySelector('.terminal-paste-input') as HTMLTextAreaElement;
+        pasteInput.focus();
         terminalContainer.dispatchEvent(
-          new TouchEvent('touchend', {
-            bubbles: true,
-            composed: true,
-            cancelable: true,
-            touches: [],
-            targetTouches: [],
-            changedTouches: [{ clientX: 10, clientY: 10 }] as unknown as Touch[],
-          })
+          new MouseEvent('click', { bubbles: true, cancelable: true })
         );
-        await vi.waitFor(() => expect(document.activeElement).toBe(mobileElement));
+        await vi.waitFor(() => expect(document.activeElement).toBe(pasteInput));
+
+        pasteInput.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'x', bubbles: true, composed: true })
+        );
+        await vi.waitFor(() =>
+          expect(terminalSocketClientMock.sendInputText).toHaveBeenCalledWith(
+            'mobile-hardware-keyboard-session',
+            'x'
+          )
+        );
       } finally {
         mobileElement?.remove();
         Object.defineProperty(navigator, 'maxTouchPoints', {

--- a/web/src/client/components/session-view.test.ts
+++ b/web/src/client/components/session-view.test.ts
@@ -69,6 +69,8 @@ interface SessionViewTestInterface extends SessionView {
   inputManager: {
     cleanup: () => void;
   };
+  getTerminalElement: () => Terminal | null;
+  ensureTerminalInitialized: () => void;
   updateTerminalTransform: () => void;
   _updateTerminalTransformTimeout: ReturnType<typeof setTimeout> | null;
 }
@@ -161,13 +163,13 @@ describe('SessionView', () => {
       const originalMatchMedia = window.matchMedia;
 
       Object.defineProperty(navigator, 'maxTouchPoints', {
-        value: 1,
+        value: 2,
         configurable: true,
       });
 
       // Mock matchMedia to simulate touch device
       window.matchMedia = (query: string) => {
-        if (query === '(any-pointer: coarse)') {
+        if (query === '(any-pointer: coarse)' || query === '(pointer: coarse)') {
           return {
             matches: true,
             media: query,
@@ -247,6 +249,30 @@ describe('SessionView', () => {
           configurable: true,
         });
         window.matchMedia = originalMatchMedia;
+      }
+    });
+
+    it('cancels deferred terminal initialization when disconnected', async () => {
+      vi.useFakeTimers();
+      const testElement = element as SessionViewTestInterface;
+      const getTerminalElementSpy = vi
+        .spyOn(testElement, 'getTerminalElement')
+        .mockReturnValue(null);
+      const requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame');
+
+      try {
+        element.session = createMockSession({ status: 'running' });
+        testElement.ensureTerminalInitialized();
+        const frameCallsBeforeDisconnect = requestAnimationFrameSpy.mock.calls.length;
+
+        element.remove();
+        await vi.advanceTimersByTimeAsync(100);
+
+        expect(requestAnimationFrameSpy).toHaveBeenCalledTimes(frameCallsBeforeDisconnect);
+      } finally {
+        getTerminalElementSpy.mockRestore();
+        requestAnimationFrameSpy.mockRestore();
+        vi.useRealTimers();
       }
     });
   });

--- a/web/src/client/components/session-view.test.ts
+++ b/web/src/client/components/session-view.test.ts
@@ -71,6 +71,7 @@ interface SessionViewTestInterface extends SessionView {
   };
   getTerminalElement: () => Terminal | null;
   ensureTerminalInitialized: () => void;
+  handleTerminalClick: (event: Event) => void;
   updateTerminalTransform: () => void;
   _updateTerminalTransformTimeout: ReturnType<typeof setTimeout> | null;
 }
@@ -239,7 +240,14 @@ describe('SessionView', () => {
         const terminalContainer = terminal?.querySelector('#terminal-container') as HTMLElement;
         terminalContainer.focus();
         terminalContainer.dispatchEvent(
-          new Event('touchend', { bubbles: true, composed: true, cancelable: true })
+          new TouchEvent('touchend', {
+            bubbles: true,
+            composed: true,
+            cancelable: true,
+            touches: [],
+            targetTouches: [],
+            changedTouches: [{ clientX: 10, clientY: 10 }] as unknown as Touch[],
+          })
         );
         await vi.waitFor(() => expect(document.activeElement).toBe(mobileElement));
       } finally {
@@ -274,6 +282,47 @@ describe('SessionView', () => {
         requestAnimationFrameSpy.mockRestore();
         vi.useRealTimers();
       }
+    });
+
+    it('leaves terminal touchend available to mobile swipe navigation', () => {
+      const testElement = element as SessionViewTestInterface;
+      testElement.uiStateManager.setIsMobile(true);
+      const touchEnd = new Event('touchend', { bubbles: true, cancelable: true });
+      const stopPropagation = vi.spyOn(touchEnd, 'stopPropagation');
+      const preventDefault = vi.spyOn(touchEnd, 'preventDefault');
+
+      testElement.handleTerminalClick(touchEnd);
+
+      expect(stopPropagation).not.toHaveBeenCalled();
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(touchEnd.defaultPrevented).toBe(false);
+    });
+
+    it('leaves mobile terminal links to native navigation', () => {
+      const testElement = element as SessionViewTestInterface;
+      testElement.uiStateManager.setIsMobile(true);
+      const anchor = document.createElement('a');
+      anchor.href = 'https://example.com';
+      const click = new MouseEvent('click', { bubbles: true, cancelable: true });
+      vi.spyOn(click, 'composedPath').mockReturnValue([anchor]);
+      const stopPropagation = vi.spyOn(click, 'stopPropagation');
+      const preventDefault = vi.spyOn(click, 'preventDefault');
+
+      testElement.handleTerminalClick(click);
+
+      expect(stopPropagation).not.toHaveBeenCalled();
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(click.defaultPrevented).toBe(false);
+    });
+
+    it('still consumes ordinary mobile terminal clicks', () => {
+      const testElement = element as SessionViewTestInterface;
+      testElement.uiStateManager.setIsMobile(true);
+      const click = new MouseEvent('click', { bubbles: true, cancelable: true });
+
+      testElement.handleTerminalClick(click);
+
+      expect(click.defaultPrevented).toBe(true);
     });
   });
 

--- a/web/src/client/components/session-view.test.ts
+++ b/web/src/client/components/session-view.test.ts
@@ -206,40 +206,44 @@ describe('SessionView', () => {
         return originalMatchMedia(query);
       };
 
-      const mobileElement = await fixture<SessionView>(html` <session-view></session-view> `);
+      let mobileElement: SessionView | undefined;
+      try {
+        // The default fixture can own focus. Remove it so terminal-ready starts from
+        // the same neutral document focus as a newly opened mobile session.
+        element.remove();
+        mobileElement = await fixture<SessionView>(html` <session-view></session-view> `);
+        await mobileElement.updateComplete;
 
-      await mobileElement.updateComplete;
+        // Component detects mobile based on touch capabilities
+        const mobileTestElement = mobileElement as SessionViewTestInterface;
+        const uiState = mobileTestElement.uiStateManager.getState();
+        expect(uiState.isMobile).toBe(true);
+        expect(document.activeElement).not.toBe(mobileElement);
 
-      // Component detects mobile based on touch capabilities
-      const mobileTestElement = mobileElement as SessionViewTestInterface;
-      const uiState = mobileTestElement.uiStateManager.getState();
-      expect(uiState.isMobile).toBe(true);
-      expect(document.activeElement).not.toBe(mobileElement);
+        const mockSession = createMockSession({
+          id: 'mobile-hardware-keyboard-session',
+          status: 'running',
+        });
+        mobileElement.session = mockSession;
+        await mobileElement.updateComplete;
+        const terminal = mobileElement.querySelector('vibe-terminal');
+        await vi.waitFor(() => expect(terminal?.getAttribute('data-ready')).toBe('true'));
+        await vi.waitFor(() => expect(document.activeElement).toBe(mobileElement));
 
-      const mockSession = createMockSession({
-        id: 'mobile-hardware-keyboard-session',
-        status: 'running',
-      });
-      mobileElement.session = mockSession;
-      await mobileElement.updateComplete;
-      const terminal = mobileElement.querySelector('vibe-terminal');
-      await vi.waitFor(() => expect(terminal?.getAttribute('data-ready')).toBe('true'));
-      await vi.waitFor(() => expect(document.activeElement).toBe(mobileElement));
-
-      const terminalContainer = terminal?.querySelector('#terminal-container') as HTMLElement;
-      terminalContainer.focus();
-      terminalContainer.dispatchEvent(
-        new Event('touchend', { bubbles: true, composed: true, cancelable: true })
-      );
-      await vi.waitFor(() => expect(document.activeElement).toBe(mobileElement));
-      mobileElement.remove();
-
-      // Restore original values
-      Object.defineProperty(navigator, 'maxTouchPoints', {
-        value: originalMaxTouchPoints,
-        configurable: true,
-      });
-      window.matchMedia = originalMatchMedia;
+        const terminalContainer = terminal?.querySelector('#terminal-container') as HTMLElement;
+        terminalContainer.focus();
+        terminalContainer.dispatchEvent(
+          new Event('touchend', { bubbles: true, composed: true, cancelable: true })
+        );
+        await vi.waitFor(() => expect(document.activeElement).toBe(mobileElement));
+      } finally {
+        mobileElement?.remove();
+        Object.defineProperty(navigator, 'maxTouchPoints', {
+          value: originalMaxTouchPoints,
+          configurable: true,
+        });
+        window.matchMedia = originalMatchMedia;
+      }
     });
   });
 

--- a/web/src/client/components/session-view.test.ts
+++ b/web/src/client/components/session-view.test.ts
@@ -211,6 +211,10 @@ describe('SessionView', () => {
         // The default fixture can own focus. Remove it so terminal-ready starts from
         // the same neutral document focus as a newly opened mobile session.
         element.remove();
+        localStorage.setItem(
+          'vibetunnel_app_preferences',
+          JSON.stringify({ useDirectKeyboard: false })
+        );
         mobileElement = await fixture<SessionView>(html` <session-view></session-view> `);
         await mobileElement.updateComplete;
 

--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -99,6 +99,7 @@ export class SessionView extends LitElement {
 
   private instanceId = `session-view-${Math.random().toString(36).substr(2, 9)}`;
   private _updateTerminalTransformTimeout: ReturnType<typeof setTimeout> | null = null;
+  private mobileHardwareFocusTimeout: ReturnType<typeof setTimeout> | null = null;
   // Measured height of the quick-keys bar; fed into --quickkeys-height so the terminal
   // reserves space for it instead of letting it cover the bottom rows.
   private quickKeysHeight = 0;
@@ -435,6 +436,10 @@ export class SessionView extends LitElement {
     if (this._updateTerminalTransformTimeout) {
       clearTimeout(this._updateTerminalTransformTimeout);
       this._updateTerminalTransformTimeout = null;
+    }
+    if (this.mobileHardwareFocusTimeout) {
+      clearTimeout(this.mobileHardwareFocusTimeout);
+      this.mobileHardwareFocusTimeout = null;
     }
 
     // Use lifecycle event manager for teardown
@@ -774,8 +779,7 @@ export class SessionView extends LitElement {
       e.stopPropagation();
       e.preventDefault();
 
-      // Don't do anything - the hidden input should handle all interactions
-      // The click on the terminal is actually a click on the hidden input overlay
+      this.scheduleMobileHardwareFocus();
       return;
     }
   }
@@ -796,6 +800,33 @@ export class SessionView extends LitElement {
     logger.log('Terminal ready event received');
     // Terminal is ready, ensure it's properly initialized
     this.ensureTerminalInitialized();
+
+    this.scheduleMobileHardwareFocus();
+  }
+
+  private scheduleMobileHardwareFocus() {
+    if (!this.uiStateManager.getState().isMobile) {
+      return;
+    }
+
+    if (this.mobileHardwareFocusTimeout) {
+      clearTimeout(this.mobileHardwareFocusTimeout);
+    }
+    this.mobileHardwareFocusTimeout = setTimeout(() => {
+      this.mobileHardwareFocusTimeout = null;
+      const activeElement = document.activeElement;
+      const terminalOwnsFocus =
+        activeElement instanceof HTMLElement && activeElement.closest('vibe-terminal') !== null;
+      if (
+        this.isConnected &&
+        !this.disableFocusManagement &&
+        (activeElement === document.body ||
+          activeElement === document.documentElement ||
+          terminalOwnsFocus)
+      ) {
+        this.focus();
+      }
+    }, 0);
   }
 
   private handleTerminalOutput(data: string) {

--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -842,14 +842,10 @@ export class SessionView extends LitElement {
     this.mobileHardwareFocusTimeout = setTimeout(() => {
       this.mobileHardwareFocusTimeout = null;
       const activeElement = document.activeElement;
-      const terminalOwnsFocus =
-        activeElement instanceof HTMLElement && activeElement.closest('vibe-terminal') !== null;
       if (
         this.isConnected &&
         !this.disableFocusManagement &&
-        (activeElement === document.body ||
-          activeElement === document.documentElement ||
-          terminalOwnsFocus)
+        (activeElement === document.body || activeElement === document.documentElement)
       ) {
         this.focus();
       }

--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -100,6 +100,8 @@ export class SessionView extends LitElement {
   private instanceId = `session-view-${Math.random().toString(36).substr(2, 9)}`;
   private _updateTerminalTransformTimeout: ReturnType<typeof setTimeout> | null = null;
   private mobileHardwareFocusTimeout: ReturnType<typeof setTimeout> | null = null;
+  private terminalInitializationTimeout: ReturnType<typeof setTimeout> | null = null;
+  private terminalInitializationFrame: number | null = null;
   // Measured height of the quick-keys bar; fed into --quickkeys-height so the terminal
   // reserves space for it instead of letting it cover the bottom rows.
   private quickKeysHeight = 0;
@@ -441,6 +443,14 @@ export class SessionView extends LitElement {
       clearTimeout(this.mobileHardwareFocusTimeout);
       this.mobileHardwareFocusTimeout = null;
     }
+    if (this.terminalInitializationTimeout) {
+      clearTimeout(this.terminalInitializationTimeout);
+      this.terminalInitializationTimeout = null;
+    }
+    if (this.terminalInitializationFrame !== null) {
+      cancelAnimationFrame(this.terminalInitializationFrame);
+      this.terminalInitializationFrame = null;
+    }
 
     // Use lifecycle event manager for teardown
     if (this.lifecycleEventManager) {
@@ -574,9 +584,17 @@ export class SessionView extends LitElement {
     const terminalElement = this.getTerminalElement();
     if (!terminalElement) {
       logger.log('Terminal element not found in DOM, deferring initialization');
+      if (this.terminalInitializationTimeout || this.terminalInitializationFrame !== null) {
+        return;
+      }
       // Retry after next render cycle with a small delay to ensure terminal-renderer has rendered
-      setTimeout(() => {
-        requestAnimationFrame(() => {
+      this.terminalInitializationTimeout = setTimeout(() => {
+        this.terminalInitializationTimeout = null;
+        this.terminalInitializationFrame = requestAnimationFrame(() => {
+          this.terminalInitializationFrame = null;
+          if (!this.isConnected) {
+            return;
+          }
           this.ensureTerminalInitialized();
         });
       }, 100);

--- a/web/src/client/components/session-view.ts
+++ b/web/src/client/components/session-view.ts
@@ -793,9 +793,18 @@ export class SessionView extends LitElement {
   private handleTerminalClick(e: Event) {
     const uiState = this.uiStateManager.getState();
     if (uiState.isMobile) {
-      // Prevent the event from bubbling and default action
-      e.stopPropagation();
-      e.preventDefault();
+      const isLinkInteraction = e
+        .composedPath()
+        .some((target) => target instanceof Element && target.matches('a[href]'));
+      if (isLinkInteraction) {
+        return;
+      }
+
+      // Keep touchend observable by the document-level swipe-back handler.
+      if (e.type !== 'touchend') {
+        e.stopPropagation();
+        e.preventDefault();
+      }
 
       this.scheduleMobileHardwareFocus();
       return;

--- a/web/src/client/components/session-view/direct-keyboard-manager.test.ts
+++ b/web/src/client/components/session-view/direct-keyboard-manager.test.ts
@@ -7,7 +7,7 @@ import type { InputManager } from './input-manager';
 
 describe('DirectKeyboardManager', () => {
   let manager: DirectKeyboardManager;
-  let mockInputManager: Pick<InputManager, 'sendInput' | 'sendInputText'>;
+  let mockInputManager: Pick<InputManager, 'isKeyboardShortcut' | 'sendInput' | 'sendInputText'>;
   let originalRequestAnimationFrame: typeof requestAnimationFrame;
 
   const getManagerState = () =>
@@ -28,7 +28,11 @@ describe('DirectKeyboardManager', () => {
     });
 
     manager = new DirectKeyboardManager('test');
-    mockInputManager = { sendInput: vi.fn(), sendInputText: vi.fn() };
+    mockInputManager = {
+      isKeyboardShortcut: vi.fn().mockReturnValue(false),
+      sendInput: vi.fn(),
+      sendInputText: vi.fn(),
+    };
     manager.setInputManager(mockInputManager as InputManager);
 
     // Mock clipboard API using Object.defineProperty
@@ -153,5 +157,50 @@ describe('DirectKeyboardManager', () => {
     } finally {
       document.removeEventListener('keydown', documentKeydown);
     }
+  });
+
+  it.each([
+    ['Enter', false, 'enter'],
+    ['Tab', false, 'tab'],
+    ['Tab', true, 'shift_tab'],
+    ['Escape', false, 'escape'],
+    ['ArrowUp', false, 'arrow_up'],
+    ['ArrowDown', false, 'arrow_down'],
+    ['ArrowLeft', false, 'arrow_left'],
+    ['ArrowRight', false, 'arrow_right'],
+    ['PageUp', false, 'page_up'],
+    ['PageDown', false, 'page_down'],
+    ['Home', false, 'home'],
+    ['End', false, 'end'],
+    ['Delete', false, 'delete'],
+  ])('routes hardware %s from the hidden input', (key, shiftKey, expected) => {
+    const hiddenInput = getManagerState().hiddenInput;
+    const keyEvent = new KeyboardEvent('keydown', {
+      key,
+      shiftKey,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    hiddenInput?.dispatchEvent(keyEvent);
+
+    expect(keyEvent.defaultPrevented).toBe(true);
+    expect(mockInputManager.sendInput).toHaveBeenCalledWith(expected);
+  });
+
+  it('preserves browser shortcuts from the hidden input', () => {
+    const hiddenInput = getManagerState().hiddenInput;
+    vi.mocked(mockInputManager.isKeyboardShortcut).mockReturnValueOnce(true);
+    const keyEvent = new KeyboardEvent('keydown', {
+      key: 'ArrowLeft',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    hiddenInput?.dispatchEvent(keyEvent);
+
+    expect(keyEvent.defaultPrevented).toBe(false);
+    expect(mockInputManager.sendInput).not.toHaveBeenCalled();
   });
 });

--- a/web/src/client/components/session-view/direct-keyboard-manager.ts
+++ b/web/src/client/components/session-view/direct-keyboard-manager.ts
@@ -34,6 +34,20 @@ import { ManagerEventEmitter } from './interfaces.js';
 
 const logger = createLogger('direct-keyboard-manager');
 
+const HARDWARE_SPECIAL_KEYS: Readonly<Record<string, string>> = {
+  Enter: 'enter',
+  Escape: 'escape',
+  ArrowUp: 'arrow_up',
+  ArrowDown: 'arrow_down',
+  ArrowLeft: 'arrow_left',
+  ArrowRight: 'arrow_right',
+  PageUp: 'page_up',
+  PageDown: 'page_down',
+  Home: 'home',
+  End: 'end',
+  Delete: 'delete',
+};
+
 export interface DirectKeyboardCallbacks {
   getShowCtrlAlpha(): boolean;
   getDisableFocusManagement(): boolean;
@@ -425,24 +439,22 @@ export class DirectKeyboardManager extends ManagerEventEmitter {
         return;
       }
 
-      // Prevent default for special keys (but NOT backspace - we need the input event to fire for iOS)
-      if (['Enter', 'Tab', 'Escape'].includes(e.key)) {
-        e.preventDefault();
+      if (this.inputManager?.isKeyboardShortcut(e)) {
+        return;
       }
 
-      if (e.key === 'Enter' && this.inputManager) {
-        this.inputManager.sendInput('enter');
+      const specialKey =
+        e.key === 'Tab' ? (e.shiftKey ? 'shift_tab' : 'tab') : HARDWARE_SPECIAL_KEYS[e.key];
+      if (specialKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        this.inputManager?.sendInput(specialKey);
       } else if (e.key === 'Backspace' && this.inputManager) {
         // Send backspace immediately on keydown for responsiveness
         // The input event handler will skip if this just fired (within 50ms)
         this.inputManager.sendInput('backspace');
         this.lastBackspaceTime = Date.now();
         // DON'T preventDefault - let browser also trigger input event for iOS key repeat
-      } else if (e.key === 'Tab' && this.inputManager) {
-        this.inputManager.sendInput(e.shiftKey ? 'shift_tab' : 'tab');
-      } else if (e.key === 'Escape') {
-        e.stopPropagation();
-        this.inputManager?.sendInput('escape');
       }
     });
 

--- a/web/src/client/components/session-view/input-manager.ts
+++ b/web/src/client/components/session-view/input-manager.ts
@@ -615,8 +615,8 @@ export class InputManager {
       target.closest?.('.editor-container') ||
       target.closest?.('inline-edit') // Allow typing in inline-edit component
     ) {
-      // Special exception: allow copy/paste shortcuts even in input fields (like our IME input)
-      if (isCopyPasteShortcut(e)) {
+      // Preserve native shortcuts in editable controls, including the terminal paste target.
+      if (isCopyPasteShortcut(e) || isBrowserShortcut(e)) {
         return true;
       }
       // Allow normal input in form fields and editors for other keys

--- a/web/src/client/components/session-view/lifecycle-event-manager.test.ts
+++ b/web/src/client/components/session-view/lifecycle-event-manager.test.ts
@@ -201,6 +201,102 @@ describe('LifecycleEventManager', () => {
       expect(mockCallbacks.handleKeyboardInput).not.toHaveBeenCalled();
     });
 
+    it('routes hardware keys from the terminal paste input', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        getInputManager: vi.fn().mockReturnValue({
+          isKeyboardShortcut: vi.fn().mockReturnValue(false),
+        }),
+        handleKeyboardInput: vi.fn(),
+      };
+      const pasteInput = document.createElement('textarea');
+      pasteInput.className = 'terminal-paste-input';
+      document.body.appendChild(pasteInput);
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+      manager.setSession({
+        id: 'test-session',
+        status: 'running',
+      } as Parameters<typeof manager.setSession>[0]);
+
+      try {
+        pasteInput.addEventListener('keydown', manager.mobileHardwareKeyboardHandler);
+        pasteInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+      } finally {
+        pasteInput.remove();
+      }
+
+      expect(eventUtils.consumeEvent).toHaveBeenCalledTimes(1);
+      expect(mockCallbacks.handleKeyboardInput).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes hardware keys from the contenteditable terminal surface', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        getInputManager: vi.fn().mockReturnValue({
+          isKeyboardShortcut: vi.fn().mockReturnValue(false),
+        }),
+        handleKeyboardInput: vi.fn(),
+      };
+      const terminal = document.createElement('vibe-terminal');
+      const terminalSurface = document.createElement('div');
+      terminalSurface.className = 'terminal-container';
+      terminalSurface.contentEditable = 'true';
+      terminal.appendChild(terminalSurface);
+      document.body.appendChild(terminal);
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+      manager.setSession({
+        id: 'test-session',
+        status: 'running',
+      } as Parameters<typeof manager.setSession>[0]);
+
+      try {
+        terminalSurface.addEventListener('keydown', manager.mobileHardwareKeyboardHandler);
+        terminalSurface.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'a', bubbles: true, composed: true })
+        );
+      } finally {
+        terminal.remove();
+      }
+
+      expect(eventUtils.consumeEvent).toHaveBeenCalledTimes(1);
+      expect(mockCallbacks.handleKeyboardInput).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes hardware keys from the terminal renderer textarea', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        getInputManager: vi.fn().mockReturnValue({
+          isKeyboardShortcut: vi.fn().mockReturnValue(false),
+        }),
+        handleKeyboardInput: vi.fn(),
+      };
+      const terminal = document.createElement('vibe-terminal');
+      const terminalInput = document.createElement('textarea');
+      terminalInput.setAttribute('aria-label', 'Terminal input');
+      terminal.appendChild(terminalInput);
+      document.body.appendChild(terminal);
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+      manager.setSession({
+        id: 'test-session',
+        status: 'running',
+      } as Parameters<typeof manager.setSession>[0]);
+
+      try {
+        terminalInput.addEventListener('keydown', manager.mobileHardwareKeyboardHandler);
+        terminalInput.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'a', bubbles: true, composed: true })
+        );
+      } finally {
+        terminal.remove();
+      }
+
+      expect(eventUtils.consumeEvent).toHaveBeenCalledTimes(1);
+      expect(mockCallbacks.handleKeyboardInput).toHaveBeenCalledTimes(1);
+    });
+
     it('leaves mobile keyboard events from Shadow DOM editors untouched', () => {
       const mockCallbacks = {
         getDisableFocusManagement: vi.fn().mockReturnValue(false),

--- a/web/src/client/components/session-view/lifecycle-event-manager.test.ts
+++ b/web/src/client/components/session-view/lifecycle-event-manager.test.ts
@@ -86,6 +86,55 @@ describe('LifecycleEventManager', () => {
       expect(eventUtils.consumeEvent).not.toHaveBeenCalled();
     });
 
+    it('handles the file browser shortcut before browser shortcut filtering', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        setShowFileBrowser: vi.fn(),
+        getInputManager: vi.fn().mockReturnValue({
+          isKeyboardShortcut: vi.fn().mockReturnValue(true),
+        }),
+        handleKeyboardInput: vi.fn(),
+      };
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+
+      const cmdOEvent = new KeyboardEvent('keydown', {
+        key: 'o',
+        metaKey: true,
+      });
+      manager.keyboardHandler(cmdOEvent);
+
+      expect(eventUtils.consumeEvent).toHaveBeenCalledWith(cmdOEvent);
+      expect(mockCallbacks.setShowFileBrowser).toHaveBeenCalledWith(true);
+      expect(mockCallbacks.getInputManager).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      { metaKey: true, shiftKey: true },
+      { ctrlKey: true, altKey: true },
+      { metaKey: true, ctrlKey: true },
+    ])('preserves modified browser O shortcuts: %o', (modifiers) => {
+      const isKeyboardShortcut = vi.fn().mockReturnValue(true);
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        setShowFileBrowser: vi.fn(),
+        getInputManager: vi.fn().mockReturnValue({ isKeyboardShortcut }),
+        handleKeyboardInput: vi.fn(),
+      };
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'o',
+        ...modifiers,
+      });
+      manager.keyboardHandler(event);
+
+      expect(isKeyboardShortcut).toHaveBeenCalledWith(event);
+      expect(eventUtils.consumeEvent).not.toHaveBeenCalled();
+      expect(mockCallbacks.setShowFileBrowser).not.toHaveBeenCalled();
+    });
+
     it('should leave native IME composition events to the browser', () => {
       const mockCallbacks = {
         getDisableFocusManagement: vi.fn().mockReturnValue(false),
@@ -197,6 +246,37 @@ describe('LifecycleEventManager', () => {
       }
 
       expect(eventUtils.consumeEvent).not.toHaveBeenCalled();
+      expect(mockCallbacks.getInputManager).not.toHaveBeenCalled();
+      expect(mockCallbacks.handleKeyboardInput).not.toHaveBeenCalled();
+    });
+
+    it('routes the mobile file browser shortcut from the hidden keyboard input', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        setShowFileBrowser: vi.fn(),
+        getInputManager: vi.fn(),
+        handleKeyboardInput: vi.fn(),
+      };
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+
+      try {
+        input.addEventListener('keydown', manager.mobileHardwareKeyboardHandler);
+        input.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'o',
+            metaKey: true,
+            bubbles: true,
+          })
+        );
+      } finally {
+        input.remove();
+      }
+
+      expect(eventUtils.consumeEvent).toHaveBeenCalledTimes(1);
+      expect(mockCallbacks.setShowFileBrowser).toHaveBeenCalledWith(true);
       expect(mockCallbacks.getInputManager).not.toHaveBeenCalled();
       expect(mockCallbacks.handleKeyboardInput).not.toHaveBeenCalled();
     });

--- a/web/src/client/components/session-view/lifecycle-event-manager.test.ts
+++ b/web/src/client/components/session-view/lifecycle-event-manager.test.ts
@@ -152,22 +152,112 @@ describe('LifecycleEventManager', () => {
       expect(mockCallbacks.handleKeyboardInput).toHaveBeenCalledWith(escapeEvent);
     });
 
-    it('ignores other mobile hardware keys outside direct keyboard mode', () => {
+    it('routes ordinary mobile hardware keys to the running terminal', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        getInputManager: vi.fn().mockReturnValue({
+          isKeyboardShortcut: vi.fn().mockReturnValue(false),
+        }),
+        handleKeyboardInput: vi.fn(),
+      };
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+      manager.setSession({
+        id: 'test-session',
+        status: 'running',
+      } as Parameters<typeof manager.setSession>[0]);
+
+      const keyEvent = new KeyboardEvent('keydown', { key: 'a' });
+      manager.mobileHardwareKeyboardHandler(keyEvent);
+
+      expect(eventUtils.consumeEvent).toHaveBeenCalledWith(keyEvent);
+      expect(mockCallbacks.handleKeyboardInput).toHaveBeenCalledWith(keyEvent);
+    });
+
+    it('leaves mobile keyboard events from editable controls untouched', () => {
       const mockCallbacks = {
         getDisableFocusManagement: vi.fn().mockReturnValue(false),
         getInputManager: vi.fn(),
         handleKeyboardInput: vi.fn(),
       };
+      const input = document.createElement('input');
+      document.body.appendChild(input);
 
       manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
-      manager.mobileHardwareKeyboardHandler(new KeyboardEvent('keydown', { key: 'a' }));
+      manager.setSession({
+        id: 'test-session',
+        status: 'running',
+      } as Parameters<typeof manager.setSession>[0]);
+
+      try {
+        input.addEventListener('keydown', manager.mobileHardwareKeyboardHandler);
+        input.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+      } finally {
+        input.remove();
+      }
 
       expect(eventUtils.consumeEvent).not.toHaveBeenCalled();
       expect(mockCallbacks.getInputManager).not.toHaveBeenCalled();
       expect(mockCallbacks.handleKeyboardInput).not.toHaveBeenCalled();
     });
 
-    it('registers and removes the mobile hardware Escape listener', () => {
+    it('leaves mobile keyboard events from Shadow DOM editors untouched', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        getInputManager: vi.fn(),
+        handleKeyboardInput: vi.fn(),
+      };
+      const inlineEdit = document.createElement('inline-edit');
+      const shadowRoot = inlineEdit.attachShadow({ mode: 'open' });
+      const input = document.createElement('input');
+      shadowRoot.appendChild(input);
+      document.body.appendChild(inlineEdit);
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+      manager.setSession({
+        id: 'test-session',
+        status: 'running',
+      } as Parameters<typeof manager.setSession>[0]);
+
+      try {
+        document.addEventListener('keydown', manager.mobileHardwareKeyboardHandler);
+        input.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'a', bubbles: true, composed: true })
+        );
+      } finally {
+        document.removeEventListener('keydown', manager.mobileHardwareKeyboardHandler);
+        inlineEdit.remove();
+      }
+
+      expect(eventUtils.consumeEvent).not.toHaveBeenCalled();
+      expect(mockCallbacks.getInputManager).not.toHaveBeenCalled();
+      expect(mockCallbacks.handleKeyboardInput).not.toHaveBeenCalled();
+    });
+
+    it('leaves mobile browser shortcuts to the browser', () => {
+      const mockCallbacks = {
+        getDisableFocusManagement: vi.fn().mockReturnValue(false),
+        getInputManager: vi.fn().mockReturnValue({
+          isKeyboardShortcut: vi.fn().mockReturnValue(true),
+        }),
+        handleKeyboardInput: vi.fn(),
+      };
+
+      manager.setCallbacks(mockCallbacks as Parameters<typeof manager.setCallbacks>[0]);
+      manager.setSession({
+        id: 'test-session',
+        status: 'running',
+      } as Parameters<typeof manager.setSession>[0]);
+
+      manager.mobileHardwareKeyboardHandler(
+        new KeyboardEvent('keydown', { key: 'l', metaKey: true })
+      );
+
+      expect(eventUtils.consumeEvent).not.toHaveBeenCalled();
+      expect(mockCallbacks.handleKeyboardInput).not.toHaveBeenCalled();
+    });
+
+    it('registers and removes the mobile hardware keyboard listener', () => {
       const mockCallbacks = {
         getDisableFocusManagement: vi.fn().mockReturnValue(false),
         getInputManager: vi.fn().mockReturnValue({
@@ -186,12 +276,12 @@ describe('LifecycleEventManager', () => {
       } as Parameters<typeof manager.setSession>[0]);
       lifecycle.setupEventListeners(true);
 
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
       expect(mockCallbacks.handleKeyboardInput).toHaveBeenCalledTimes(1);
 
       manager.cleanup();
       vi.clearAllMocks();
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a' }));
 
       expect(mockCallbacks.handleKeyboardInput).not.toHaveBeenCalled();
     });

--- a/web/src/client/components/session-view/lifecycle-event-manager.ts
+++ b/web/src/client/components/session-view/lifecycle-event-manager.ts
@@ -27,6 +27,11 @@ export type { LifecycleEventManagerCallbacks } from './interfaces.js';
 // Threshold for determining when keyboard is considered visible (in pixels)
 const KEYBOARD_VISIBLE_THRESHOLD = 50;
 
+function isFileBrowserShortcut(e: KeyboardEvent): boolean {
+  const hasSinglePrimaryModifier = e.metaKey !== e.ctrlKey;
+  return hasSinglePrimaryModifier && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'o';
+}
+
 export class LifecycleEventManager extends ManagerEventEmitter {
   private callbacks: LifecycleEventManagerCallbacks | null = null;
   private session: Session | null = null;
@@ -263,18 +268,17 @@ export class LifecycleEventManager extends ManagerEventEmitter {
       return;
     }
 
-    // Check if this is a browser shortcut we should allow FIRST before any other processing
-    const inputManager = this.callbacks.getInputManager();
-    if (inputManager?.isKeyboardShortcut(e)) {
-      // Let the browser handle this shortcut - don't call any preventDefault or stopPropagation
+    // App shortcuts take precedence over browser/system shortcut filtering.
+    if (isFileBrowserShortcut(e)) {
+      consumeEvent(e);
+      this.callbacks.setShowFileBrowser(true);
       return;
     }
 
-    // Handle Cmd+O / Ctrl+O to open file browser
-    if ((e.metaKey || e.ctrlKey) && e.key === 'o') {
-      // Stop propagation to prevent parent handlers from interfering with our file browser
-      consumeEvent(e);
-      this.callbacks.setShowFileBrowser(true);
+    // Check if this is a browser shortcut we should allow before terminal input processing.
+    const inputManager = this.callbacks.getInputManager();
+    if (inputManager?.isKeyboardShortcut(e)) {
+      // Let the browser handle this shortcut - don't call any preventDefault or stopPropagation
       return;
     }
 
@@ -303,6 +307,12 @@ export class LifecycleEventManager extends ManagerEventEmitter {
   };
 
   mobileHardwareKeyboardHandler = (e: KeyboardEvent): void => {
+    // The hidden mobile keyboard input still needs to expose app-level hardware shortcuts.
+    if (isFileBrowserShortcut(e)) {
+      this.keyboardHandler(e);
+      return;
+    }
+
     // Mobile's hidden software-keyboard input owns its events. Route only hardware
     // keyboard events that originate outside editable or interactive controls.
     for (const target of e.composedPath()) {

--- a/web/src/client/components/session-view/lifecycle-event-manager.ts
+++ b/web/src/client/components/session-view/lifecycle-event-manager.ts
@@ -37,7 +37,7 @@ export class LifecycleEventManager extends ManagerEventEmitter {
 
   // Event listener tracking
   private keyboardListenerAdded = false;
-  private mobileEscapeListenerAdded = false;
+  private mobileKeyboardListenerAdded = false;
   private touchListenersAdded = false;
   private visualViewportHandler: (() => void) | null = null;
   private viewportTrackingHandler: (() => void) | null = null;
@@ -303,9 +303,21 @@ export class LifecycleEventManager extends ManagerEventEmitter {
   };
 
   mobileHardwareKeyboardHandler = (e: KeyboardEvent): void => {
-    if (e.key === 'Escape') {
-      this.keyboardHandler(e);
+    // Mobile's hidden software-keyboard input owns its events. Route only hardware
+    // keyboard events that originate outside editable or interactive controls.
+    for (const target of e.composedPath()) {
+      if (
+        target instanceof HTMLElement &&
+        (target.matches(
+          'input, textarea, select, button, a[href], [role="button"], [role="link"], [contenteditable]:not([contenteditable="false"]), inline-edit'
+        ) ||
+          target.closest?.('.monaco-editor, [data-keybinding-context], .editor-container'))
+      ) {
+        return;
+      }
     }
+
+    this.keyboardHandler(e);
   };
 
   touchStartHandler = (e: TouchEvent): void => {
@@ -535,9 +547,9 @@ export class LifecycleEventManager extends ManagerEventEmitter {
       document.addEventListener('keydown', this.keyboardHandler);
       this.keyboardListenerAdded = true;
     } else if (isMobile) {
-      if (!this.mobileEscapeListenerAdded) {
+      if (!this.mobileKeyboardListenerAdded) {
         document.addEventListener('keydown', this.mobileHardwareKeyboardHandler);
-        this.mobileEscapeListenerAdded = true;
+        this.mobileKeyboardListenerAdded = true;
       }
       if (!this.touchListenersAdded) {
         // Add touch event listeners for mobile swipe gestures
@@ -590,9 +602,9 @@ export class LifecycleEventManager extends ManagerEventEmitter {
       document.removeEventListener('keydown', this.keyboardHandler);
       this.keyboardListenerAdded = false;
     }
-    if (this.mobileEscapeListenerAdded) {
+    if (this.mobileKeyboardListenerAdded) {
       document.removeEventListener('keydown', this.mobileHardwareKeyboardHandler);
-      this.mobileEscapeListenerAdded = false;
+      this.mobileKeyboardListenerAdded = false;
     }
     if (this.touchListenersAdded) {
       // Remove touch event listeners
@@ -649,9 +661,9 @@ export class LifecycleEventManager extends ManagerEventEmitter {
       document.removeEventListener('keydown', this.keyboardHandler);
       this.keyboardListenerAdded = false;
     }
-    if (this.mobileEscapeListenerAdded) {
+    if (this.mobileKeyboardListenerAdded) {
       document.removeEventListener('keydown', this.mobileHardwareKeyboardHandler);
-      this.mobileEscapeListenerAdded = false;
+      this.mobileKeyboardListenerAdded = false;
     }
     if (this.touchListenersAdded) {
       // Remove touch event listeners

--- a/web/src/client/components/session-view/lifecycle-event-manager.ts
+++ b/web/src/client/components/session-view/lifecycle-event-manager.ts
@@ -306,11 +306,19 @@ export class LifecycleEventManager extends ManagerEventEmitter {
     // Mobile's hidden software-keyboard input owns its events. Route only hardware
     // keyboard events that originate outside editable or interactive controls.
     for (const target of e.composedPath()) {
+      const isTerminalKeyboardTarget =
+        target instanceof HTMLElement &&
+        (target.matches('textarea.terminal-paste-input') ||
+          (target.closest('vibe-terminal') !== null &&
+            target.matches(
+              'textarea, [contenteditable]:not([contenteditable="false"]), .terminal-container, vibe-terminal'
+            )));
       if (
         target instanceof HTMLElement &&
-        (target.matches(
-          'input, textarea, select, button, a[href], [role="button"], [role="link"], [contenteditable]:not([contenteditable="false"]), inline-edit'
-        ) ||
+        ((!isTerminalKeyboardTarget &&
+          target.matches(
+            'input, textarea, select, button, a[href], [role="button"], [role="link"], [contenteditable]:not([contenteditable="false"]), inline-edit'
+          )) ||
           target.closest?.('.monaco-editor, [data-keybinding-context], .editor-container'))
       ) {
         return;

--- a/web/src/client/components/session-view/terminal-renderer.ts
+++ b/web/src/client/components/session-view/terminal-renderer.ts
@@ -62,6 +62,7 @@ export class TerminalRenderer extends LitElement {
         .hideScrollButton=${this.hideScrollButton}
         class="w-full h-full p-0 m-0 terminal-container"
         @click=${(e: Event) => this.handleClick(e)}
+        @touchend=${(e: Event) => this.handleClick(e)}
         @terminal-input=${(e: Event) => this.handleTerminalInput(e)}
         @terminal-resize=${(e: Event) => this.handleTerminalResize(e)}
         @terminal-ready=${(e: Event) => this.handleTerminalReady(e)}

--- a/web/src/client/utils/browser-shortcuts.test.ts
+++ b/web/src/client/utils/browser-shortcuts.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest';
+import { isBrowserShortcut, isCopyPasteShortcut } from './browser-shortcuts.js';
+
+const originalPlatform = navigator.platform;
+const originalUserAgent = navigator.userAgent;
+const originalMaxTouchPoints = navigator.maxTouchPoints;
+
+afterEach(() => {
+  Object.defineProperties(navigator, {
+    platform: { value: originalPlatform, configurable: true },
+    userAgent: { value: originalUserAgent, configurable: true },
+    maxTouchPoints: { value: originalMaxTouchPoints, configurable: true },
+  });
+});
+
+describe('browser shortcuts', () => {
+  it('preserves iPhone Command shortcuts', () => {
+    Object.defineProperties(navigator, {
+      platform: { value: 'iPhone', configurable: true },
+      userAgent: { value: 'Mobile Safari on iPhone', configurable: true },
+    });
+
+    expect(
+      isBrowserShortcut({
+        key: 'l',
+        ctrlKey: false,
+        metaKey: true,
+        altKey: false,
+        shiftKey: false,
+      })
+    ).toBe(true);
+    expect(
+      isCopyPasteShortcut({
+        key: 'v',
+        ctrlKey: false,
+        metaKey: true,
+        altKey: false,
+        shiftKey: false,
+      })
+    ).toBe(true);
+  });
+
+  it('preserves iPadOS Command shortcuts with desktop platform reporting', () => {
+    Object.defineProperties(navigator, {
+      platform: { value: 'MacIntel', configurable: true },
+      userAgent: { value: 'Mobile Safari', configurable: true },
+      maxTouchPoints: { value: 5, configurable: true },
+    });
+
+    expect(
+      isBrowserShortcut({
+        key: 'c',
+        ctrlKey: false,
+        metaKey: true,
+        altKey: false,
+        shiftKey: false,
+      })
+    ).toBe(true);
+  });
+});

--- a/web/src/client/utils/browser-shortcuts.ts
+++ b/web/src/client/utils/browser-shortcuts.ts
@@ -3,9 +3,20 @@
  * Centralized logic for detecting browser keyboard shortcuts
  */
 
-// Platform detection helper
-function isMacOS(): boolean {
-  return navigator.platform.toLowerCase().includes('mac');
+// Apple mobile hardware keyboards use Command even when navigator.platform is iPhone/iPad.
+function isApplePlatform(): boolean {
+  const platform = navigator.platform.toLowerCase();
+  const userAgent = navigator.userAgent.toLowerCase();
+  return platform.includes('mac') || /iphone|ipad|ipod/.test(`${platform} ${userAgent}`);
+}
+
+function isAppleMobilePlatform(): boolean {
+  const platform = navigator.platform.toLowerCase();
+  const userAgent = navigator.userAgent.toLowerCase();
+  return (
+    /iphone|ipad|ipod/.test(`${platform} ${userAgent}`) ||
+    (platform === 'macintel' && navigator.maxTouchPoints > 1)
+  );
 }
 
 // Constants for magic patterns
@@ -50,14 +61,19 @@ export function isBrowserShortcut(event: KeyboardShortcutEvent): boolean {
   const { key, ctrlKey, metaKey, altKey, shiftKey } = event;
   const keyLower = key.toLowerCase();
 
+  // iOS/iPadOS reserves Command chords for browser and system actions.
+  if (isAppleMobilePlatform() && metaKey && !ctrlKey) {
+    return true;
+  }
+
   // Platform-specific primary modifier
-  const primaryModifier = isMacOS() ? metaKey : ctrlKey;
-  const wrongModifier = isMacOS() ? ctrlKey : metaKey;
+  const primaryModifier = isApplePlatform() ? metaKey : ctrlKey;
+  const wrongModifier = isApplePlatform() ? ctrlKey : metaKey;
 
   // Early return if wrong modifier for platform
   if (wrongModifier || !primaryModifier) {
     // Special case: Alt+F4 on Windows
-    if (!isMacOS() && altKey && !ctrlKey && !metaKey && !shiftKey && keyLower === 'f4') {
+    if (!isApplePlatform() && altKey && !ctrlKey && !metaKey && !shiftKey && keyLower === 'f4') {
       return true;
     }
     return false;
@@ -65,8 +81,10 @@ export function isBrowserShortcut(event: KeyboardShortcutEvent): boolean {
 
   // Check modifier combinations
   const modifierKey = shiftKey ? 'withShift' : altKey ? 'withAlt' : 'noModifiers';
-  const platform = isMacOS() ? 'mac' : 'other';
-  const shortcuts = isMacOS() ? CRITICAL_SHORTCUTS.mac.withCmd : CRITICAL_SHORTCUTS.other.withCtrl;
+  const platform = isApplePlatform() ? 'mac' : 'other';
+  const shortcuts = isApplePlatform()
+    ? CRITICAL_SHORTCUTS.mac.withCmd
+    : CRITICAL_SHORTCUTS.other.withCtrl;
 
   // Check critical shortcuts
   if (shortcuts[modifierKey]?.includes(keyLower)) {
@@ -95,7 +113,7 @@ export function isCopyPasteShortcut(event: KeyboardShortcutEvent): boolean {
   const { key, ctrlKey, metaKey, altKey, shiftKey } = event;
   const keyLower = key.toLowerCase();
 
-  if (isMacOS()) {
+  if (isApplePlatform()) {
     return (
       metaKey && !ctrlKey && !altKey && !shiftKey && COPY_PASTE_SHORTCUTS.mac.includes(keyLower)
     );
@@ -110,7 +128,7 @@ export function isCopyPasteShortcut(event: KeyboardShortcutEvent): boolean {
  * Gets the platform name for display
  */
 export function getPlatformName(): 'mac' | 'windows' | 'linux' {
-  if (isMacOS()) return 'mac';
+  if (isApplePlatform()) return 'mac';
   if (navigator.platform.toLowerCase().includes('win')) return 'windows';
   return 'linux';
 }
@@ -119,5 +137,5 @@ export function getPlatformName(): 'mac' | 'windows' | 'linux' {
  * Formats a keyboard shortcut for display based on the current platform
  */
 export function formatShortcut(mac: string, other: string): string {
-  return isMacOS() ? mac : other;
+  return isApplePlatform() ? mac : other;
 }


### PR DESCRIPTION
## Summary

- route iOS hardware keyboard events to the active terminal without requiring the software keyboard toggle
- preserve browser shortcuts and editable controls
- restore terminal-session focus after mobile terminal interaction
- add focused regression coverage and a changelog entry

## Verification

- `pnpm check`
- focused session/input tests: 57 passed, 6 skipped
- client coverage suite: 672 passed, 14 skipped
- server coverage suite: 582 passed, 75 skipped
- fast browser E2E suite: 24 passed, 3 skipped
- exact production build with the repository Node and Zig toolchain
- live iPhone 17 simulator on iOS 26.5 Safari/WebKit: initial hardware typing, post-touch typing, Escape routing, software-keyboard toggle, Tab, and slash quick keys

Fixes #491
