### PR TITLE
fix(mac): support Warp Preview terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Add Warp Preview as a selectable macOS terminal, including app detection and command launching. (#535)
 - Show friendly authentication labels in the web user menu instead of raw internal method names (#369)
 - Keep macOS DMG labels readable and fully visible across Finder toolbar settings (reported by [@MrMage](https://github.com/MrMage)) (#409)
 - Accept iOS hardware keyboard input without first opening the software keyboard (#491)

--- a/mac/VibeTunnel/Core/Constants/BundleIdentifiers.swift
+++ b/mac/VibeTunnel/Core/Constants/BundleIdentifiers.swift
@@ -17,6 +17,7 @@ enum BundleIdentifiers {
     static let ghostty = "com.mitchellh.ghostty"
     static let wezterm = "com.github.wez.wezterm"
     static let warp = "dev.warp.Warp-Stable"
+    static let warpPreview = "dev.warp.Warp-Preview"
     static let alacritty = "org.alacritty"
     static let hyper = "co.zeit.hyper"
     static let kitty = "net.kovidgoyal.kitty"

--- a/mac/VibeTunnel/Utilities/TerminalLauncher.swift
+++ b/mac/VibeTunnel/Utilities/TerminalLauncher.swift
@@ -76,6 +76,7 @@ enum Terminal: String, CaseIterable {
     case iTerm2
     case ghostty = "Ghostty"
     case warp = "Warp"
+    case warpPreview = "Warp Preview"
     case alacritty = "Alacritty"
     case hyper = "Hyper"
     case wezterm = "WezTerm"
@@ -91,6 +92,8 @@ enum Terminal: String, CaseIterable {
             BundleIdentifiers.ghostty
         case .warp:
             BundleIdentifiers.warp
+        case .warpPreview:
+            BundleIdentifiers.warpPreview
         case .alacritty:
             BundleIdentifiers.alacritty
         case .hyper:
@@ -108,6 +111,7 @@ enum Terminal: String, CaseIterable {
         case .terminal: 100 // Highest - macOS default, most popular
         case .iTerm2: 95 // Very popular among developers
         case .warp: 85 // Popular modern terminal
+        case .warpPreview: 84 // Prefer stable Warp when both channels are installed
         case .ghostty: 80 // New but gaining popularity
         case .kitty: 75 // Fast GPU-based terminal
         case .alacritty: 70 // Popular among power users
@@ -126,6 +130,7 @@ enum Terminal: String, CaseIterable {
         case .iTerm2: "iTerm2"
         case .ghostty: "Ghostty"
         case .warp: "Warp"
+        case .warpPreview: "WarpPreview"
         case .alacritty: "Alacritty"
         case .hyper: "Hyper"
         case .wezterm: "WezTerm"
@@ -134,10 +139,16 @@ enum Terminal: String, CaseIterable {
     }
 
     var isInstalled: Bool {
+        self.isInstalled { bundleIdentifier in
+            NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
+        }
+    }
+
+    func isInstalled(applicationURL: (String) -> URL?) -> Bool {
         if self == .terminal {
             return true // Terminal is always installed
         }
-        return NSWorkspace.shared.urlForApplication(withBundleIdentifier: self.bundleIdentifier) != nil
+        return applicationURL(self.bundleIdentifier) != nil
     }
 
     var appIcon: NSImage? {
@@ -148,7 +159,13 @@ enum Terminal: String, CaseIterable {
     }
 
     static var installed: [Self] {
-        allCases.filter(\.isInstalled)
+        self.installed { bundleIdentifier in
+            NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
+        }
+    }
+
+    static func installed(applicationURL: (String) -> URL?) -> [Self] {
+        allCases.filter { $0.isInstalled(applicationURL: applicationURL) }
     }
 
     /// Check if a specific terminal application is currently running
@@ -195,7 +212,7 @@ enum Terminal: String, CaseIterable {
         // Special handling for Warp terminal
         // Warp doesn't recognize standard key codes for Enter (36 or 76)
         // and requires ASCII character 13 (carriage return) to execute commands
-        if self == .warp {
+        if self == .warp || self == .warpPreview {
             return """
             tell application "\(self.processName)"
                 activate
@@ -277,7 +294,7 @@ enum Terminal: String, CaseIterable {
             // Use unified AppleScript approach for consistency
             .appleScript(script: self.unifiedAppleScript(for: config))
 
-        case .warp:
+        case .warp, .warpPreview:
             // Use unified AppleScript approach
             .appleScript(script: self.unifiedAppleScript(for: config))
 
@@ -302,6 +319,7 @@ enum Terminal: String, CaseIterable {
         case .iTerm2: "iTerm"
         case .ghostty: "ghostty" // lowercase for System Events
         case .warp: "Warp"
+        case .warpPreview: "WarpPreview"
         case .alacritty: "Alacritty"
         case .hyper: "Hyper"
         case .wezterm: "WezTerm"

--- a/mac/VibeTunnelTests/TerminalLaunchTests.swift
+++ b/mac/VibeTunnelTests/TerminalLaunchTests.swift
@@ -171,6 +171,33 @@ struct TerminalLaunchTests {
         #expect(script.contains("key code 36"))
     }
 
+    @Test
+    func warpPreviewUsesItsOwnAppIdentityAndWarpLaunchBehavior() {
+        #expect(Terminal.warpPreview.rawValue == "Warp Preview")
+        #expect(Terminal.warpPreview.bundleIdentifier == BundleIdentifiers.warpPreview)
+        #expect(Terminal.warpPreview.applicationName == "WarpPreview")
+        #expect(Terminal.warpPreview.processName == "WarpPreview")
+        #expect(Terminal.warpPreview.detectionPriority < Terminal.warp.detectionPriority)
+
+        let installed = Terminal.installed { bundleIdentifier in
+            bundleIdentifier == BundleIdentifiers.warpPreview
+                ? URL(fileURLWithPath: "/Applications/WarpPreview.app")
+                : nil
+        }
+        #expect(installed == [.terminal, .warpPreview])
+
+        let config = TerminalLaunchConfig(
+            command: "printf 'VibeTunnel Warp Preview test'",
+            workingDirectory: nil,
+            terminal: .warpPreview)
+        let script = Terminal.warpPreview.unifiedAppleScript(for: config)
+
+        #expect(script.contains("tell application \"WarpPreview\""))
+        #expect(script.contains("keystroke \"n\" using {command down}"))
+        #expect(script.contains("keystroke \"v\" using {command down}"))
+        #expect(script.contains("keystroke (ASCII character 13)"))
+    }
+
     // MARK: - Script File Tests
 
     @Test


### PR DESCRIPTION
## Summary
- add Warp Preview as a first-class macOS terminal choice
- detect its signed application bundle while preferring stable Warp when both channels are installed
- reuse Warp's carriage-return launch behavior and cover detection, identity, priority, and command delivery

Fixes #535

## Verification
- source-only SwiftFormat lint: 190 files clean
- SwiftLint: changed production files clean; full lint has only three pre-existing warnings
- focused `TerminalLaunchTests`: passed
- full macOS Debug build: passed
- full macOS test scheme: passed
- autoreview: no actionable findings

## Live proof
Tested the exact Debug app candidate with the current provider-signed Warp Preview application installed in `/Applications`. VibeTunnel showed the real application and icon in Advanced Settings, persisted the selection across restart, and its terminal test launched Warp Preview and delivered the paste/Enter sequence. A fresh Warp Preview install stopped at provider account onboarding, so authenticated shell execution was not available; no credentials or private terminal content are included here.
