### PR TITLE
fix(server): preserve Tailscale state after reset failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### 🐛 Bug Fixes
 - Report Tailscale Serve as running after its background setup command exits successfully, instead of leaving the macOS app stuck on “Starting…” (#556)
+- Preserve the configured Tailscale Serve port when reset fails instead of hiding a persistent non-default proxy.
 - Guide macOS terminal-test permission failures to the correct Automation or Accessibility settings pane (#554)
 - Add Warp Preview as a selectable macOS terminal, including app detection and command launching. (#535)
 - Show friendly authentication labels in the web user menu instead of raw internal method names (#369)

--- a/web/src/server/services/tailscale-serve-service-start.test.ts
+++ b/web/src/server/services/tailscale-serve-service-start.test.ts
@@ -226,9 +226,10 @@ describe('TailscaleServeService startup', () => {
     expect(internals.currentPort).toBe(43213);
   });
 
-  it('terminates a tracked Serve child when reset fails', async () => {
+  it('terminates a tracked Serve child without hiding state when reset fails', async () => {
     const resetProcess = fakeProcess();
     const serveProcess = fakeProcess();
+    const startTime = new Date('2026-06-12T23:00:00.000Z');
     serveProcess.kill = vi.fn((signal) => {
       serveProcess.killed = true;
       queueMicrotask(() => serveProcess.emit('exit', null, signal));
@@ -237,11 +238,18 @@ describe('TailscaleServeService startup', () => {
     const internals = service as unknown as {
       currentPort: number | null;
       isStarting: boolean;
+      lastError: string | undefined;
       serveProcess: ChildProcess | null;
+      startTime: Date | undefined;
+      handleServeProcessExit(code: number | null, signal: NodeJS.Signals | null): void;
     };
     internals.currentPort = 43213;
     internals.isStarting = false;
     internals.serveProcess = serveProcess;
+    internals.startTime = startTime;
+    serveProcess.on('exit', (code, signal) => {
+      internals.handleServeProcessExit(code, signal);
+    });
 
     spawnMock.mockImplementationOnce(() => {
       queueMicrotask(() => resetProcess.emit('exit', 1, null));
@@ -251,7 +259,15 @@ describe('TailscaleServeService startup', () => {
     await expect(service.stop()).resolves.toBeUndefined();
     expect(serveProcess.kill).toHaveBeenCalledWith('SIGTERM');
     expect(internals.serveProcess).toBeNull();
-    expect(internals.currentPort).toBeNull();
-    expect(service.isRunning()).toBe(false);
+    expect(internals.currentPort).toBe(43213);
+    expect(internals.lastError).toBe('Failed to reset Tailscale Serve configuration');
+    expect(internals.startTime).toBe(startTime);
+    expect(service.isRunning()).toBe(true);
+    await expect(service.getStatus()).resolves.toMatchObject({
+      isRunning: true,
+      port: 43213,
+      lastError: undefined,
+      startTime,
+    });
   });
 });

--- a/web/src/server/services/tailscale-serve-service-start.test.ts
+++ b/web/src/server/services/tailscale-serve-service-start.test.ts
@@ -137,4 +137,121 @@ describe('TailscaleServeService startup', () => {
     await expect(startPromise).resolves.toBeUndefined();
     expect(verificationMock).toHaveBeenCalledTimes(3);
   });
+
+  it('clears tracked state after Serve reset succeeds', async () => {
+    const resetProcess = fakeProcess();
+    const internals = service as unknown as {
+      currentPort: number | null;
+      isStarting: boolean;
+    };
+    internals.currentPort = 43213;
+    internals.isStarting = false;
+
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => resetProcess.emit('exit', 0, null));
+      return resetProcess;
+    });
+
+    await expect(service.stop()).resolves.toBeUndefined();
+    expect(service.isRunning()).toBe(false);
+    expect(internals.currentPort).toBeNull();
+  });
+
+  it('preserves tracked state when Serve reset exits non-zero', async () => {
+    const resetProcess = fakeProcess();
+    const internals = service as unknown as {
+      currentPort: number | null;
+      isStarting: boolean;
+      lastError: string | undefined;
+    };
+    internals.currentPort = 43213;
+    internals.isStarting = false;
+
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => resetProcess.emit('exit', 1, null));
+      return resetProcess;
+    });
+
+    await expect(service.stop()).resolves.toBeUndefined();
+    expect(service.isRunning()).toBe(true);
+    expect(internals.currentPort).toBe(43213);
+
+    const retryResetProcess = fakeProcess();
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => retryResetProcess.emit('exit', 0, null));
+      return retryResetProcess;
+    });
+
+    await expect(service.stop()).resolves.toBeUndefined();
+    expect(service.isRunning()).toBe(false);
+    expect(internals.currentPort).toBeNull();
+    expect(internals.lastError).toBeUndefined();
+  });
+
+  it('preserves tracked state when Serve reset emits an error', async () => {
+    const resetProcess = fakeProcess();
+    const internals = service as unknown as {
+      currentPort: number | null;
+      isStarting: boolean;
+    };
+    internals.currentPort = 43213;
+    internals.isStarting = false;
+
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => resetProcess.emit('error', new Error('reset unavailable')));
+      return resetProcess;
+    });
+
+    await expect(service.stop()).resolves.toBeUndefined();
+    expect(service.isRunning()).toBe(true);
+    expect(internals.currentPort).toBe(43213);
+  });
+
+  it('preserves tracked state when Serve reset times out', async () => {
+    const resetProcess = fakeProcess();
+    const internals = service as unknown as {
+      currentPort: number | null;
+      isStarting: boolean;
+    };
+    internals.currentPort = 43213;
+    internals.isStarting = false;
+    spawnMock.mockReturnValueOnce(resetProcess);
+
+    const stopExpectation = expect(service.stop()).resolves.toBeUndefined();
+    await vi.advanceTimersByTimeAsync(2_001);
+
+    await stopExpectation;
+    expect(resetProcess.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(service.isRunning()).toBe(true);
+    expect(internals.currentPort).toBe(43213);
+  });
+
+  it('terminates a tracked Serve child when reset fails', async () => {
+    const resetProcess = fakeProcess();
+    const serveProcess = fakeProcess();
+    serveProcess.kill = vi.fn((signal) => {
+      serveProcess.killed = true;
+      queueMicrotask(() => serveProcess.emit('exit', null, signal));
+      return true;
+    });
+    const internals = service as unknown as {
+      currentPort: number | null;
+      isStarting: boolean;
+      serveProcess: ChildProcess | null;
+    };
+    internals.currentPort = 43213;
+    internals.isStarting = false;
+    internals.serveProcess = serveProcess;
+
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => resetProcess.emit('exit', 1, null));
+      return resetProcess;
+    });
+
+    await expect(service.stop()).resolves.toBeUndefined();
+    expect(serveProcess.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(internals.serveProcess).toBeNull();
+    expect(internals.currentPort).toBeNull();
+    expect(service.isRunning()).toBe(false);
+  });
 });

--- a/web/src/server/services/tailscale-serve-service.ts
+++ b/web/src/server/services/tailscale-serve-service.ts
@@ -386,27 +386,22 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
       }
     }
 
-    // Reset Serve configuration (since we're using --bg, there's no process to kill)
-    try {
-      logger.debug('Removing Tailscale Serve configuration...');
+    if (!this.serveProcess && this.currentPort === null) {
+      logger.debug('No Tailscale Serve configuration to stop');
+      this.cleanup();
+      return;
+    }
 
-      // Use 'reset' to completely clear all serve configuration
-      const resetProcess = spawn(this.tailscaleExecutable, ['serve', 'reset'], {
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-
-      await new Promise<void>((resolve) => {
-        resetProcess.on('exit', (code) => {
-          if (code === 0) {
-            logger.debug('Tailscale Serve configuration reset successfully');
-          }
-          resolve();
-        });
-        resetProcess.on('error', () => resolve());
-        setTimeout(resolve, 2000); // Timeout after 2 seconds
-      });
-    } catch (_error) {
-      logger.debug('Failed to reset serve config during stop');
+    // Reset Serve configuration (since --bg usually leaves no process to kill).
+    const resetSucceeded = await this.resetServeConfiguration();
+    if (!resetSucceeded) {
+      this.lastError = 'Failed to reset Tailscale Serve configuration';
+      logger.warn(this.lastError);
+      if (!this.serveProcess) {
+        return;
+      }
+    } else {
+      this.lastError = undefined;
     }
 
     if (!this.serveProcess) {
@@ -445,6 +440,56 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
       // Try graceful shutdown first
       this.serveProcess.kill('SIGTERM');
     });
+  }
+
+  private async resetServeConfiguration(): Promise<boolean> {
+    logger.debug('Removing Tailscale Serve configuration...');
+
+    try {
+      const resetProcess = spawn(this.tailscaleExecutable, ['serve', 'reset'], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      return await new Promise<boolean>((resolve) => {
+        let settled = false;
+
+        const settle = (succeeded: boolean) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          resolve(succeeded);
+        };
+
+        resetProcess.once('exit', (code) => {
+          if (code === 0) {
+            logger.debug('Tailscale Serve configuration reset successfully');
+            settle(true);
+          } else {
+            logger.warn(`Tailscale Serve reset exited with code ${code}`);
+            settle(false);
+          }
+        });
+        resetProcess.once('error', (error) => {
+          logger.warn(`Tailscale Serve reset failed: ${error.message}`);
+          settle(false);
+        });
+
+        const timeout = setTimeout(() => {
+          logger.warn('Tailscale Serve reset timed out');
+          if (!resetProcess.killed) {
+            try {
+              resetProcess.kill('SIGTERM');
+            } catch (error) {
+              logger.warn(`Failed to terminate timed-out Tailscale Serve reset: ${error}`);
+            }
+          }
+          settle(false);
+        }, 2000);
+      });
+    } catch (error) {
+      logger.warn(`Failed to reset Tailscale Serve configuration: ${error}`);
+      return false;
+    }
   }
 
   isRunning(): boolean {

--- a/web/src/server/services/tailscale-serve-service.ts
+++ b/web/src/server/services/tailscale-serve-service.ts
@@ -411,6 +411,13 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
     }
 
     logger.info('Stopping Tailscale Serve process...');
+    const stateToPreserve = resetSucceeded
+      ? null
+      : {
+          currentPort: this.currentPort,
+          lastError: this.lastError,
+          startTime: this.startTime,
+        };
 
     return new Promise<void>((resolve) => {
       if (!this.serveProcess) {
@@ -420,6 +427,11 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
 
       const cleanup = () => {
         this.cleanup();
+        if (stateToPreserve) {
+          this.currentPort = stateToPreserve.currentPort;
+          this.lastError = stateToPreserve.lastError;
+          this.startTime = stateToPreserve.startTime;
+        }
         resolve();
       };
 


### PR DESCRIPTION
## Summary

- preserve the configured Tailscale Serve port when `tailscale serve reset` exits non-zero, errors, or times out
- terminate an attached Serve command child without clearing the remembered persistent proxy state after reset failure
- preserve the reset error and original start timestamp until a later confirmed reset succeeds
- add lifecycle coverage for reset success, all failure modes, retry success, and production child-exit listener cleanup

Follow-up to #665 and the unresolved review at https://github.com/amantus-ai/vibetunnel/pull/665#discussion_r3406612698.

## Verification

- focused Tailscale suites: 29 passed
- full server coverage suite: 593 passed, 75 skipped
- lint, server typecheck, and exact CI build: passed
- autoreview: no actionable findings
- live Tailscale proof on the exact final built candidate at a non-default local port:
  - forced reset failure retained the configured port, reset error, and start timestamp
  - an attached command child terminated normally while public status still verified the persistent proxy as running
  - the private HTTPS endpoint remained HTTP 200 with identical content before and after the failed reset
  - restoring the real CLI allowed a normal reset, returned idle state, and restored the original empty Serve configuration exactly

## Safety

Public Model Identifier Gate: PASS. The exact diff, changed tests, changelog, local and exact-head CI logs, generated outputs, live-proof artifact, and public proof contain no model identifiers. No fixtures, snapshots, or workflows changed.
