### PR TITLE
fix(web): show friendly authentication labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Show friendly authentication labels in the web user menu instead of raw internal method names (#369)
 - Keep macOS DMG labels readable and fully visible across Finder toolbar settings (reported by [@MrMage](https://github.com/MrMage)) (#409)
 - Accept iOS hardware keyboard input without first opening the software keyboard (#491)
 - Keep iOS hardware Escape keys inside active terminal sessions (#492)

--- a/web/src/client/components/full-header.test.ts
+++ b/web/src/client/components/full-header.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment happy-dom
+
+import { fixture, html } from '@open-wc/testing';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import type { FullHeader } from './full-header';
+
+vi.mock('./notification-status.js', () => ({}));
+
+describe('FullHeader', () => {
+  beforeAll(async () => {
+    await import('./full-header');
+  });
+
+  it.each([
+    ['password', 'System Account'],
+    ['ssh-key', 'SSH Key'],
+    ['tailscale', 'Tailscale'],
+    [null, 'Authenticated'],
+    ['future-auth-method', 'Authenticated'],
+  ])('shows a friendly label for the %s auth method', async (authMethod, expectedLabel) => {
+    const element = await fixture<FullHeader>(html`
+      <full-header .currentUser=${'test-user'} .authMethod=${authMethod}></full-header>
+    `);
+
+    const menuButton = element.querySelector<HTMLButtonElement>('[title="User menu"]');
+    menuButton?.click();
+    await element.updateComplete;
+
+    expect(element.querySelector('[data-testid="auth-method-label"]')?.textContent?.trim()).toBe(
+      expectedLabel
+    );
+  });
+});

--- a/web/src/client/components/full-header.ts
+++ b/web/src/client/components/full-header.ts
@@ -12,6 +12,19 @@ import './theme-toggle-icon.js';
 
 @customElement('full-header')
 export class FullHeader extends HeaderBase {
+  private get authMethodLabel(): string {
+    switch (this.authMethod) {
+      case 'password':
+        return 'System Account';
+      case 'ssh-key':
+        return 'SSH Key';
+      case 'tailscale':
+        return 'Tailscale';
+      default:
+        return 'Authenticated';
+    }
+  }
+
   render() {
     const runningSessions = this.runningSessions;
 
@@ -125,8 +138,11 @@ export class FullHeader extends HeaderBase {
               <div
                 class="absolute right-0 top-full mt-1 bg-surface border border-border rounded-lg shadow-lg py-1 z-50 min-w-36"
               >
-                <div class="px-3 py-2 text-sm text-text-muted border-b border-border">
-                  ${this.authMethod || 'authenticated'}
+                <div
+                  class="px-3 py-2 text-sm text-text-muted border-b border-border"
+                  data-testid="auth-method-label"
+                >
+                  ${this.authMethodLabel}
                 </div>
                 <button
                   class="w-full text-left px-3 py-2 text-sm font-mono text-status-warning hover:bg-bg-secondary hover:text-status-error"


### PR DESCRIPTION
## Summary

- replace raw authentication method values in the full-header user menu with friendly labels
- show a neutral fallback for missing or future authentication methods
- add focused component coverage for system account, SSH key, Tailscale, null, and unknown values

Fixes #369.

## Verification

- `pnpm exec vitest run --mode=client src/client/components/full-header.test.ts --maxWorkers=4`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- full client suite: 705 passed, 14 skipped
- full server suite: 582 passed, 75 skipped
- `pnpm run build`
- structured autoreview: clean, no actionable findings

## Live proof

Loaded the exact production JS/CSS bundle in Chrome and verified:

- system account, SSH key, Tailscale, and unknown-method labels
- user menu opens and closes with Enter
- Tab reaches Logout
- 390x844 mobile viewport has no horizontal overflow and keeps the menu fully within the viewport

## Safety

Public Model Identifier Gate: PASS. No model identifiers exist in the exact diff, changed test, workflow surface, generated/public candidate artifacts, or this PR text.
