### PR TITLE
fix(mac): shorten update onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### ✨ Improvements
+- Show returning users only the CLI maintenance page after updates, while keeping the full onboarding flow available manually (reported by [@MrMage](https://github.com/MrMage), with earlier investigation by [@gioneill](https://github.com/gioneill)) (#411)
 - Pin CI actions, runner images, and downloaded build tools to immutable, checksum-verified versions (via [@davisbuilds](https://github.com/davisbuilds)) (#616)
 - Make the web app installable with correctly sized 192px and 512px manifest icons (via [@Tyoneva](https://github.com/Tyoneva)) (#615)
 - Enlarge mobile session navigation and terminal quick-key tap targets (via [@Nachx639](https://github.com/Nachx639)) (#647)
@@ -59,6 +60,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
+- Thanks [@MrMage](https://github.com/MrMage) and [@gioneill](https://github.com/gioneill) for reporting and investigating repetitive update onboarding.
 - Thanks [@davisbuilds](https://github.com/davisbuilds) for hardening CI workflows and build-tool bootstrap paths.
 - Thanks [@apex-skyner](https://github.com/apex-skyner) and [@yashiels](https://github.com/yashiels) for identifying the macOS session-creation timestamp decoding failure.
 - Thanks [@waxzce](https://github.com/waxzce) for adding configurable IPv4/IPv6 server binding and restoring reliable iOS terminal rendering and input echo.

--- a/mac/VibeTunnel/Presentation/Views/WelcomeView.swift
+++ b/mac/VibeTunnel/Presentation/Views/WelcomeView.swift
@@ -1,11 +1,37 @@
 import SwiftUI
 
+enum WelcomePresentationMode: Equatable {
+    case full
+    case cliMaintenance
+
+    static func automatic(storedWelcomeVersion: Int) -> Self {
+        storedWelcomeVersion == 0 ? .full : .cliMaintenance
+    }
+
+    var pageCount: Int {
+        switch self {
+        case .full:
+            9
+        case .cliMaintenance:
+            1
+        }
+    }
+
+    var showsPageIndicators: Bool {
+        self == .full
+    }
+
+    var opensSettingsOnFinish: Bool {
+        self == .full
+    }
+}
+
 /// Welcome onboarding view for first-time users.
 ///
-/// Presents a multi-page onboarding experience that introduces VibeTunnel's features,
+/// Presents either the full onboarding experience or the CLI maintenance page used
+/// for returning users after an update. The full flow introduces VibeTunnel's features,
 /// guides through CLI installation, requests AppleScript permissions, and explains
-/// dashboard security best practices. The view tracks completion state to ensure
-/// it's only shown once.
+/// dashboard security best practices.
 ///
 /// ## Topics
 ///
@@ -21,6 +47,8 @@ import SwiftUI
 /// - ``ControlAgentArmyPageView`` - Managing multiple AI agent sessions
 /// - ``AccessDashboardPageView`` - Remote access instructions
 struct WelcomeView: View {
+    let mode: WelcomePresentationMode
+
     @State private var currentPage = 0
     @Environment(\.dismiss)
     private var dismiss
@@ -32,6 +60,10 @@ struct WelcomeView: View {
 
     private let pageWidth: CGFloat = 640
     private let contentHeight: CGFloat = 468 // Total height minus navigation area
+
+    init(mode: WelcomePresentationMode = .full) {
+        self.mode = mode
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -48,41 +80,46 @@ struct WelcomeView: View {
             // Scrollable content area
             GeometryReader { _ in
                 HStack(spacing: 0) {
-                    // Page 1: Welcome content (without icon)
-                    WelcomeContentView()
-                        .frame(width: self.pageWidth)
+                    if self.mode == .cliMaintenance {
+                        VTCommandPageView(cliInstaller: self.cliInstaller)
+                            .frame(width: self.pageWidth)
+                    } else {
+                        // Page 1: Welcome content (without icon)
+                        WelcomeContentView()
+                            .frame(width: self.pageWidth)
 
-                    // Page 2: VT Command
-                    VTCommandPageView(cliInstaller: self.cliInstaller)
-                        .frame(width: self.pageWidth)
+                        // Page 2: VT Command
+                        VTCommandPageView(cliInstaller: self.cliInstaller)
+                            .frame(width: self.pageWidth)
 
-                    // Page 3: Request Permissions
-                    RequestPermissionsPageView(isCurrentPage: self.currentPage == 2)
-                        .frame(width: self.pageWidth)
+                        // Page 3: Request Permissions
+                        RequestPermissionsPageView(isCurrentPage: self.currentPage == 2)
+                            .frame(width: self.pageWidth)
 
-                    // Page 4: Select Terminal
-                    SelectTerminalPageView()
-                        .frame(width: self.pageWidth)
+                        // Page 4: Select Terminal
+                        SelectTerminalPageView()
+                            .frame(width: self.pageWidth)
 
-                    // Page 5: Project Folder
-                    ProjectFolderPageView(currentPage: self.$currentPage)
-                        .frame(width: self.pageWidth)
+                        // Page 5: Project Folder
+                        ProjectFolderPageView(currentPage: self.$currentPage)
+                            .frame(width: self.pageWidth)
 
-                    // Page 6: Protect Your Dashboard
-                    ProtectDashboardPageView()
-                        .frame(width: self.pageWidth)
+                        // Page 6: Protect Your Dashboard
+                        ProtectDashboardPageView()
+                            .frame(width: self.pageWidth)
 
-                    // Page 7: Notification Permissions
-                    NotificationPermissionPageView()
-                        .frame(width: self.pageWidth)
+                        // Page 7: Notification Permissions
+                        NotificationPermissionPageView()
+                            .frame(width: self.pageWidth)
 
-                    // Page 8: Control Your Agent Army
-                    ControlAgentArmyPageView()
-                        .frame(width: self.pageWidth)
+                        // Page 8: Control Your Agent Army
+                        ControlAgentArmyPageView()
+                            .frame(width: self.pageWidth)
 
-                    // Page 9: Accessing Dashboard
-                    AccessDashboardPageView()
-                        .frame(width: self.pageWidth)
+                        // Page 9: Accessing Dashboard
+                        AccessDashboardPageView()
+                            .frame(width: self.pageWidth)
+                    }
                 }
                 .offset(x: CGFloat(-self.currentPage) * self.pageWidth)
                 .animation(
@@ -125,19 +162,21 @@ struct WelcomeView: View {
                 Spacer()
 
                 // Page indicators centered
-                HStack(spacing: 8) {
-                    ForEach(0..<9) { index in
-                        Button {
-                            withAnimation {
-                                self.currentPage = index
+                if self.mode.showsPageIndicators {
+                    HStack(spacing: 8) {
+                        ForEach(0..<self.mode.pageCount, id: \.self) { index in
+                            Button {
+                                withAnimation {
+                                    self.currentPage = index
+                                }
+                            } label: {
+                                Circle()
+                                    .fill(index == self.currentPage ? Color.accentColor : Color.gray.opacity(0.3))
+                                    .frame(width: 8, height: 8)
                             }
-                        } label: {
-                            Circle()
-                                .fill(index == self.currentPage ? Color.accentColor : Color.gray.opacity(0.3))
-                                .frame(width: 8, height: 8)
+                            .buttonStyle(.plain)
+                            .pointingHandCursor()
                         }
-                        .buttonStyle(.plain)
-                        .pointingHandCursor()
                     }
                 }
 
@@ -167,7 +206,7 @@ struct WelcomeView: View {
     }
 
     private var buttonTitle: String {
-        self.currentPage == 8 ? "Finish" : "Next"
+        self.currentPage == self.mode.pageCount - 1 ? "Finish" : "Next"
     }
 
     private func handleBackAction() {
@@ -177,7 +216,7 @@ struct WelcomeView: View {
     }
 
     private func handleNextAction() {
-        if self.currentPage < 8 {
+        if self.currentPage < self.mode.pageCount - 1 {
             withAnimation {
                 self.currentPage += 1
             }
@@ -188,10 +227,12 @@ struct WelcomeView: View {
             // Close the window using the SwiftUI dismiss environment
             self.dismiss()
 
-            // Open settings after a delay to ensure the window is fully closed
-            Task { @MainActor in
-                try? await Task.sleep(for: .milliseconds(200))
-                SettingsOpener.openSettings()
+            if self.mode.opensSettingsOnFinish {
+                // Open settings after a delay to ensure the window is fully closed
+                Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(200))
+                    SettingsOpener.openSettings()
+                }
             }
         }
     }

--- a/mac/VibeTunnel/Utilities/WelcomeWindowController.swift
+++ b/mac/VibeTunnel/Utilities/WelcomeWindowController.swift
@@ -13,13 +13,7 @@ final class WelcomeWindowController: NSWindowController, NSWindowDelegate {
     private var windowObserver: NSObjectProtocol?
 
     private init() {
-        let welcomeView = WelcomeView()
-            .environment(SessionMonitor.shared)
-            .environment(ServerManager.shared)
-            .environment(NgrokService.shared)
-            .environment(SystemPermissionManager.shared)
-            .environment(TerminalLauncher.shared)
-        let hostingController = NSHostingController(rootView: welcomeView)
+        let hostingController = NSHostingController(rootView: Self.makeWelcomeView(mode: .full))
 
         let window = NSWindow(contentViewController: hostingController)
         window.title = UIStrings.welcomeTitle
@@ -53,8 +47,12 @@ final class WelcomeWindowController: NSWindowController, NSWindowDelegate {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func show() {
+    func show(mode: WelcomePresentationMode = .full) {
         guard let window else { return }
+
+        let hostingController = NSHostingController(rootView: Self.makeWelcomeView(mode: mode))
+        hostingController.sizingOptions = [.preferredContentSize]
+        window.contentViewController = hostingController
 
         // Ensure dock icon is visible for window activation
         DockIconManager.shared.temporarilyShowDock()
@@ -81,7 +79,7 @@ final class WelcomeWindowController: NSWindowController, NSWindowDelegate {
 
     @objc
     private func handleShowWelcomeNotification() {
-        self.show()
+        self.show(mode: .full)
     }
 
     // MARK: - NSWindowDelegate
@@ -92,6 +90,15 @@ final class WelcomeWindowController: NSWindowController, NSWindowDelegate {
             // Give SwiftUI time to clean up
             try? await Task.sleep(for: .milliseconds(100))
         }
+    }
+
+    private static func makeWelcomeView(mode: WelcomePresentationMode) -> some View {
+        WelcomeView(mode: mode)
+            .environment(SessionMonitor.shared)
+            .environment(ServerManager.shared)
+            .environment(NgrokService.shared)
+            .environment(SystemPermissionManager.shared)
+            .environment(TerminalLauncher.shared)
     }
 }
 

--- a/mac/VibeTunnel/VibeTunnelApp.swift
+++ b/mac/VibeTunnel/VibeTunnelApp.swift
@@ -218,7 +218,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             if storedWelcomeVersion < AppConstants.currentWelcomeVersion || cliInstaller.isOutdated,
                !isRunningInTests, !isRunningInPreview
             {
-                self?.showWelcomeScreen()
+                self?.showWelcomeScreen(
+                    mode: WelcomePresentationMode.automatic(storedWelcomeVersion: storedWelcomeVersion))
             }
         }
 
@@ -363,15 +364,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     /// Shows the welcome screen
-    private func showWelcomeScreen() {
+    private func showWelcomeScreen(mode: WelcomePresentationMode) {
         // Initialize the welcome window controller (singleton will handle the rest)
         _ = WelcomeWindowController.shared
-        WelcomeWindowController.shared.show()
+        WelcomeWindowController.shared.show(mode: mode)
     }
 
     /// Public method to show welcome screen (can be called from settings)
     static func showWelcomeScreen() {
-        WelcomeWindowController.shared.show()
+        WelcomeWindowController.shared.show(mode: .full)
     }
 
     /// Creates a custom dock menu when the user right-clicks on the dock icon.

--- a/mac/VibeTunnelTests/WelcomePresentationModeTests.swift
+++ b/mac/VibeTunnelTests/WelcomePresentationModeTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import VibeTunnel
+
+@Suite("Welcome presentation mode")
+struct WelcomePresentationModeTests {
+    @Test("First launch uses the full onboarding flow")
+    func firstLaunch() {
+        let mode = WelcomePresentationMode.automatic(storedWelcomeVersion: 0)
+
+        #expect(mode == .full)
+        #expect(mode.pageCount == 9)
+        #expect(mode.showsPageIndicators)
+        #expect(mode.opensSettingsOnFinish)
+    }
+
+    @Test("Returning users see only CLI maintenance", arguments: [1, 4, 5])
+    func returningUser(storedWelcomeVersion: Int) {
+        let mode = WelcomePresentationMode.automatic(storedWelcomeVersion: storedWelcomeVersion)
+
+        #expect(mode == .cliMaintenance)
+        #expect(mode.pageCount == 1)
+        #expect(!mode.showsPageIndicators)
+        #expect(!mode.opensSettingsOnFinish)
+    }
+}


### PR DESCRIPTION
## Summary
- show returning users only the CLI maintenance page on automatic update launches
- keep the complete onboarding flow for first launch and manual Show Tutorial actions
- rebuild the Welcome root view for each presentation so automatic mode cannot leak into later manual launches
- add focused mode regressions and changelog credit

## Validation
- focused `WelcomePresentationModeTests`
- full macOS suite: 271 tests, 255 passed, 16 skipped, 0 failed
- web type and lint checks
- exact built macOS app proof: returning automatic launch showed one CLI page; first launch and manual Show Tutorial each showed all nine pages
- autoreview: no actionable findings

## Safety
- Public Model Identifier Gate: PASS. No model identifiers in the exact commit, changed tests, workflows, fixtures, snapshots, build/test logs, generated artifacts, or this public proof.

Closes #411
