### PR TITLE
fix(mac): improve terminal permission recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Guide macOS terminal-test permission failures to the correct Automation or Accessibility settings pane (#554)
 - Add Warp Preview as a selectable macOS terminal, including app detection and command launching. (#535)
 - Show friendly authentication labels in the web user menu instead of raw internal method names (#369)
 - Keep macOS DMG labels readable and fully visible across Finder toolbar settings (reported by [@MrMage](https://github.com/MrMage)) (#409)

--- a/mac/VibeTunnel/Core/Models/TerminalLaunchAlertContent.swift
+++ b/mac/VibeTunnel/Core/Models/TerminalLaunchAlertContent.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// User-facing alert content for terminal launch failures.
+struct TerminalLaunchAlertContent {
+    let title: String
+    let message: String
+    let recoveryPermission: SystemPermission?
+
+    private init(
+        title: String,
+        message: String,
+        recoveryPermission: SystemPermission?)
+    {
+        self.title = title
+        self.message = message
+        self.recoveryPermission = recoveryPermission
+    }
+
+    init(error: Error, terminalName: String) {
+        guard let terminalError = error as? TerminalLauncherError else {
+            self.title = "Terminal Launch Failed"
+            self.message = error.localizedDescription
+            self.recoveryPermission = nil
+            return
+        }
+
+        switch terminalError {
+        case .appleScriptPermissionDenied:
+            self = Self.automationPermissionDenied
+        case .accessibilityPermissionDenied:
+            self = Self.accessibilityPermissionDenied(terminalName: terminalName)
+        case .terminalNotFound:
+            self.title = "Terminal Not Found"
+            self.message = "The selected terminal application could not be found. Please select a different terminal."
+            self.recoveryPermission = nil
+        case let .appleScriptExecutionFailed(details, errorCode):
+            self = Self.appleScriptExecutionFailure(
+                details: details,
+                errorCode: errorCode,
+                terminalName: terminalName)
+        case let .processLaunchFailed(details):
+            self.title = "Process Launch Failed"
+            self.message = "Failed to start terminal process: \(details)"
+            self.recoveryPermission = nil
+        }
+    }
+
+    private static var automationPermissionDenied: Self {
+        Self(
+            title: "Permission Denied",
+            message: """
+            VibeTunnel needs permission to control terminal applications.
+
+            Please grant Automation permission in System Settings > Privacy & Security > Automation.
+            """,
+            recoveryPermission: .appleScript)
+    }
+
+    private static func accessibilityPermissionDenied(terminalName: String) -> Self {
+        Self(
+            title: "Accessibility Permission Required",
+            message: """
+            VibeTunnel needs Accessibility permission to send keystrokes to \(terminalName).
+
+            Please grant permission in System Settings > Privacy & Security > Accessibility.
+            """,
+            recoveryPermission: .accessibility)
+    }
+
+    private static func appleScriptExecutionFailure(
+        details: String,
+        errorCode: Int?,
+        terminalName: String)
+        -> Self
+    {
+        switch errorCode {
+        case -1743:
+            self.automationPermissionDenied
+        case 1002, -25211, -1719:
+            self.accessibilityPermissionDenied(terminalName: terminalName)
+        case -1728:
+            Self(
+                title: "Terminal Not Available",
+                message: "The terminal application is not running or cannot be controlled.\n\nDetails: \(details)",
+                recoveryPermission: nil)
+        case -1708:
+            Self(
+                title: "Terminal Communication Error",
+                message: "The terminal did not respond to the command.\n\nDetails: \(details)",
+                recoveryPermission: nil)
+        case let code?:
+            Self(
+                title: "Terminal Launch Failed",
+                message: "AppleScript error \(code): \(details)",
+                recoveryPermission: nil)
+        case nil:
+            Self(
+                title: "Terminal Launch Failed",
+                message: "Failed to launch terminal: \(details)",
+                recoveryPermission: nil)
+        }
+    }
+}

--- a/mac/VibeTunnel/Core/Services/SystemPermissionManager.swift
+++ b/mac/VibeTunnel/Core/Services/SystemPermissionManager.swift
@@ -71,13 +71,17 @@ enum SystemPermission {
         }
     }
 
-    fileprivate var settingsURLString: String {
+    private var settingsURLString: String {
         switch self {
         case .appleScript:
             "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation"
         case .accessibility:
             "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
         }
+    }
+
+    var settingsURL: URL? {
+        URL(string: self.settingsURLString)
     }
 }
 
@@ -349,7 +353,7 @@ final class SystemPermissionManager {
     // MARK: - Utilities
 
     private func openSystemSettings(for permission: SystemPermission) {
-        if let url = URL(string: permission.settingsURLString) {
+        if let url = permission.settingsURL {
             NSWorkspace.shared.open(url)
         }
     }

--- a/mac/VibeTunnel/Presentation/Views/Settings/AdvancedSettingsView.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/AdvancedSettingsView.swift
@@ -138,6 +138,7 @@ private struct TerminalPreferenceSection: View {
     @State private var showingError = false
     @State private var errorMessage = ""
     @State private var errorTitle = "Terminal Launch Failed"
+    @State private var recoveryPermission: SystemPermission?
 
     var body: some View {
         Section {
@@ -154,56 +155,12 @@ private struct TerminalPreferenceSection: View {
                                 // Log the error
                                 Logger.advanced.error("Failed to launch terminal test: \(error)")
 
-                                // Set up alert content based on error type
-                                if let terminalError = error as? TerminalLauncherError {
-                                    switch terminalError {
-                                    case .appleScriptPermissionDenied:
-                                        self.errorTitle = "Permission Denied"
-                                        self.errorMessage =
-                                            "VibeTunnel needs permission to control terminal applications.\n\nPlease grant Automation permission in System Settings > Privacy & Security > Automation."
-                                    case .accessibilityPermissionDenied:
-                                        self.errorTitle = "Accessibility Permission Required"
-                                        self.errorMessage =
-                                            "VibeTunnel needs Accessibility permission to send keystrokes to \(Terminal(rawValue: self.preferredTerminal)?.displayName ?? "terminal").\n\nPlease grant permission in System Settings > Privacy & Security > Accessibility."
-                                    case .terminalNotFound:
-                                        self.errorTitle = "Terminal Not Found"
-                                        self.errorMessage =
-                                            "The selected terminal application could not be found. Please select a different terminal."
-                                    case let .appleScriptExecutionFailed(details, errorCode):
-                                        if let code = errorCode {
-                                            switch code {
-                                            case -1743:
-                                                self.errorTitle = "Permission Denied"
-                                                self.errorMessage =
-                                                    "VibeTunnel needs permission to control terminal applications.\n\nPlease grant Automation permission in System Settings > Privacy & Security > Automation."
-                                            case -1728:
-                                                self.errorTitle = "Terminal Not Available"
-                                                self.errorMessage =
-                                                    "The terminal application is not running or cannot be controlled.\n\nDetails: \(details)"
-                                            case -1708:
-                                                self.errorTitle = "Terminal Communication Error"
-                                                self.errorMessage =
-                                                    "The terminal did not respond to the command.\n\nDetails: \(details)"
-                                            case -25211:
-                                                self.errorTitle = "Accessibility Permission Required"
-                                                self.errorMessage =
-                                                    "System Events requires Accessibility permission to send keystrokes.\n\nPlease grant permission in System Settings > Privacy & Security > Accessibility."
-                                            default:
-                                                self.errorTitle = "Terminal Launch Failed"
-                                                self.errorMessage = "AppleScript error \(code): \(details)"
-                                            }
-                                        } else {
-                                            self.errorTitle = "Terminal Launch Failed"
-                                            self.errorMessage = "Failed to launch terminal: \(details)"
-                                        }
-                                    case let .processLaunchFailed(details):
-                                        self.errorTitle = "Process Launch Failed"
-                                        self.errorMessage = "Failed to start terminal process: \(details)"
-                                    }
-                                } else {
-                                    self.errorTitle = "Terminal Launch Failed"
-                                    self.errorMessage = error.localizedDescription
-                                }
+                                let alert = TerminalLaunchAlertContent(
+                                    error: error,
+                                    terminalName: Terminal(rawValue: self.preferredTerminal)?.displayName ?? "terminal")
+                                self.errorTitle = alert.title
+                                self.errorMessage = alert.message
+                                self.recoveryPermission = alert.recoveryPermission
 
                                 self.showingError = true
                             }
@@ -258,11 +215,9 @@ private struct TerminalPreferenceSection: View {
         }
         .alert(self.errorTitle, isPresented: self.$showingError) {
             Button("OK") {}
-            if self.errorTitle == "Permission Denied" {
+            if let recoveryPermission = self.recoveryPermission {
                 Button("Open System Settings") {
-                    if let url =
-                        URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation")
-                    {
+                    if let url = recoveryPermission.settingsURL {
                         NSWorkspace.shared.open(url)
                     }
                 }

--- a/mac/VibeTunnel/Presentation/Views/Welcome/SelectTerminalPageView.swift
+++ b/mac/VibeTunnel/Presentation/Views/Welcome/SelectTerminalPageView.swift
@@ -19,6 +19,7 @@ struct SelectTerminalPageView: View {
     @State private var showingError = false
     @State private var errorTitle = ""
     @State private var errorMessage = ""
+    @State private var recoveryPermission: SystemPermission?
 
     var body: some View {
         VStack(spacing: 30) {
@@ -66,11 +67,9 @@ struct SelectTerminalPageView: View {
         .padding()
         .alert(self.errorTitle, isPresented: self.$showingError) {
             Button("OK") {}
-            if self.errorTitle == "Permission Denied" {
+            if let recoveryPermission = self.recoveryPermission {
                 Button("Open System Settings") {
-                    if let url =
-                        URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation")
-                    {
+                    if let url = recoveryPermission.settingsURL {
                         NSWorkspace.shared.open(url)
                     }
                 }
@@ -87,55 +86,12 @@ struct SelectTerminalPageView: View {
                     .launchCommand(
                         "echo 'VibeTunnel Terminal Test: Success! You can now use VibeTunnel with your terminal.'")
             } catch {
-                // Handle errors
-                if let terminalError = error as? TerminalLauncherError {
-                    switch terminalError {
-                    case .appleScriptPermissionDenied:
-                        self.errorTitle = "Permission Denied"
-                        self.errorMessage =
-                            "VibeTunnel needs permission to control terminal applications.\n\nPlease grant Automation permission in System Settings > Privacy & Security > Automation."
-                    case .accessibilityPermissionDenied:
-                        self.errorTitle = "Accessibility Permission Required"
-                        self.errorMessage =
-                            "VibeTunnel needs Accessibility permission to send keystrokes to \(Terminal(rawValue: self.preferredTerminal)?.displayName ?? "terminal").\n\nPlease grant permission in System Settings > Privacy & Security > Accessibility."
-                    case .terminalNotFound:
-                        self.errorTitle = "Terminal Not Found"
-                        self.errorMessage =
-                            "The selected terminal application could not be found. Please select a different terminal."
-                    case let .appleScriptExecutionFailed(details, errorCode):
-                        if let code = errorCode {
-                            switch code {
-                            case -1743:
-                                self.errorTitle = "Permission Denied"
-                                self.errorMessage =
-                                    "VibeTunnel needs permission to control terminal applications.\n\nPlease grant Automation permission in System Settings > Privacy & Security > Automation."
-                            case -1728:
-                                self.errorTitle = "Terminal Not Available"
-                                self.errorMessage =
-                                    "The terminal application is not running or cannot be controlled.\n\nDetails: \(details)"
-                            case -1708:
-                                self.errorTitle = "Terminal Communication Error"
-                                self.errorMessage = "The terminal did not respond to the command.\n\nDetails: \(details)"
-                            case -25211:
-                                self.errorTitle = "Accessibility Permission Required"
-                                self.errorMessage =
-                                    "System Events requires Accessibility permission to send keystrokes.\n\nPlease grant permission in System Settings > Privacy & Security > Accessibility."
-                            default:
-                                self.errorTitle = "Terminal Launch Failed"
-                                self.errorMessage = "AppleScript error \(code): \(details)"
-                            }
-                        } else {
-                            self.errorTitle = "Terminal Launch Failed"
-                            self.errorMessage = "Failed to launch terminal: \(details)"
-                        }
-                    case let .processLaunchFailed(details):
-                        self.errorTitle = "Process Launch Failed"
-                        self.errorMessage = "Failed to start terminal process: \(details)"
-                    }
-                } else {
-                    self.errorTitle = "Terminal Launch Failed"
-                    self.errorMessage = error.localizedDescription
-                }
+                let alert = TerminalLaunchAlertContent(
+                    error: error,
+                    terminalName: Terminal(rawValue: self.preferredTerminal)?.displayName ?? "terminal")
+                self.errorTitle = alert.title
+                self.errorMessage = alert.message
+                self.recoveryPermission = alert.recoveryPermission
 
                 self.showingError = true
             }

--- a/mac/VibeTunnelTests/TerminalLaunchTests.swift
+++ b/mac/VibeTunnelTests/TerminalLaunchTests.swift
@@ -139,6 +139,14 @@ struct TerminalLaunchTests {
             Issue.record("Expected accessibility permission error for AppleScript code \(errorCode)")
             return
         }
+
+        let alert = TerminalLaunchAlertContent(
+            error: error.toTerminalLauncherError(),
+            terminalName: "iTerm2")
+        #expect(alert.title == "Accessibility Permission Required")
+        #expect(alert.message.contains("iTerm2"))
+        #expect(alert.recoveryPermission == .accessibility)
+        #expect(alert.recoveryPermission?.settingsURL?.absoluteString.contains("Privacy_Accessibility") == true)
     }
 
     @Test
@@ -154,6 +162,13 @@ struct TerminalLaunchTests {
             Issue.record("Expected automation permission error")
             return
         }
+
+        let alert = TerminalLaunchAlertContent(
+            error: error.toTerminalLauncherError(),
+            terminalName: "iTerm2")
+        #expect(alert.title == "Permission Denied")
+        #expect(alert.recoveryPermission == .appleScript)
+        #expect(alert.recoveryPermission?.settingsURL?.absoluteString.contains("Privacy_Automation") == true)
     }
 
     @Test


### PR DESCRIPTION
Fixes #554.

## Summary

- centralize terminal-launch alert content shared by onboarding and Advanced Settings
- route Automation failures to Automation settings and keystroke-denial failures to Accessibility settings
- preserve specific terminal-not-found, communication, and process-launch diagnostics
- add regression coverage for the reported macOS error and related permission codes

## Verification

- focused `TerminalLaunchTests`: passed
- full macOS test suite: passed
- SwiftFormat and focused SwiftLint: passed
- autoreview: no actionable findings
- exact built app live proof: reset the app's Accessibility grant, selected iTerm2, and ran the onboarding terminal test; the app showed the Accessibility-specific recovery alert and `Open System Settings` opened Privacy & Security > Accessibility directly

## Safety

Public Model Identifier Gate: PASS. No model identifiers are present in the exact diff, changed tests, workflow changes, or public proof.
