### PR TITLE
test(web): cover Chinese IME composition

### DIFF
--- a/docs/cjk-ime-input.md
+++ b/docs/cjk-ime-input.md
@@ -4,12 +4,13 @@
 
 VibeTunnel provides comprehensive Chinese, Japanese, and Korean (CJK) Input Method Editor (IME) support across both desktop and mobile platforms. The implementation uses platform-specific approaches to ensure optimal user experience:
 
-- **Desktop**: Invisible input element with native browser IME integration
+- **Desktop**: Cursor-positioned text input with native browser IME integration
 - **Mobile**: Native virtual keyboard with direct input handling
 
 ## Architecture
 
 ### Core Components
+
 ```
 SessionView
 ├── InputManager (Main input coordination layer)
@@ -19,7 +20,7 @@ SessionView
 │   ├── WebSocket/HTTP input routing
 │   └── Terminal cursor position access
 ├── DesktopIMEInput (Desktop-specific IME component)
-│   ├── Invisible input element creation
+│   ├── Cursor-positioned input element creation
 │   ├── IME composition event handling
 │   ├── Global paste handling
 │   ├── Dynamic cursor positioning
@@ -41,47 +42,55 @@ SessionView
 The cursor position tracking system uses renderer-specific cursor coordinates:
 
 #### Coordinate System
+
 ```typescript
 export function calculateCursorPosition(
-  cursorX: number,        // 0-based column position
-  cursorY: number,        // 0-based row position  
-  fontSize: number,       // Terminal font size in pixels
-  container: Element,     // Terminal container element
-  sessionStatus: string   // Session status for validation
-): { x: number; y: number } | null
+  cursorX: number, // 0-based column position
+  cursorY: number, // 0-based row position
+  fontSize: number, // Terminal font size in pixels
+  container: Element, // Terminal container element
+  sessionStatus: string, // Session status for validation
+): { x: number; y: number } | null;
 ```
 
 #### Position Calculation Process
+
 1. **Character Measurement**: Dynamically measures actual character width using font metrics
 2. **Absolute Positioning**: Calculates page-absolute cursor coordinates
 3. **Container Relative**: Converts to position relative to `#session-terminal` container
 4. **IME Positioning**: Returns coordinates suitable for IME input placement
 
 #### Terminal Type Support
+
 - **Ghostty Terminal (`vibe-terminal`)**: Uses the active buffer cursor and renderer cell metrics.
 - **Buffer Terminal (`vibe-terminal-buffer`)**: Uses `buffer.cursorX/Y` from VT snapshot data.
 
 #### Key Features
+
 - **Precise Alignment**: Accounts for exact character width and line height
 - **Container Aware**: Handles side panels and complex layouts
 - **Font Responsive**: Adapts to different font sizes and families
 - **Platform Consistent**: Same calculation logic across all terminal types
 
 #### Error Handling
+
 The function includes comprehensive error handling and graceful fallbacks:
+
 - Returns `null` when session is not running
-- Returns `null` when container element is not found  
+- Returns `null` when container element is not found
 - Returns `null` when character measurement fails
 - Falls back to absolute coordinates if session container is missing
 
 ### Platform Detection
+
 **File**: `mobile-utils.ts`
 
 VibeTunnel automatically detects the platform and chooses the appropriate IME strategy:
+
 ```typescript
 export function detectMobile(): boolean {
   return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-    navigator.userAgent
+    navigator.userAgent,
   );
 }
 ```
@@ -89,20 +98,24 @@ export function detectMobile(): boolean {
 ### Desktop Implementation
 
 #### 1. DesktopIMEInput Component
-**File**: `ime-input.ts:32-382`
 
-A dedicated component for desktop browsers that creates and manages an invisible input element:
+**File**: `ime-input.ts`
+
+A dedicated component for desktop browsers that creates and manages a native text input:
+
 - Positioned dynamically at terminal cursor location
-- Completely invisible (`opacity: 0`, `1px x 1px`, `pointerEvents: none`)
+- Uses a normal input size so browsers can anchor native candidate windows reliably
+- Transparent background and hidden caret keep the terminal visually unobstructed
 - Handles all CJK composition events through standard DOM APIs
-- Placeholder: "CJK Input"
-- Auto-focus with retention mechanism to prevent focus loss
+- Focuses when the user clicks the terminal, with short animation-frame retries for browser timing
 - Clean lifecycle management with proper cleanup
 
 #### 2. Desktop Input Manager Integration
-**File**: `input-manager.ts:71-129`
+
+**File**: `input-manager.ts`
 
 The `InputManager` detects platform and creates the appropriate IME component:
+
 ```typescript
 private setupIMEInput(): void {
   // Skip IME input setup on mobile devices (they use native keyboard)
@@ -131,74 +144,79 @@ private setupIMEInput(): void {
 }
 ```
 
-#### 3. Desktop Focus Retention
-**File**: `ime-input.ts:317-343`
+#### 3. Desktop Focus Management
 
-Desktop IME requires special focus handling to prevent losing focus during composition:
+**File**: `ime-input.ts`
+
+Desktop IME focus follows terminal clicks. The implementation avoids polling because repeatedly stealing focus interferes with native candidate selection:
+
 ```typescript
-private startFocusRetention(): void {
-  // Skip in test environment to avoid infinite loops
-  if (typeof process !== 'undefined' && process.env?.NODE_ENV === 'test') {
-    return;
-  }
-  
-  this.focusRetentionInterval = setInterval(() => {
+focus(): void {
+  this.updatePosition();
+  this.input.focus();
+
+  requestAnimationFrame(() => {
     if (document.activeElement !== this.input) {
-      this.input.focus();
+      requestAnimationFrame(() => this.input.focus());
     }
-  }, 100);
+  });
 }
 ```
 
 ### Mobile Implementation
 
 #### 1. Direct Keyboard Manager
+
 **File**: `direct-keyboard-manager.ts`
 
 Mobile devices use the native virtual keyboard with a visible input field:
+
 - Standard HTML input element (not hidden)
 - Native virtual keyboard with CJK support
 - Quick keys toolbar for common terminal operations
 - No special IME handling needed (OS provides it)
 
 #### 2. Mobile Input Flow
+
 **Files**: `session-view.ts`, `lifecycle-event-manager.ts`
 
 Mobile input handling follows a different flow:
+
 1. User taps terminal area
 2. Native virtual keyboard appears with CJK support
 3. User types or selects from IME candidates
 4. Input is sent directly to terminal
-5. No invisible elements or composition tracking needed
+5. No desktop composition bridge is needed
 
 ## Platform Differences
 
 ### Key Implementation Differences
 
-| Aspect | Desktop | Mobile |
-|--------|---------|---------|
-| **Input Element** | Invisible 1px × 1px input | Visible standard input field |
-| **IME Handling** | Custom composition events | Native OS keyboard |
-| **Positioning** | Follows terminal cursor | Fixed position or overlay |
-| **Focus Management** | Active focus retention | Standard focus behavior |
-| **Keyboard** | Physical + software IME | Virtual keyboard with IME |
-| **Integration** | Completely transparent | Visible UI component |
-| **Performance** | Minimal overhead | Standard input performance |
+| Aspect               | Desktop                          | Mobile                       |
+| -------------------- | -------------------------------- | ---------------------------- |
+| **Input Element**    | Cursor-positioned standard input | Visible standard input field |
+| **IME Handling**     | Custom composition events        | Native OS keyboard           |
+| **Positioning**      | Follows terminal cursor          | Fixed position or overlay    |
+| **Focus Management** | Click focus with bounded retries | Standard focus behavior      |
+| **Keyboard**         | Physical + software IME          | Virtual keyboard with IME    |
+| **Integration**      | Transparent terminal overlay     | Visible UI component         |
+| **Performance**      | Minimal overhead                 | Standard input performance   |
 
 ### Technical Architecture Differences
 
 #### Desktop Implementation
+
 ```typescript
-// Creates invisible input at cursor position
-const input = document.createElement('input');
-input.style.opacity = '0';
-input.style.width = '1px';
-input.style.height = '1px';
-input.style.pointerEvents = 'none';
+// Creates a browser-compatible input at the terminal cursor
+const input = document.createElement("input");
+input.style.width = "200px";
+input.style.height = "24px";
+input.style.backgroundColor = "transparent";
+input.style.caretColor = "transparent";
 
 // Handles IME composition events
-input.addEventListener('compositionstart', handleStart);
-input.addEventListener('compositionend', handleEnd);
+input.addEventListener("compositionstart", handleStart);
+input.addEventListener("compositionend", handleEnd);
 
 // Positions at terminal cursor
 input.style.left = `${cursorX}px`;
@@ -206,11 +224,12 @@ input.style.top = `${cursorY}px`;
 ```
 
 #### Mobile Implementation
+
 ```typescript
 // Uses DirectKeyboardManager with visible input
-const input = document.createElement('input');
-input.type = 'text';
-input.placeholder = 'Type here...';
+const input = document.createElement("input");
+input.type = "text";
+input.placeholder = "Type here...";
 // Standard visible input - no special IME handling needed
 
 // OS handles IME automatically through virtual keyboard
@@ -220,13 +239,15 @@ input.placeholder = 'Type here...';
 ### User Experience Differences
 
 #### Desktop Experience
+
 - **Seamless**: No visible UI changes
 - **Cursor following**: IME popup appears at terminal cursor
 - **Click to focus**: Click anywhere in terminal area
 - **Traditional**: Works like native terminal IME
 - **Paste support**: Global paste handling anywhere in terminal
 
-#### Mobile Experience  
+#### Mobile Experience
+
 - **Touch-first**: Designed for finger interaction
 - **Visible input**: Clear indication of where to type
 - **Quick keys**: Easy access to terminal-specific keys
@@ -236,14 +257,16 @@ input.placeholder = 'Type here...';
 ## Platform-Specific Features
 
 ### Desktop Features
+
 - **Dynamic cursor positioning**: IME popup follows terminal cursor exactly
 - **Global paste handling**: Paste works anywhere in terminal area
 - **Composition state tracking**: Via native `KeyboardEvent.isComposing` plus the `data-ime-composing` DOM attribute
-- **Focus retention**: Active mechanism prevents accidental focus loss
-- **Invisible integration**: Zero visual footprint for users
+- **Focus management**: Click focus plus bounded browser-timing retries
+- **Transparent integration**: Native input text appears at the terminal cursor without a separate control
 - **Performance optimized**: Minimal resource usage when not composing
 
-### Mobile Features  
+### Mobile Features
+
 - **Native virtual keyboard**: Full OS-level CJK IME integration
 - **Quick keys toolbar**: Touch-friendly terminal keys (Tab, Esc, Ctrl, etc.)
 - **Touch-optimized UI**: Larger tap targets and touch gestures
@@ -254,88 +277,74 @@ input.placeholder = 'Type here...';
 ## User Experience
 
 ### Desktop Workflow
+
 ```
-User clicks terminal → Invisible input focuses → Types CJK → 
+User clicks terminal → Cursor-positioned input focuses → Types CJK →
 Browser shows IME candidates → User selects → Text appears in terminal
 ```
 
 ### Mobile Workflow
+
 ```
-User taps terminal → Virtual keyboard appears → Types CJK → 
+User taps terminal → Virtual keyboard appears → Types CJK →
 OS shows IME candidates → User selects → Text appears in terminal
 ```
 
 ### Visual Behavior
-- **Desktop**: Completely invisible, native IME popup at cursor position
+
+- **Desktop**: Transparent input text and native IME popup at the terminal cursor
 - **Mobile**: Standard input field with native virtual keyboard
 - **Both platforms**: Seamless CJK text input with full IME support
 
 ## Performance
 
-### Resource Usage
-- **Memory**: <1KB (1 invisible DOM element + event listeners)
-- **CPU**: ~0.1ms per event (negligible overhead)
-- **Impact on English users**: None (actually improves paste reliability)
-
 ### Optimization Features
-- Event handlers only active during IME usage
+
+- One input element and listener set per active desktop session
 - Dynamic positioning only calculated when needed
-- Minimal DOM footprint (single invisible input element)
+- Minimal DOM footprint (single input element)
 - Clean event delegation and lifecycle management
-- Automatic focus management with click-to-focus behavior
+- Click-to-focus behavior without polling
 - Proper cleanup prevents memory leaks during session changes
 
 ## Code Reference
 
 ### Primary Files
-- `cursor-position.ts` - **Shared cursor position calculation**
-  - `14-20` - Main `calculateCursorPosition()` function signature
-  - `32-46` - Character width measurement using test elements
-  - `48-69` - Coordinate conversion (absolute → container-relative)
-  - `70-72` - Error handling and cleanup
-- `ime-input.ts` - Desktop IME component implementation
-  - `32-48` - DesktopIMEInput class definition
-  - `50-80` - Invisible input element creation
-  - `82-132` - Event listener setup (composition, paste, focus)
-  - `134-156` - IME composition event handling
-  - `317-343` - Focus retention mechanism
-- `input-manager.ts` - Input coordination and platform detection
-  - `71-129` - Platform detection and IME setup
-  - `131-144` - IME state checking during keyboard input
-  - `453-458` - Cleanup and lifecycle management
+
+- `ime-input.ts` - Desktop input creation, composition events, positioning, focus, paste, and cleanup
+- `input-manager.ts` - Input coordination, desktop/mobile selection, terminal routing, and lifecycle
+- `terminal.ts` - Ghostty renderer cursor geometry used to anchor the native input
+- `lifecycle-event-manager.ts` - Keyboard interception that leaves active composition to the browser
 - `direct-keyboard-manager.ts` - Mobile keyboard handling
-  - Complete mobile input implementation
 - `mobile-utils.ts` - Mobile detection utilities
 
 ### Supporting Files
-- `cursor-position.ts` - **Shared cursor position calculation utility**
-- `terminal.ts` - Ghostty renderer (no cursor info provider yet; IME uses fallback)
-- `vibe-terminal-buffer.ts` - Buffer terminal cursor position API (uses shared utility)
+
 - `session-view.ts` - Container element and terminal integration
-- `lifecycle-event-manager.ts` - Event coordination and interception
 - `ime-constants.ts` - IME-related key filtering utilities
-- `terminal-constants.ts` - **Centralized terminal element IDs and selectors**
+- `terminal-constants.ts` - Terminal element IDs, font settings, and IME positioning constants
 
 ## Browser Compatibility
 
 Works with all major browsers that support:
+
 - IME composition events (`compositionstart`, `compositionupdate`, `compositionend`)
 - Clipboard API for paste functionality
 - Standard DOM positioning APIs
 
-Tested with:
-- Chrome, Firefox, Safari, Edge
-- macOS, Windows, Linux IME systems
-- Chinese (Simplified/Traditional), Japanese, Korean input methods
+The affected macOS boundary has live coverage with Chrome and Safari using Chinese Pinyin. Automated coverage verifies the composition lifecycle and cursor anchoring independently of the operating-system candidate UI.
 
 ## Configuration
 
 ### Automatic Platform Detection
+
 CJK IME support is automatically configured based on the detected platform:
-- **Desktop**: Invisible IME input with cursor following
+
+- **Desktop**: Cursor-positioned IME input with native candidate-window anchoring
 - **Mobile**: Native virtual keyboard with OS IME
 
 ### Requirements
+
 1. User has CJK input method enabled in their OS
 2. Desktop: User clicks in terminal area to focus
 3. Mobile: User taps terminal or input field
@@ -344,12 +353,15 @@ CJK IME support is automatically configured based on the detected platform:
 ## Troubleshooting
 
 ### Common Issues
+
 - **IME candidates not showing**: Ensure browser supports composition events
 - **Text not appearing**: Check if terminal session is active and receiving input
 - **Paste not working**: Verify clipboard permissions in browser
 
 ### Debug Information
+
 Comprehensive logging available in browser console:
+
 - `🔍 Setting up IME input on desktop device` - Platform detection
 - `[ime-input]` - Desktop IME component events
 - `[direct-keyboard-manager]` - Mobile keyboard events
@@ -363,18 +375,21 @@ Comprehensive logging available in browser console:
 ## Recent Improvements (v1.0.0-beta.16+)
 
 ### Unified Cursor Position Tracking
+
 - **Shared Utility**: Created `cursor-position.ts` for consistent cursor calculation across all terminal types
 - **Container-Aware Positioning**: Fixed IME positioning issues with side panels and complex layouts
 - **Precise Alignment**: Improved character width measurement for pixel-perfect cursor alignment
 - **Debug Logging**: Enhanced debug output with comprehensive coordinate information
 
 ### Technical Improvements
+
 - **Code Deduplication**: Eliminated ~120 lines of duplicate cursor calculation code
 - **Maintainability**: Single source of truth for cursor positioning logic
 - **Type Safety**: Improved TypeScript interfaces and error handling
 - **Performance**: More efficient coordinate conversion with optimized calculations
 
 ### Element ID Centralization
+
 - **Constants File**: Created `terminal-constants.ts` to centralize all critical terminal element IDs
 - **Prevention of Breakage**: Changes to IDs like `session-terminal`, `buffer-container`, or `terminal-container` now only require updates in one location
 - **Consistent References**: All components now import `TERMINAL_IDS` constants instead of using hardcoded strings
@@ -385,4 +400,4 @@ Comprehensive logging available in browser console:
 **Status**: ✅ Production Ready  
 **Platforms**: Desktop (Windows, macOS, Linux) and Mobile (iOS, Android)  
 **Version**: VibeTunnel Web v1.0.0-beta.16+  
-**Last Updated**: 2025-12-19
+**Last Updated**: 2026-06-13

--- a/web/src/client/components/ime-input.test.ts
+++ b/web/src/client/components/ime-input.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IME_VERTICAL_OFFSET_PX } from '../utils/terminal-constants.js';
+import { DesktopIMEInput } from './ime-input.js';
+
+describe('DesktopIMEInput', () => {
+  let container: HTMLDivElement;
+  let imeInput: DesktopIMEInput;
+  let onTextInput: ReturnType<typeof vi.fn>;
+  let onSpecialKey: ReturnType<typeof vi.fn>;
+
+  const createCompositionEvent = (type: string, data = ''): CompositionEvent => {
+    const event = new Event(type, { bubbles: true }) as CompositionEvent;
+    Object.defineProperty(event, 'data', { value: data });
+    return event;
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    container.id = 'session-terminal';
+    document.body.appendChild(container);
+
+    onTextInput = vi.fn();
+    onSpecialKey = vi.fn();
+    imeInput = new DesktopIMEInput({
+      container,
+      onTextInput,
+      onSpecialKey,
+      getCursorInfo: () => ({ x: 48, y: 72 }),
+      getFontSize: () => 16,
+    });
+  });
+
+  afterEach(() => {
+    imeInput.cleanup();
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it('anchors the native input at the terminal cursor when focused', () => {
+    container.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+    const input = container.querySelector('input');
+    expect(input).not.toBeNull();
+    expect(document.activeElement).toBe(input);
+    expect(input?.style.left).toBe('48px');
+    expect(input?.style.top).toBe(`${72 - IME_VERTICAL_OFFSET_PX}px`);
+    expect(input?.style.width).toBe('200px');
+    expect(input?.style.opacity).toBe('1');
+    expect(document.body.getAttribute('data-ime-input-focused')).toBe('true');
+  });
+
+  it('commits composed text exactly once', () => {
+    const input = container.querySelector('input');
+    expect(input).not.toBeNull();
+
+    input?.dispatchEvent(createCompositionEvent('compositionstart'));
+    if (input) input.value = 'ni hao';
+    input?.dispatchEvent(new InputEvent('input', { bubbles: true, data: 'ni hao' }));
+
+    expect(onTextInput).not.toHaveBeenCalled();
+    expect(document.body.getAttribute('data-ime-composing')).toBe('true');
+
+    if (input) input.value = '你好';
+    input?.dispatchEvent(createCompositionEvent('compositionend', '你好'));
+    input?.dispatchEvent(new InputEvent('input', { bubbles: true, data: '你好' }));
+
+    expect(onTextInput).toHaveBeenCalledOnce();
+    expect(onTextInput).toHaveBeenCalledWith('你好');
+    expect(input?.value).toBe('');
+    expect(document.body.hasAttribute('data-ime-composing')).toBe(false);
+  });
+
+  it('preserves ordinary typing and terminal Enter handling', () => {
+    const input = container.querySelector('input');
+    expect(input).not.toBeNull();
+
+    if (input) input.value = 'plain text';
+    input?.dispatchEvent(new InputEvent('input', { bubbles: true, data: 'plain text' }));
+
+    expect(onTextInput).toHaveBeenCalledWith('plain text');
+    expect(input?.value).toBe('');
+
+    input?.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' }));
+
+    expect(onSpecialKey).toHaveBeenCalledOnce();
+    expect(onSpecialKey).toHaveBeenCalledWith('enter');
+  });
+
+  it('removes the native input and composition markers during cleanup', () => {
+    const input = container.querySelector('input');
+    input?.dispatchEvent(new FocusEvent('focus'));
+    input?.dispatchEvent(createCompositionEvent('compositionstart'));
+
+    imeInput.cleanup();
+
+    expect(container.querySelector('input')).toBeNull();
+    expect(document.body.hasAttribute('data-ime-input-focused')).toBe(false);
+    expect(document.body.hasAttribute('data-ime-composing')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- add direct regression coverage for desktop Chinese IME cursor anchoring and composition
- verify composed text is committed once while ordinary typing and terminal Enter handling remain intact
- update the CJK IME documentation to match the current cursor-positioned browser input implementation

Closes #421.

## Reproduction and live proof

Current `main` already contains the runtime fix. I built commit `7f9b30c1` from source and exercised the exact generated server bundle on macOS with the built-in Simplified Chinese Pinyin input source.

- Chrome 149: the native candidate window appeared at the terminal cursor; selecting the first candidate committed `你好` once; Enter reached the shell; terminal output confirmed the expected UTF-8 bytes.
- Safari 26.5: the native candidate window appeared at the terminal cursor; candidate selection, terminal echo, and Enter behaved identically.
- The proof used synthetic terminal content only. Full-screen captures remain local because they include unrelated desktop context.

## Validation

- `pnpm exec vitest run --mode=client src/client/components/ime-input.test.ts`
- `pnpm exec vitest run --reporter=dot --maxWorkers=8` (1,539 passed, 111 skipped)
- `pnpm run check`
- `pnpm exec biome check src/client/components/ime-input.test.ts`
- `pnpm exec prettier --check ../docs/cjk-ime-input.md`
- `scripts/validate-docs.sh`
- structured autoreview: clean, no actionable findings
- Public Model Identifier Gate: PASS; no model identifiers in the diff, changed tests/docs, workflows, test output, or public proof
