### PR TITLE
fix(web): show session titles on iPhone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Show long session titles with ellipsis in the compact iPhone header instead of hiding them entirely. (#516)
 - Report Tailscale Serve as running after its background setup command exits successfully, instead of leaving the macOS app stuck on “Starting…” (#556)
 - Preserve the configured Tailscale Serve port when reset fails instead of hiding a persistent non-default proxy.
 - Guide macOS terminal-test permission failures to the correct Automation or Accessibility settings pane (#554)

--- a/web/src/client/components/inline-edit.ts
+++ b/web/src/client/components/inline-edit.ts
@@ -83,6 +83,12 @@ export class InlineEdit extends LitElement {
       border-color: rgb(var(--color-primary));
     }
 
+    @media (max-width: 639px) {
+      input {
+        font-size: 16px;
+      }
+    }
+
     .action-buttons {
       display: flex;
       gap: 0.25rem;

--- a/web/src/client/components/session-view/session-header.test.ts
+++ b/web/src/client/components/session-view/session-header.test.ts
@@ -30,6 +30,7 @@ describe('SessionHeader', () => {
 
   async function renderHeader(options: {
     isMobile: boolean;
+    sessionName?: string;
     showBackButton?: boolean;
     showSidebarToggle?: boolean;
     sidebarCollapsed?: boolean;
@@ -38,7 +39,10 @@ describe('SessionHeader', () => {
   }): Promise<SessionHeader> {
     const element = await fixture<SessionHeader>(html`
       <session-header
-        .session=${createMockSession({ id: 'header-controls' })}
+        .session=${createMockSession({
+          id: 'header-controls',
+          name: options.sessionName,
+        })}
         .isMobile=${options.isMobile}
         .showBackButton=${options.showBackButton ?? false}
         .showSidebarToggle=${options.showSidebarToggle ?? false}
@@ -101,5 +105,25 @@ describe('SessionHeader', () => {
     expect(backButton?.textContent?.trim()).toBe('Back');
     expect(backButton?.classList.contains('md:w-auto')).toBe(true);
     expect(backButton?.classList.contains('md:h-auto')).toBe(true);
+  });
+
+  it('shows an ellipsized title on mobile while keeping secondary details desktop-only', async () => {
+    const sessionName =
+      'Issue 516 iPhone session title that is intentionally very long to verify truncation';
+    const element = await renderHeader({ isMobile: true, sessionName });
+    const titleContainer = element.querySelector<HTMLElement>(
+      '[data-testid="session-title-container"]'
+    );
+    const details = element.querySelector<HTMLElement>('[data-testid="session-details"]');
+    const inlineEdit = titleContainer?.querySelector('inline-edit') as
+      | (HTMLElement & { value: string })
+      | null;
+
+    expect(titleContainer).toBeTruthy();
+    expect(titleContainer?.classList.contains('hidden')).toBe(false);
+    expect(titleContainer?.classList.contains('flex-1')).toBe(true);
+    expect(inlineEdit?.value).toBe(sessionName);
+    expect(details?.classList.contains('hidden')).toBe(true);
+    expect(details?.classList.contains('sm:flex')).toBe(true);
   });
 });

--- a/web/src/client/components/session-view/session-header.ts
+++ b/web/src/client/components/session-view/session-header.ts
@@ -268,7 +268,10 @@ export class SessionHeader extends LitElement {
               `
               : ''
           }
-          <div class="text-primary min-w-0 flex-1 overflow-hidden hidden sm:block">
+          <div
+            class="text-primary min-w-0 flex-1 overflow-hidden"
+            data-testid="session-title-container"
+          >
             <div class="text-bright font-medium text-xs sm:text-sm min-w-0 overflow-hidden">
               <div class="flex items-center gap-1 min-w-0 overflow-hidden" @mouseenter=${this.handleMouseEnter} @mouseleave=${this.handleMouseLeave}>
                 <inline-edit
@@ -328,7 +331,10 @@ export class SessionHeader extends LitElement {
                 }
               </div>
             </div>
-            <div class="text-xs opacity-75 mt-0.5 flex items-center gap-2 min-w-0 overflow-hidden">
+            <div
+              class="text-xs opacity-75 mt-0.5 hidden sm:flex items-center gap-2 min-w-0 overflow-hidden"
+              data-testid="session-details"
+            >
               <clickable-path
                 class="min-w-0 flex-1 truncate"
                 .path=${this.session.workingDir}

--- a/web/src/test/playwright/specs/session-header-responsive.spec.ts
+++ b/web/src/test/playwright/specs/session-header-responsive.spec.ts
@@ -30,10 +30,13 @@ test.describe('mobile session header', () => {
   });
 
   let sessionManager: TestSessionManager;
+  let sessionName: string;
 
   test.beforeEach(async ({ page }) => {
     sessionManager = new TestSessionManager(page, 'header-mobile');
-    await sessionManager.createTrackedSession();
+    sessionName =
+      'Issue 516 iPhone session title that is intentionally very long to verify truncation and visibility';
+    await sessionManager.createTrackedSession(sessionName);
     await expect(page.locator('session-header')).toBeVisible();
   });
 
@@ -49,6 +52,8 @@ test.describe('mobile session header', () => {
       page.getByRole('button', { name: 'Switch to Chat Mode', exact: true }),
       page.getByRole('button', { name: 'More actions menu', exact: true }),
     ];
+    const titleContainer = page.getByTestId('session-title-container');
+    const titleText = titleContainer.locator('inline-edit').locator('.display-text');
 
     for (const viewport of [
       { width: 700, height: 500 },
@@ -66,7 +71,44 @@ test.describe('mobile session header', () => {
         await expect(control).toBeVisible();
         await expectInsideViewport(page, control);
       }
+
+      await expect(titleContainer).toBeVisible();
+      await expectInsideViewport(page, titleContainer, 0);
+      await expect(titleText).toHaveAttribute('title', sessionName);
     }
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    const inlineEdit = titleContainer.locator('inline-edit');
+    await inlineEdit.locator('.edit-icon').click();
+    const titleInput = inlineEdit.locator('input');
+    await expect(titleInput).toBeVisible();
+    await expect
+      .poll(() =>
+        titleInput.evaluate((element) => Number.parseFloat(getComputedStyle(element).fontSize))
+      )
+      .toBeGreaterThanOrEqual(16);
+    await inlineEdit.locator('.cancel').click();
+    for (const control of headerControls) {
+      await expectInsideViewport(page, control);
+    }
+
+    await page.setViewportSize({ width: 360, height: 800 });
+    await expect
+      .poll(() =>
+        titleText.evaluate((element) => {
+          const styles = getComputedStyle(element);
+          return {
+            isTruncated: element.scrollWidth > element.clientWidth,
+            textOverflow: styles.textOverflow,
+            whiteSpace: styles.whiteSpace,
+          };
+        })
+      )
+      .toEqual({
+        isTruncated: true,
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+      });
 
     await page.setViewportSize({ width: 434, height: 965 });
     const menuButton = page.getByRole('button', { name: 'More actions menu', exact: true });

--- a/web/src/test/playwright/specs/session-management-advanced.spec.ts
+++ b/web/src/test/playwright/specs/session-management-advanced.spec.ts
@@ -121,17 +121,17 @@ test.describe('Advanced Session Management', () => {
     // Create a tracked session
     await sessionManager.createTrackedSession();
 
-    // Should see copy button for path
-    await expect(page.locator('[title="Click to copy path"]')).toBeVisible();
+    const headerPath = page.locator('session-header').getByTitle('Click to copy path');
+    await expect(headerPath).toBeVisible();
 
     // Click to copy path
-    await page.click('[title="Click to copy path"]');
+    await headerPath.click();
 
     // Visual feedback would normally appear (toast notification)
     // We can't test clipboard content directly in Playwright
 
     // Verify the clickable-path component exists and has the right behavior
-    const clickablePath = page.locator('clickable-path').first();
+    const clickablePath = page.locator('session-header clickable-path');
     await expect(clickablePath).toBeVisible();
   });
 


### PR DESCRIPTION
## Summary

- show the session title in the compact iPhone header while keeping secondary details desktop-only
- keep long titles ellipsized so navigation, chat, and menu controls remain reachable
- use a 16px mobile inline-edit input to prevent Safari focus zoom from displacing header controls
- narrow the session copy-path browser test to the header control

Fixes #516

## Verification

- iPhone 17 simulator, iOS 26.5, MobileSafari: long title visible and ellipsized at the reported viewport and narrower widths
- title edit keyboard path: save/cancel, chat toggle, and compact menu remain reachable without focus zoom
- real MobileSafari pinch gesture: page zoom visibly changes on the exact built candidate
- desktop header spacing and details unchanged
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test:vt`
- `pnpm run build:ci`
- client and server Vitest coverage suites
- focused session-header unit and responsive Playwright tests
- `pnpm run test:e2e:fast` (24 passed, 3 skipped)
- autoreview clean

## Safety

Public Model Identifier Gate: PASS. No model identifiers exist in the exact diff, changed tests, logs, generated artifacts, workflows, or public proof.
