### PR TITLE
fix(server): preserve Tailscale Serve background state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Report Tailscale Serve as running after its background setup command exits successfully, instead of leaving the macOS app stuck on “Starting…” (#556)
 - Guide macOS terminal-test permission failures to the correct Automation or Accessibility settings pane (#554)
 - Add Warp Preview as a selectable macOS terminal, including app detection and command launching. (#535)
 - Show friendly authentication labels in the web user menu instead of raw internal method names (#369)

--- a/web/src/server/services/tailscale-serve-service-start.test.ts
+++ b/web/src/server/services/tailscale-serve-service-start.test.ts
@@ -42,8 +42,14 @@ describe('TailscaleServeService startup', () => {
     (
       service as unknown as {
         checkTailscaleAvailable(): Promise<void>;
+        verifyServeConfiguration(port: number): Promise<boolean>;
       }
     ).checkTailscaleAvailable = vi.fn().mockResolvedValue(undefined);
+    (
+      service as unknown as {
+        verifyServeConfiguration(port: number): Promise<boolean>;
+      }
+    ).verifyServeConfiguration = vi.fn().mockResolvedValue(true);
   });
 
   afterEach(() => {
@@ -87,5 +93,48 @@ describe('TailscaleServeService startup', () => {
 
     await service.stop();
     expect(service.isRunning()).toBe(false);
+  });
+
+  it('waits for the persistent proxy to become observable before resolving startup', async () => {
+    const resetProcess = fakeProcess();
+    const serveProcess = fakeProcess();
+    const verificationMock = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    (
+      service as unknown as {
+        verifyServeConfiguration(port: number): Promise<boolean>;
+      }
+    ).verifyServeConfiguration = verificationMock;
+
+    spawnMock
+      .mockImplementationOnce(
+        (_command: string, _args: readonly string[], _options: SpawnOptions) => {
+          queueMicrotask(() => resetProcess.emit('exit', 0, null));
+          return resetProcess;
+        }
+      )
+      .mockImplementationOnce(
+        (_command: string, _args: readonly string[], _options: StdioOptions) => {
+          queueMicrotask(() => serveProcess.emit('exit', 0, null));
+          return serveProcess;
+        }
+      );
+
+    const startPromise = service.start(43213);
+    let resolved = false;
+    void startPromise.then(() => {
+      resolved = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(resolved).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(200);
+    await expect(startPromise).resolves.toBeUndefined();
+    expect(verificationMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/web/src/server/services/tailscale-serve-service-start.test.ts
+++ b/web/src/server/services/tailscale-serve-service-start.test.ts
@@ -1,0 +1,91 @@
+import type { ChildProcess, SpawnOptions, StdioOptions } from 'child_process';
+import { EventEmitter } from 'events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock,
+}));
+
+vi.mock('../utils/logger.js', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    log: vi.fn(),
+  })),
+}));
+
+import { TailscaleServeServiceImpl } from './tailscale-serve-service.js';
+
+function fakeProcess(): ChildProcess {
+  const process = new EventEmitter() as EventEmitter & Partial<ChildProcess>;
+  process.stdout = new EventEmitter() as ChildProcess['stdout'];
+  process.stderr = new EventEmitter() as ChildProcess['stderr'];
+  process.killed = false;
+  process.kill = vi.fn(() => {
+    process.killed = true;
+    return true;
+  });
+  return process as ChildProcess;
+}
+
+describe('TailscaleServeService startup', () => {
+  let service: TailscaleServeServiceImpl;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    spawnMock.mockReset();
+    service = new TailscaleServeServiceImpl();
+    (
+      service as unknown as {
+        checkTailscaleAvailable(): Promise<void>;
+      }
+    ).checkTailscaleAvailable = vi.fn().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('keeps the configured port when --bg exits successfully near the startup deadline', async () => {
+    const resetProcess = fakeProcess();
+    const serveProcess = fakeProcess();
+    const stopResetProcess = fakeProcess();
+
+    spawnMock
+      .mockImplementationOnce(
+        (_command: string, _args: readonly string[], _options: SpawnOptions) => {
+          queueMicrotask(() => resetProcess.emit('exit', 0, null));
+          return resetProcess;
+        }
+      )
+      .mockImplementationOnce(
+        (_command: string, _args: readonly string[], _options: StdioOptions) => {
+          setTimeout(() => serveProcess.emit('exit', 0, null), 2_500);
+          return serveProcess;
+        }
+      )
+      .mockImplementationOnce(
+        (_command: string, _args: readonly string[], _options: SpawnOptions) => {
+          queueMicrotask(() => stopResetProcess.emit('exit', 0, null));
+          return stopResetProcess;
+        }
+      );
+
+    const startPromise = service.start(43213);
+    await vi.advanceTimersByTimeAsync(3_001);
+
+    await expect(startPromise).resolves.toBeUndefined();
+    expect(service.isRunning()).toBe(true);
+    expect(await service.getStatus()).toMatchObject({
+      isRunning: true,
+      port: 43213,
+    });
+
+    await service.stop();
+    expect(service.isRunning()).toBe(false);
+  });
+});

--- a/web/src/server/services/tailscale-serve-service.test.ts
+++ b/web/src/server/services/tailscale-serve-service.test.ts
@@ -36,27 +36,40 @@ describe('TailscaleServeService Integration Tests', () => {
   });
 
   describe('Exit Code Handling', () => {
-    it('correctly interprets exit code 0 as success', async () => {
-      // This test verifies the fix for the critical bug where exit code 0 was treated as failure
+    it('preserves configured state after a successful background command exit', () => {
+      const internals = service as unknown as {
+        currentPort: number | null;
+        isStarting: boolean;
+        serveProcess: { killed: boolean; kill: ReturnType<typeof vi.fn> } | null;
+        handleServeProcessExit(code: number | null, signal: NodeJS.Signals | null): void;
+      };
+      internals.currentPort = 43213;
+      internals.isStarting = false;
+      internals.serveProcess = { killed: true, kill: vi.fn() };
 
-      // Mock environment to test exit code logic without actually starting Tailscale
-      const originalEnv = process.env.VIBETUNNEL_TAILSCALE_ERROR;
+      internals.handleServeProcessExit(0, null);
 
-      try {
-        // Test successful status (no error environment variable)
-        delete process.env.VIBETUNNEL_TAILSCALE_ERROR;
+      expect(internals.serveProcess).toBeNull();
+      expect(internals.currentPort).toBe(43213);
+      expect(service.isRunning()).toBe(true);
+    });
 
-        const status = await service.getStatus();
+    it('clears configured state after a failed background command exit', () => {
+      const internals = service as unknown as {
+        currentPort: number | null;
+        isStarting: boolean;
+        serveProcess: { killed: boolean; kill: ReturnType<typeof vi.fn> } | null;
+        handleServeProcessExit(code: number | null, signal: NodeJS.Signals | null): void;
+      };
+      internals.currentPort = 43213;
+      internals.isStarting = false;
+      internals.serveProcess = { killed: true, kill: vi.fn() };
 
-        // If there's no explicit error set, the service should report based on actual state
-        expect(typeof status.isRunning).toBe('boolean');
-        expect(status.lastError === undefined || typeof status.lastError === 'string').toBe(true);
-      } finally {
-        // Restore original environment
-        if (originalEnv !== undefined) {
-          process.env.VIBETUNNEL_TAILSCALE_ERROR = originalEnv;
-        }
-      }
+      internals.handleServeProcessExit(1, null);
+
+      expect(internals.serveProcess).toBeNull();
+      expect(internals.currentPort).toBeNull();
+      expect(service.isRunning()).toBe(false);
     });
 
     it('handles error states correctly', async () => {

--- a/web/src/server/services/tailscale-serve-service.test.ts
+++ b/web/src/server/services/tailscale-serve-service.test.ts
@@ -89,6 +89,62 @@ describe('TailscaleServeService Integration Tests', () => {
   });
 
   describe('Status Verification', () => {
+    it('reports a clean idle status before Serve has been configured', async () => {
+      const internals = service as unknown as {
+        currentPort: number | null;
+        verifyServeConfiguration(port: number): Promise<boolean>;
+        checkServeAvailability(): Promise<string>;
+      };
+      internals.currentPort = null;
+      internals.verifyServeConfiguration = vi.fn().mockResolvedValue(false);
+      internals.checkServeAvailability = vi.fn().mockResolvedValue('');
+      delete process.env.VIBETUNNEL_SKIP_TAILSCALE;
+
+      try {
+        await expect(service.getStatus()).resolves.toMatchObject({
+          isRunning: false,
+          port: undefined,
+          lastError: undefined,
+        });
+      } finally {
+        process.env.VIBETUNNEL_SKIP_TAILSCALE = '1';
+      }
+    });
+
+    it.each([
+      { desiredFunnel: false, funnelEnabled: false, mode: 'private' },
+      { desiredFunnel: true, funnelEnabled: true, mode: 'public' },
+    ])('reports stopped in $mode mode when the persistent proxy configuration disappears', async ({
+      desiredFunnel,
+      funnelEnabled,
+    }) => {
+      const internals = service as unknown as {
+        currentPort: number | null;
+        desiredFunnel: boolean;
+        funnelEnabled: boolean;
+        isStarting: boolean;
+        verifyServeConfiguration(port: number): Promise<boolean>;
+        checkServeAvailability(): Promise<string>;
+      };
+      internals.currentPort = 43213;
+      internals.desiredFunnel = desiredFunnel;
+      internals.funnelEnabled = funnelEnabled;
+      internals.isStarting = false;
+      internals.verifyServeConfiguration = vi.fn().mockResolvedValue(false);
+      internals.checkServeAvailability = vi.fn().mockResolvedValue('');
+      delete process.env.VIBETUNNEL_SKIP_TAILSCALE;
+
+      try {
+        await expect(service.getStatus()).resolves.toMatchObject({
+          isRunning: false,
+          port: undefined,
+          lastError: 'Tailscale Serve proxy not configured for this port',
+        });
+      } finally {
+        process.env.VIBETUNNEL_SKIP_TAILSCALE = '1';
+      }
+    });
+
     it('provides consistent status information', async () => {
       const status = await service.getStatus();
 

--- a/web/src/server/services/tailscale-serve-service.ts
+++ b/web/src/server/services/tailscale-serve-service.ts
@@ -114,17 +114,7 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
       });
 
       this.serveProcess.on('exit', (code, signal) => {
-        logger.info(`Tailscale Serve process exited with code ${code}, signal ${signal}`);
-        if (code !== 0) {
-          // Check if this is the common "Serve not enabled" error
-          if (this.lastError?.includes('Serve is not enabled on your tailnet')) {
-            // Keep the more user-friendly error message we set in stderr handler
-            logger.info('Tailscale Serve failed due to tailnet permissions');
-          } else {
-            this.lastError = `Process exited with code ${code}`;
-          }
-        }
-        this.cleanup();
+        this.handleServeProcessExit(code, signal);
       });
 
       // Log stdout/stderr
@@ -197,10 +187,9 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
               logger.info('Tailscale Serve configured successfully (exit code 0)');
               // The serve process is now running in background
               this.serveProcess = null; // Clear reference as process has exited
-              // Give the configuration a moment to take effect
-              setTimeout(() => {
-                settlePromise(true); // SUCCESS - proxy is configured
-              }, 500);
+              // Exit code 0 is the CLI's completion signal. Settle immediately so the
+              // startup timeout cannot clear the configured port before status polling.
+              settlePromise(true);
             } else {
               settlePromise(false, `Tailscale Serve failed with exit code ${code}`);
             }
@@ -415,6 +404,7 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
 
     if (!this.serveProcess) {
       logger.debug('No Tailscale Serve process to stop');
+      this.cleanup();
       return;
     }
 
@@ -928,6 +918,26 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
 
     logger.warn(`No proxy configuration found for port ${port} in Tailscale serve status`);
     return false;
+  }
+
+  private handleServeProcessExit(code: number | null, signal: NodeJS.Signals | null): void {
+    logger.info(`Tailscale Serve process exited with code ${code}, signal ${signal}`);
+
+    // `tailscale serve --bg` exits after successfully installing the persistent proxy.
+    // Keep the configured port so status checks verify the proxy instead of falling back to 4020.
+    if (code === 0) {
+      this.serveProcess = null;
+      return;
+    }
+
+    // Check if this is the common "Serve not enabled" error.
+    if (this.lastError?.includes('Serve is not enabled on your tailnet')) {
+      // Keep the more user-friendly error message we set in stderr handler.
+      logger.info('Tailscale Serve failed due to tailnet permissions');
+    } else {
+      this.lastError = `Process exited with code ${code}`;
+    }
+    this.cleanup();
   }
 
   private cleanup(): void {

--- a/web/src/server/services/tailscale-serve-service.ts
+++ b/web/src/server/services/tailscale-serve-service.ts
@@ -187,9 +187,16 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
               logger.info('Tailscale Serve configured successfully (exit code 0)');
               // The serve process is now running in background
               this.serveProcess = null; // Clear reference as process has exited
-              // Exit code 0 is the CLI's completion signal. Settle immediately so the
-              // startup timeout cannot clear the configured port before status polling.
-              settlePromise(true);
+              clearTimeout(timeout);
+              void this.waitForServeConfiguration(port).then(
+                (isConfigured) => {
+                  settlePromise(
+                    isConfigured,
+                    'Tailscale Serve proxy was not configured after the command completed'
+                  );
+                },
+                (error) => settlePromise(false, error)
+              );
             } else {
               settlePromise(false, `Tailscale Serve failed with exit code ${code}`);
             }
@@ -588,8 +595,11 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
             `✅ [TAILSCALE STATUS] Found manually configured Tailscale Serve for port ${portToCheck}`
           );
         } else {
-          // No configuration found - this is a normal case, not an error
-          verificationError = 'Tailscale Serve is starting up or needs reconfiguration';
+          // No configuration is expected while idle. Only report an error when a
+          // previously configured proxy has disappeared.
+          if (this.currentPort !== null) {
+            verificationError = 'Tailscale Serve is starting up or needs reconfiguration';
+          }
           logger.info(
             `[TAILSCALE STATUS] No Serve configuration found for port ${portToCheck} - may need restart`
           );
@@ -621,21 +631,14 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
     // This handles the case where --bg makes the process exit immediately
     const desiredMode = this.desiredFunnel ? 'public' : 'private';
     const actualMode = this.funnelEnabled ? 'public' : 'private';
-    const modesMatch = desiredMode === actualMode;
-
-    // If desired and actual modes match, and we have a port configured, consider it running
-    // This is important because with --bg flag, the process exits immediately after configuration
-    // Also, if we're in public mode and Funnel has been enabled, trust that it's working
-    const effectivelyRunning =
-      actuallyRunning ||
-      (modesMatch && this.currentPort !== null && !this.isStarting) ||
-      (this.funnelEnabled && actualMode === 'public');
+    // The background command exiting successfully only records the port to verify.
+    // Do not report Serve as running after its persistent proxy is removed externally.
+    const effectivelyRunning = actuallyRunning;
 
     const result: TailscaleServeStatus = {
       isRunning: effectivelyRunning,
       port: effectivelyRunning ? (this.currentPort ?? undefined) : undefined,
-      // Don't show error if modes match and we're configured
-      lastError: effectivelyRunning || modesMatch ? undefined : verificationError || this.lastError,
+      lastError: effectivelyRunning ? undefined : verificationError || this.lastError,
       startTime: this.startTime,
       isPermanentlyDisabled: this.isPermanentlyDisabled,
       funnelEnabled: this.funnelEnabled,
@@ -777,6 +780,22 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
         }
       }, 3000);
     });
+  }
+
+  private async waitForServeConfiguration(port: number): Promise<boolean> {
+    const maxAttempts = 5;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (await this.verifyServeConfiguration(port)) {
+        return true;
+      }
+
+      if (attempt < maxAttempts - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 200));
+      }
+    }
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
Fixes #556.

## Problem

`tailscale serve --bg` exits successfully after installing its persistent proxy. VibeTunnel treated that normal exit as a stopped process and cleared the configured port. A startup timeout race could then leave the macOS app showing “Starting…” even though the private HTTPS endpoint was already working.

## Fix

- preserve the configured port when the background setup command exits successfully
- wait until the persistent proxy is observable before settling successful startup
- report stopped with a diagnostic if the persistent proxy is removed externally
- preserve a clean no-error status before Serve has ever been configured
- clear preserved state when stopping the persistent configuration
- add timing and lifecycle regression coverage for successful and failed exits

## Verification

- focused Tailscale service tests: 24 passed
- full server suite: 588 passed, 75 skipped
- full client suite: 705 passed, 14 skipped
- web build, lint, format, and typecheck passed
- macOS project tests passed
- exact fresh Debug app bundle embedded the final server binary byte-for-byte
- live app reported private Serve running on the configured port with no error
- local dashboard and private Tailscale HTTPS both returned HTTP 200
- external Serve reset was detected while the app stayed healthy; status reported stopped with no port and an actionable error
- restoring the persistent proxy returned status to running with no error
- clean app shutdown removed the persistent Serve target; original local Serve configuration was restored afterward
- no-Tailscale Ubuntu/Node fallback kept the server API reachable and reported Serve inactive without a persistent error
- structured autoreview completed with no actionable findings

## CI timing

The macOS workflow has a 40-minute job limit with tighter 10-minute build and 20-minute test limits, so a stalled macOS run cannot block for hours.
