### PR TITLE
feat(web): customize mobile quick keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### ✨ Improvements
+- Let mobile users reorder, hide, and choose layouts for terminal quick keys, with browser-local persistence and an unchanged default layout (via [@ndraiman](https://github.com/ndraiman)) (#564)
 - Restore clickable Ctrl+letter shortcuts in the Ghostty terminal renderer (reported by [@manmal](https://github.com/manmal), based on the original implementation by [@hjanuschka](https://github.com/hjanuschka)) (#51)
 - Show returning users only the CLI maintenance page after updates, while keeping the full onboarding flow available manually (reported by [@MrMage](https://github.com/MrMage), with earlier investigation by [@gioneill](https://github.com/gioneill)) (#411)
 - Pin CI actions, runner images, and downloaded build tools to immutable, checksum-verified versions (via [@davisbuilds](https://github.com/davisbuilds)) (#616)
@@ -61,6 +62,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
+- Thanks [@ndraiman](https://github.com/ndraiman) for proposing customizable mobile terminal quick-key layouts.
 - Thanks [@manmal](https://github.com/manmal) and [@hjanuschka](https://github.com/hjanuschka) for proposing and originally implementing clickable terminal shortcuts.
 - Thanks [@MrMage](https://github.com/MrMage) and [@gioneill](https://github.com/gioneill) for reporting and investigating repetitive update onboarding.
 - Thanks [@davisbuilds](https://github.com/davisbuilds) for hardening CI workflows and build-tool bootstrap paths.

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -24,6 +24,10 @@ VibeTunnel operates in two keyboard capture modes:
 
 Press Escape twice within 500ms to toggle between capture modes.
 
+## Mobile Quick Keys
+
+On touch devices, open **Settings → Mobile Quick Keys → Customize** to reorder or hide the terminal shortcut buttons. VibeTunnel includes Default and Compact layouts, stores the selected layout in the current browser, and keeps the Done button fixed so the software keyboard can always be dismissed.
+
 ## Critical Browser Shortcuts (Always Available)
 
 These shortcuts always work, regardless of keyboard capture state:

--- a/web/src/client/components/quick-keys-editor.test.ts
+++ b/web/src/client/components/quick-keys-editor.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { restoreLocalStorage, setupLocalStorageMock } from '../../test/utils/component-helpers.js';
+import {
+  COMPACT_QUICK_KEYS_LAYOUT,
+  loadQuickKeysLayout,
+  QUICK_KEYS_STORAGE_KEY,
+  saveQuickKeysLayout,
+} from '../utils/quick-keys-layout.js';
+import { QuickKeysEditor } from './quick-keys-editor.js';
+
+interface QuickKeysEditorPrivate extends QuickKeysEditor {
+  draftLayout: typeof COMPACT_QUICK_KEYS_LAYOUT;
+  selectedKey: 'Escape' | 'Control' | 'Home';
+  applyPreset(layout: typeof COMPACT_QUICK_KEYS_LAYOUT): void;
+  hideSelected(): void;
+  moveSelectedToRow(row: number): void;
+  moveSelectedWithinRow(offset: -1 | 1): void;
+  handleSave(): void;
+}
+
+describe('QuickKeysEditor', () => {
+  let component: QuickKeysEditorPrivate;
+
+  beforeEach(async () => {
+    setupLocalStorageMock();
+    component = new QuickKeysEditor() as QuickKeysEditorPrivate;
+    component.visible = true;
+    document.body.append(component);
+    await component.updateComplete;
+  });
+
+  afterEach(() => {
+    component.remove();
+    restoreLocalStorage();
+  });
+
+  it('opens with the persisted layout and keeps Done outside customization', async () => {
+    component.remove();
+    saveQuickKeysLayout(COMPACT_QUICK_KEYS_LAYOUT);
+    component = new QuickKeysEditor() as QuickKeysEditorPrivate;
+    component.visible = true;
+    document.body.append(component);
+    await component.updateComplete;
+
+    expect(component.draftLayout).toEqual(COMPACT_QUICK_KEYS_LAYOUT);
+    expect(component.querySelectorAll('[data-key="Done"]')).toHaveLength(0);
+    expect(component.textContent).toContain('Done remains fixed');
+  });
+
+  it('reorders, moves, and hides a selected key without emptying a row', () => {
+    component.applyPreset(COMPACT_QUICK_KEYS_LAYOUT);
+    component.selectedKey = 'Control';
+    component.moveSelectedWithinRow(-1);
+    expect(component.draftLayout[0].slice(0, 2)).toEqual(['Control', 'Escape']);
+
+    component.moveSelectedToRow(1);
+    expect(component.draftLayout[0]).not.toContain('Control');
+    expect(component.draftLayout[1]).toContain('Control');
+
+    component.hideSelected();
+    expect(component.draftLayout.flat()).not.toContain('Control');
+
+    component.selectedKey = 'Home';
+    component.draftLayout = [['Escape'], ['Home']];
+    component.hideSelected();
+    expect(component.draftLayout).toEqual([['Escape'], ['Home']]);
+  });
+
+  it('adds a hidden key to a chosen row and persists only on Apply', () => {
+    component.applyPreset(COMPACT_QUICK_KEYS_LAYOUT);
+    component.selectedKey = 'Control';
+    component.hideSelected();
+    component.moveSelectedToRow(1);
+
+    expect(localStorage.getItem(QUICK_KEYS_STORAGE_KEY)).toBeNull();
+    component.handleSave();
+
+    expect(loadQuickKeysLayout()[1]).toContain('Control');
+  });
+});

--- a/web/src/client/components/quick-keys-editor.ts
+++ b/web/src/client/components/quick-keys-editor.ts
@@ -1,0 +1,407 @@
+import { html, LitElement, type PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import {
+  DEFAULT_QUICK_KEYS_LAYOUT,
+  getHiddenQuickKeys,
+  getQuickKeyDefinition,
+  loadQuickKeysLayout,
+  QUICK_KEYS_PRESETS,
+  type QuickKeyId,
+  type QuickKeysLayout,
+  saveQuickKeysLayout,
+} from '../utils/quick-keys-layout.js';
+
+const MAX_KEYS_PER_ROW = 12;
+
+@customElement('quick-keys-editor')
+export class QuickKeysEditor extends LitElement {
+  createRenderRoot() {
+    return this;
+  }
+
+  @property({ type: Boolean }) visible = false;
+
+  @state() private draftLayout: QuickKeysLayout = [];
+  @state() private selectedKey: QuickKeyId | null = null;
+  @state() private saveError = false;
+
+  protected willUpdate(changedProperties: PropertyValues) {
+    if (changedProperties.has('visible') && this.visible) {
+      this.draftLayout = loadQuickKeysLayout();
+      this.selectedKey = this.draftLayout[0]?.[0] ?? null;
+      this.saveError = false;
+    }
+  }
+
+  private handleClose() {
+    this.dispatchEvent(new CustomEvent('close'));
+  }
+
+  private applyPreset(layout: QuickKeysLayout) {
+    this.draftLayout = layout.map((row) => [...row]);
+    this.selectedKey = this.draftLayout[0]?.[0] ?? null;
+    this.saveError = false;
+  }
+
+  private getSelectedPosition(): { row: number; index: number } | null {
+    if (!this.selectedKey) return null;
+
+    for (let row = 0; row < this.draftLayout.length; row++) {
+      const index = this.draftLayout[row].indexOf(this.selectedKey);
+      if (index >= 0) {
+        return { row, index };
+      }
+    }
+    return null;
+  }
+
+  private moveSelectedWithinRow(offset: -1 | 1) {
+    const position = this.getSelectedPosition();
+    if (!position) return;
+
+    const targetIndex = position.index + offset;
+    const sourceRow = this.draftLayout[position.row];
+    if (targetIndex < 0 || targetIndex >= sourceRow.length) return;
+
+    const nextLayout = this.draftLayout.map((row) => [...row]);
+    const [key] = nextLayout[position.row].splice(position.index, 1);
+    nextLayout[position.row].splice(targetIndex, 0, key);
+    this.draftLayout = nextLayout;
+  }
+
+  private moveSelectedToRow(targetRow: number) {
+    if (!this.selectedKey || !this.draftLayout[targetRow]) return;
+    if (this.draftLayout[targetRow].length >= MAX_KEYS_PER_ROW) return;
+
+    const position = this.getSelectedPosition();
+    const nextLayout = this.draftLayout.map((row) => [...row]);
+
+    if (position) {
+      if (position.row === targetRow || nextLayout[position.row].length === 1) return;
+      nextLayout[position.row].splice(position.index, 1);
+    }
+
+    nextLayout[targetRow].push(this.selectedKey);
+    this.draftLayout = nextLayout;
+  }
+
+  private hideSelected() {
+    const position = this.getSelectedPosition();
+    if (!position || this.draftLayout[position.row].length === 1) return;
+
+    const nextLayout = this.draftLayout.map((row) => [...row]);
+    nextLayout[position.row].splice(position.index, 1);
+    this.draftLayout = nextLayout;
+  }
+
+  private addRow() {
+    if (this.draftLayout.length >= 3) return;
+
+    const hiddenKey = getHiddenQuickKeys(this.draftLayout)[0]?.key;
+    if (hiddenKey) {
+      this.draftLayout = [...this.draftLayout.map((row) => [...row]), [hiddenKey]];
+      this.selectedKey = hiddenKey;
+      return;
+    }
+
+    const sourceRow = this.draftLayout.findIndex((row) => row.length > 1);
+    if (sourceRow < 0) return;
+
+    const nextLayout = this.draftLayout.map((row) => [...row]);
+    const key = nextLayout[sourceRow].pop();
+    if (!key) return;
+
+    nextLayout.push([key]);
+    this.draftLayout = nextLayout;
+    this.selectedKey = key;
+  }
+
+  private removeThirdRow() {
+    if (this.draftLayout.length !== 3) return;
+
+    const nextLayout = this.draftLayout.slice(0, 2).map((row) => [...row]);
+    for (const key of this.draftLayout[2]) {
+      const targetRow = nextLayout[0].length <= nextLayout[1].length ? 0 : 1;
+      if (nextLayout[targetRow].length >= MAX_KEYS_PER_ROW) return;
+      nextLayout[targetRow].push(key);
+    }
+
+    this.draftLayout = nextLayout;
+  }
+
+  private handleSave() {
+    if (!saveQuickKeysLayout(this.draftLayout)) {
+      this.saveError = true;
+      return;
+    }
+
+    this.handleClose();
+  }
+
+  private renderKey(key: QuickKeyId, rowIndex?: number) {
+    const definition = getQuickKeyDefinition(key);
+    const selected = this.selectedKey === key;
+    const location = rowIndex === undefined ? 'Hidden' : `Row ${rowIndex + 1}`;
+
+    return html`
+      <button
+        type="button"
+        class="min-h-11 min-w-11 px-2 py-2 rounded border font-mono text-xs transition-colors ${
+          selected
+            ? 'border-primary bg-primary/20 text-primary'
+            : 'border-border bg-bg-tertiary text-text-muted hover:border-primary/60 hover:text-primary'
+        }"
+        aria-pressed=${selected ? 'true' : 'false'}
+        aria-label="${definition.label}, ${location}"
+        data-key=${key}
+        @click=${() => {
+          this.selectedKey = key;
+          this.saveError = false;
+        }}
+      >
+        ${definition.label}
+      </button>
+    `;
+  }
+
+  private renderSelectedControls() {
+    if (!this.selectedKey) return html``;
+
+    const position = this.getSelectedPosition();
+    if (!position) {
+      return html`
+        <div class="flex flex-wrap gap-2" aria-label="Add selected key">
+          ${this.draftLayout.map(
+            (row, rowIndex) => html`
+              <button
+                type="button"
+                class="btn-secondary text-xs px-3 py-2"
+                ?disabled=${row.length >= MAX_KEYS_PER_ROW}
+                @click=${() => this.moveSelectedToRow(rowIndex)}
+              >
+                Add to row ${rowIndex + 1}
+              </button>
+            `
+          )}
+        </div>
+      `;
+    }
+
+    const row = this.draftLayout[position.row];
+    return html`
+      <div class="flex flex-wrap gap-2" aria-label="Reorder selected key">
+        <button
+          type="button"
+          class="btn-secondary text-xs px-3 py-2"
+          ?disabled=${position.index === 0}
+          @click=${() => this.moveSelectedWithinRow(-1)}
+        >
+          Move earlier
+        </button>
+        <button
+          type="button"
+          class="btn-secondary text-xs px-3 py-2"
+          ?disabled=${position.index === row.length - 1}
+          @click=${() => this.moveSelectedWithinRow(1)}
+        >
+          Move later
+        </button>
+        ${this.draftLayout.map((target, rowIndex) =>
+          rowIndex === position.row
+            ? ''
+            : html`
+                <button
+                  type="button"
+                  class="btn-secondary text-xs px-3 py-2"
+                  ?disabled=${row.length === 1 || target.length >= MAX_KEYS_PER_ROW}
+                  @click=${() => this.moveSelectedToRow(rowIndex)}
+                >
+                  Move to row ${rowIndex + 1}
+                </button>
+              `
+        )}
+        <button
+          type="button"
+          class="btn-secondary text-xs px-3 py-2 text-status-error"
+          ?disabled=${row.length === 1}
+          @click=${this.hideSelected}
+        >
+          Hide
+        </button>
+      </div>
+    `;
+  }
+
+  render() {
+    if (!this.visible) return html``;
+
+    const hiddenKeys = getHiddenQuickKeys(this.draftLayout);
+    const selectedDefinition = this.selectedKey
+      ? getQuickKeyDefinition(this.selectedKey)
+      : undefined;
+
+    return html`
+      <div
+        class="fixed inset-0 bg-bg/90 flex items-center justify-center p-2 sm:p-4"
+        style="z-index: 1010"
+        @click=${(event: Event) => {
+          event.stopPropagation();
+          if (event.target === event.currentTarget) {
+            this.handleClose();
+          }
+        }}
+      >
+        <div
+          class="bg-bg-secondary border border-border rounded-xl shadow-2xl w-full max-w-2xl max-h-[calc(100dvh-1rem)] overflow-hidden flex flex-col"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="quick-keys-editor-title"
+          @click=${(event: Event) => event.stopPropagation()}
+        >
+          <div class="p-4 border-b border-border/50 flex items-center justify-between">
+            <div>
+              <h2 id="quick-keys-editor-title" class="text-primary text-lg font-bold">
+                Mobile Quick Keys
+              </h2>
+              <p class="text-muted text-xs mt-1">
+                Stored in this browser. Done remains fixed.
+              </p>
+            </div>
+            <button
+              type="button"
+              class="min-h-11 min-w-11 text-text-muted hover:text-primary"
+              aria-label="Close quick keys editor"
+              @click=${this.handleClose}
+            >
+              ✕
+            </button>
+          </div>
+
+          <div class="flex-1 overflow-y-auto p-4 space-y-5">
+            <div>
+              <h3 class="text-sm font-medium text-primary mb-2">Presets</h3>
+              <div class="flex flex-wrap gap-2">
+                ${QUICK_KEYS_PRESETS.map(
+                  (preset) => html`
+                    <button
+                      type="button"
+                      class="btn-secondary text-xs px-3 py-2"
+                      @click=${() => this.applyPreset(preset.layout.map((row) => [...row]))}
+                    >
+                      ${preset.name}
+                    </button>
+                  `
+                )}
+              </div>
+            </div>
+
+            <div class="space-y-3">
+              ${this.draftLayout.map(
+                (row, rowIndex) => html`
+                  <section class="p-3 bg-bg rounded-lg border border-border/50">
+                    <div class="flex items-center justify-between mb-2">
+                      <h3 class="text-sm font-medium text-primary">Row ${rowIndex + 1}</h3>
+                      <span class="text-xs text-muted">${row.length}/${MAX_KEYS_PER_ROW}</span>
+                    </div>
+                    <div class="flex flex-wrap gap-1.5">
+                      ${row.map((key) => this.renderKey(key, rowIndex))}
+                      ${
+                        rowIndex === 1
+                          ? html`<span
+                            class="min-h-11 px-3 py-2 rounded border border-dashed border-border text-xs text-muted flex items-center"
+                            >Done</span
+                          >`
+                          : ''
+                      }
+                    </div>
+                  </section>
+                `
+              )}
+              <div class="flex flex-wrap gap-2">
+                ${
+                  this.draftLayout.length < 3
+                    ? html`
+                      <button
+                        type="button"
+                        class="btn-secondary text-xs px-3 py-2"
+                        @click=${this.addRow}
+                      >
+                        Add third row
+                      </button>
+                    `
+                    : html`
+                      <button
+                        type="button"
+                        class="btn-secondary text-xs px-3 py-2"
+                        @click=${this.removeThirdRow}
+                      >
+                        Remove third row
+                      </button>
+                    `
+                }
+              </div>
+            </div>
+
+            <div class="p-3 bg-bg rounded-lg border border-border/50">
+              <h3 class="text-sm font-medium text-primary mb-2">
+                ${
+                  selectedDefinition
+                    ? html`Selected: <span class="font-mono">${selectedDefinition.label}</span>`
+                    : 'Select a key'
+                }
+              </h3>
+              ${this.renderSelectedControls()}
+            </div>
+
+            <div>
+              <h3 class="text-sm font-medium text-primary mb-2">Hidden keys</h3>
+              <div class="flex flex-wrap gap-1.5 min-h-11">
+                ${
+                  hiddenKeys.length > 0
+                    ? hiddenKeys.map(({ key }) => this.renderKey(key))
+                    : html`<span class="text-xs text-muted">All keys are visible.</span>`
+                }
+              </div>
+            </div>
+
+            ${
+              this.saveError
+                ? html`
+                  <p class="text-sm text-status-error" role="alert">
+                    Could not save this layout. Check browser storage permissions.
+                  </p>
+                `
+                : ''
+            }
+          </div>
+
+          <div class="p-4 border-t border-border/50 flex items-center justify-between gap-3">
+            <button
+              type="button"
+              class="btn-secondary text-xs px-3 py-2"
+              @click=${() => this.applyPreset(DEFAULT_QUICK_KEYS_LAYOUT)}
+            >
+              Reset draft
+            </button>
+            <div class="flex gap-2">
+              <button
+                type="button"
+                class="btn-secondary text-xs px-3 py-2"
+                @click=${this.handleClose}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                class="btn-primary text-xs px-4 py-2"
+                @click=${this.handleSave}
+              >
+                Apply
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}

--- a/web/src/client/components/settings.ts
+++ b/web/src/client/components/settings.ts
@@ -12,6 +12,7 @@ import { RepositoryService } from '../services/repository-service.js';
 import { ServerConfigService } from '../services/server-config-service.js';
 import { createLogger } from '../utils/logger.js';
 import { VERSION } from '../version.js';
+import './quick-keys-editor.js';
 
 const logger = createLogger('settings');
 
@@ -37,6 +38,7 @@ export class Settings extends LitElement {
   @state() private repositoryBasePath = DEFAULT_REPOSITORY_BASE_PATH;
   @state() private repositoryCount = 0;
   @state() private isDiscoveringRepositories = false;
+  @state() private showQuickKeysEditor = false;
 
   private permissionChangeUnsubscribe?: () => void;
   private subscriptionChangeUnsubscribe?: () => void;
@@ -81,6 +83,7 @@ export class Settings extends LitElement {
         this.refreshNotificationState();
       } else {
         document.removeEventListener('keydown', this.handleKeyDown);
+        this.showQuickKeysEditor = false;
       }
     }
 
@@ -509,6 +512,12 @@ export class Settings extends LitElement {
           </div>
         </div>
       </div>
+      <quick-keys-editor
+        .visible=${this.showQuickKeysEditor}
+        @close=${() => {
+          this.showQuickKeysEditor = false;
+        }}
+      ></quick-keys-editor>
     `;
   }
 
@@ -728,6 +737,26 @@ export class Settings extends LitElement {
               placeholder="~/"
               class="input-field py-2 text-sm flex-1"
             />
+          </div>
+        </div>
+
+        <div class="p-4 bg-bg-tertiary rounded-lg border border-border/50">
+          <div class="flex items-center justify-between gap-4">
+            <div>
+              <label class="text-primary font-medium">Mobile Quick Keys</label>
+              <p class="text-muted text-xs mt-1">
+                Reorder or hide terminal shortcuts on this browser.
+              </p>
+            </div>
+            <button
+              type="button"
+              class="btn-secondary text-xs px-3 py-2 flex-shrink-0"
+              @click=${() => {
+                this.showQuickKeysEditor = true;
+              }}
+            >
+              Customize
+            </button>
           </div>
         </div>
       </div>

--- a/web/src/client/components/terminal-quick-keys.test.ts
+++ b/web/src/client/components/terminal-quick-keys.test.ts
@@ -1,6 +1,12 @@
 // @vitest-environment happy-dom
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { restoreLocalStorage, setupLocalStorageMock } from '../../test/utils/component-helpers.js';
+import {
+  COMPACT_QUICK_KEYS_LAYOUT,
+  DEFAULT_QUICK_KEYS_LAYOUT,
+  saveQuickKeysLayout,
+} from '../utils/quick-keys-layout.js';
 import { TerminalQuickKeys } from './terminal-quick-keys.js';
 
 // Define interface for private methods we need to test
@@ -22,10 +28,16 @@ describe('TerminalQuickKeys', () => {
   let mockOnKeyPress: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    setupLocalStorageMock();
     component = new TerminalQuickKeys() as TerminalQuickKeysPrivate;
     mockOnKeyPress = vi.fn();
     component.onKeyPress = mockOnKeyPress;
     component.visible = true;
+  });
+
+  afterEach(() => {
+    component.remove();
+    restoreLocalStorage();
   });
 
   describe('Option key chord system', () => {
@@ -186,6 +198,48 @@ describe('TerminalQuickKeys', () => {
 
       expect(arrowKey?.classList.contains('px-1.5')).toBe(true);
       expect(arrowKey?.classList.contains('py-2.5')).toBe(true);
+      component.remove();
+    });
+  });
+
+  describe('custom layouts', () => {
+    it('keeps the existing three-row layout as the default', async () => {
+      document.body.append(component);
+      await component.updateComplete;
+
+      const renderedKeys = Array.from(component.querySelectorAll<HTMLElement>('[data-key]')).map(
+        (element) => element.dataset.key
+      );
+
+      expect(renderedKeys).toEqual([
+        ...DEFAULT_QUICK_KEYS_LAYOUT[0],
+        ...DEFAULT_QUICK_KEYS_LAYOUT[1],
+        'Done',
+        ...DEFAULT_QUICK_KEYS_LAYOUT[2],
+      ]);
+      component.remove();
+    });
+
+    it('updates an open keyboard when a valid layout is saved', async () => {
+      document.body.append(component);
+      await component.updateComplete;
+
+      expect(saveQuickKeysLayout(COMPACT_QUICK_KEYS_LAYOUT)).toBe(true);
+      await component.updateComplete;
+
+      const renderedKeys = Array.from(component.querySelectorAll<HTMLElement>('[data-key]')).map(
+        (element) => element.dataset.key
+      );
+
+      expect(renderedKeys).toEqual([
+        ...COMPACT_QUICK_KEYS_LAYOUT[0],
+        ...COMPACT_QUICK_KEYS_LAYOUT[1],
+        'Done',
+      ]);
+      expect(component.querySelectorAll('[data-key="Done"]')).toHaveLength(1);
+      expect(component.querySelector('[data-key="ArrowUp"]')?.classList.contains('arrow-key')).toBe(
+        true
+      );
       component.remove();
     });
   });

--- a/web/src/client/components/terminal-quick-keys.test.ts
+++ b/web/src/client/components/terminal-quick-keys.test.ts
@@ -242,5 +242,35 @@ describe('TerminalQuickKeys', () => {
       );
       component.remove();
     });
+
+    it.each([
+      ['CtrlExpand', 'Ctrl+D'],
+      ['F', 'F1'],
+    ] as const)('keeps the %s toggle reachable when row 2 is expanded', async (toggle, expandedKey) => {
+      expect(
+        saveQuickKeysLayout([
+          ['Escape', 'Control', 'Tab'],
+          [toggle, 'Home', 'Paste'],
+        ])
+      ).toBe(true);
+      document.body.append(component);
+      await component.updateComplete;
+
+      component.handleKeyPress(toggle, false, false, true);
+      await component.updateComplete;
+
+      const collapseButton = component.querySelector<HTMLButtonElement>(`[data-key="${toggle}"]`);
+      expect(collapseButton).not.toBeNull();
+      expect(component.querySelector(`[data-key="${expandedKey}"]`)).not.toBeNull();
+
+      collapseButton?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, composed: true, detail: 1 })
+      );
+      await component.updateComplete;
+
+      expect(component.querySelector(`[data-key="${expandedKey}"]`)).toBeNull();
+      expect(component.querySelector('[data-key="Home"]')).not.toBeNull();
+      component.remove();
+    });
   });
 });

--- a/web/src/client/components/terminal-quick-keys.ts
+++ b/web/src/client/components/terminal-quick-keys.ts
@@ -330,6 +330,14 @@ export class TerminalQuickKeys extends LitElement {
     return this.quickKeysLayout.map((row) => row.map((key) => getQuickKeyDefinition(key)));
   }
 
+  private renderExpandedToggle(rows: QuickKeyDefinition[][], key: 'CtrlExpand' | 'F') {
+    const remainsVisible = [rows[0], ...rows.slice(2)].some((row) =>
+      row.some((definition) => definition.key === key)
+    );
+
+    return remainsVisible ? '' : this.renderQuickKey(getQuickKeyDefinition(key));
+  }
+
   private renderQuickKey(definition: QuickKeyDefinition) {
     const { key, label, modifier, combo, arrow, toggle } = definition;
     const activeToggle =
@@ -641,6 +649,7 @@ export class TerminalQuickKeys extends LitElement {
               ? html`
               <div class="flex gap-0.5 ${rows.length > 2 ? 'mb-0.5' : ''}">
                 ${CTRL_SHORTCUTS.map((key) => this.renderAuxiliaryKey(key))}
+                ${this.renderExpandedToggle(rows, 'CtrlExpand')}
                 ${this.renderDoneButton()}
               </div>
             `
@@ -648,6 +657,7 @@ export class TerminalQuickKeys extends LitElement {
                 ? html`
               <div class="flex gap-0.5 ${rows.length > 2 ? 'mb-0.5' : ''}">
                 ${FUNCTION_KEYS.map((key) => this.renderAuxiliaryKey(key))}
+                ${this.renderExpandedToggle(rows, 'F')}
                 ${this.renderDoneButton()}
               </div>
             `

--- a/web/src/client/components/terminal-quick-keys.ts
+++ b/web/src/client/components/terminal-quick-keys.ts
@@ -1,47 +1,13 @@
 import { html, LitElement, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { Z_INDEX } from '../utils/constants.js';
-
-// Terminal-specific quick keys for mobile use
-const TERMINAL_QUICK_KEYS = [
-  // First row
-  { key: 'Escape', label: 'Esc', row: 1 },
-  { key: 'Control', label: 'Ctrl', modifier: true, row: 1 },
-  { key: 'CtrlExpand', label: '⌃', toggle: true, row: 1 },
-  { key: 'F', label: 'F', toggle: true, row: 1 },
-  { key: 'Tab', label: 'Tab', row: 1 },
-  { key: 'shift_tab', label: '⇤', row: 1 },
-  { key: 'ArrowUp', label: '↑', arrow: true, row: 1 },
-  { key: 'ArrowDown', label: '↓', arrow: true, row: 1 },
-  { key: 'ArrowLeft', label: '←', arrow: true, row: 1 },
-  { key: 'ArrowRight', label: '→', arrow: true, row: 1 },
-  { key: 'PageUp', label: 'PgUp', row: 1 },
-  { key: 'PageDown', label: 'PgDn', row: 1 },
-  // Second row
-  { key: 'Home', label: 'Home', row: 2 },
-  { key: 'Paste', label: 'Paste', row: 2 },
-  { key: 'End', label: 'End', row: 2 },
-  { key: 'Delete', label: 'Del', row: 2 },
-  { key: '`', label: '`', row: 2 },
-  { key: '~', label: '~', row: 2 },
-  { key: '|', label: '|', row: 2 },
-  { key: '/', label: '/', row: 2 },
-  { key: '\\', label: '\\', row: 2 },
-  { key: '-', label: '-', row: 2 },
-  // Third row - additional special characters
-  { key: 'Option', label: '⌥', modifier: true, row: 3 },
-  { key: 'Command', label: '⌘', modifier: true, row: 3 },
-  { key: 'Ctrl+C', label: '^C', combo: true, row: 3 },
-  { key: 'Ctrl+Z', label: '^Z', combo: true, row: 3 },
-  { key: "'", label: "'", row: 3 },
-  { key: '"', label: '"', row: 3 },
-  { key: '{', label: '{', row: 3 },
-  { key: '}', label: '}', row: 3 },
-  { key: '[', label: '[', row: 3 },
-  { key: ']', label: ']', row: 3 },
-  { key: '(', label: '(', row: 3 },
-  { key: ')', label: ')', row: 3 },
-];
+import {
+  getQuickKeyDefinition,
+  loadQuickKeysLayout,
+  type QuickKeyDefinition,
+  type QuickKeysLayout,
+  subscribeToQuickKeysLayout,
+} from '../utils/quick-keys-layout.js';
 
 // Common Ctrl key combinations
 const CTRL_SHORTCUTS = [
@@ -84,10 +50,12 @@ export class TerminalQuickKeys extends LitElement {
   @state() private showFunctionKeys = false;
   @state() private showCtrlKeys = false;
   @state() private isLandscape = false;
+  @state() private quickKeysLayout: QuickKeysLayout = loadQuickKeysLayout();
 
   private keyRepeatInterval: number | null = null;
   private keyRepeatTimeout: number | null = null;
   private orientationHandler: (() => void) | null = null;
+  private quickKeysLayoutUnsubscribe?: () => void;
 
   // Chord system state
   private activeModifiers = new Set<string>();
@@ -114,6 +82,11 @@ export class TerminalQuickKeys extends LitElement {
     // We attach to the component host itself since it captures events from shadow DOM
     this.addEventListener('touchstart', this.handleDelegatedTouchStart, { passive: true });
     this.addEventListener('touchmove', this.handleDelegatedTouchMove, { passive: true });
+
+    this.quickKeysLayout = loadQuickKeysLayout();
+    this.quickKeysLayoutUnsubscribe = subscribeToQuickKeysLayout(() => {
+      this.quickKeysLayout = loadQuickKeysLayout();
+    });
   }
 
   private checkOrientation() {
@@ -200,7 +173,8 @@ export class TerminalQuickKeys extends LitElement {
       changedProperties.has('visible') ||
       changedProperties.has('showFunctionKeys') ||
       changedProperties.has('showCtrlKeys') ||
-      changedProperties.has('isLandscape')
+      changedProperties.has('isLandscape') ||
+      changedProperties.has('quickKeysLayout')
     ) {
       this.dispatchEvent(
         new CustomEvent('quick-keys-layout-change', {
@@ -348,6 +322,125 @@ export class TerminalQuickKeys extends LitElement {
     // Remove passive touch listeners
     this.removeEventListener('touchstart', this.handleDelegatedTouchStart);
     this.removeEventListener('touchmove', this.handleDelegatedTouchMove);
+    this.quickKeysLayoutUnsubscribe?.();
+    this.quickKeysLayoutUnsubscribe = undefined;
+  }
+
+  private getQuickKeyRows(): QuickKeyDefinition[][] {
+    return this.quickKeysLayout.map((row) => row.map((key) => getQuickKeyDefinition(key)));
+  }
+
+  private renderQuickKey(definition: QuickKeyDefinition) {
+    const { key, label, modifier, combo, arrow, toggle } = definition;
+    const activeToggle =
+      toggle &&
+      ((key === 'CtrlExpand' && this.showCtrlKeys) || (key === 'F' && this.showFunctionKeys));
+    const activeModifier = modifier && key === 'Option' && this.activeModifiers.has('Option');
+
+    return html`
+      <button
+        type="button"
+        tabindex="-1"
+        class="quick-key-btn ${this.getButtonFontClass(label)} min-w-0 ${this.getButtonSizeClass(label)} bg-bg-tertiary text-primary font-mono rounded border border-border hover:bg-surface hover:border-primary transition-all whitespace-nowrap ${modifier ? 'modifier-key' : ''} ${combo ? 'combo-key' : ''} ${arrow ? 'arrow-key' : ''} ${toggle ? 'toggle-key' : ''} ${activeToggle || activeModifier ? 'active' : ''}"
+        data-key=${key}
+        ?data-modifier=${modifier}
+        ?data-combo=${combo}
+        ?data-arrow=${arrow}
+        ?data-toggle=${toggle}
+        @mousedown=${(event: Event) => {
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+        @touchend=${(event: TouchEvent) => {
+          this.handleTouchEnd(event, () => {
+            if (arrow) {
+              this.stopKeyRepeat();
+            } else if (key === 'Paste') {
+              this.handlePasteImmediate(event);
+            } else {
+              this.handleKeyPress(key, Boolean(modifier || combo), false, Boolean(toggle), event);
+            }
+          });
+        }}
+        @touchcancel=${() => {
+          if (arrow) {
+            this.stopKeyRepeat();
+          }
+        }}
+        @click=${(event: MouseEvent) => {
+          if (event.detail !== 0 && !arrow) {
+            this.handleKeyPress(key, Boolean(modifier || combo), false, Boolean(toggle), event);
+          }
+        }}
+      >
+        ${label}
+      </button>
+    `;
+  }
+
+  private renderAuxiliaryKey(definition: {
+    key: string;
+    label: string;
+    combo?: boolean;
+    special?: boolean;
+    func?: boolean;
+  }) {
+    const { key, label, combo, special, func } = definition;
+
+    return html`
+      <button
+        type="button"
+        tabindex="-1"
+        class="${func ? 'func-key-btn' : 'ctrl-shortcut-btn'} ${this.getButtonFontClass(label)} min-w-0 ${this.getButtonSizeClass(label)} bg-bg-tertiary text-primary font-mono rounded border border-border hover:bg-surface hover:border-primary transition-all whitespace-nowrap ${combo ? 'combo-key' : ''} ${special ? 'special-key' : ''}"
+        data-key=${key}
+        ?data-combo=${combo}
+        ?data-special=${special}
+        @mousedown=${(event: Event) => {
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+        @touchend=${(event: TouchEvent) => {
+          this.handleTouchEnd(event, () => {
+            this.handleKeyPress(key, false, Boolean(special), false, event);
+          });
+        }}
+        @click=${(event: MouseEvent) => {
+          if (event.detail !== 0) {
+            this.handleKeyPress(key, false, Boolean(special), false, event);
+          }
+        }}
+      >
+        ${label}
+      </button>
+    `;
+  }
+
+  private renderDoneButton() {
+    return html`
+      <button
+        type="button"
+        tabindex="-1"
+        class="quick-key-btn ${this.getButtonFontClass(DONE_BUTTON.label)} min-w-0 ${this.getButtonSizeClass(DONE_BUTTON.label)} bg-bg-tertiary text-primary font-mono rounded border border-border hover:bg-surface hover:border-primary transition-all whitespace-nowrap special-key"
+        data-key=${DONE_BUTTON.key}
+        data-special
+        @mousedown=${(event: Event) => {
+          event.preventDefault();
+          event.stopPropagation();
+        }}
+        @touchend=${(event: TouchEvent) => {
+          this.handleTouchEnd(event, () => {
+            this.handleKeyPress(DONE_BUTTON.key, false, true, false, event);
+          });
+        }}
+        @click=${(event: MouseEvent) => {
+          if (event.detail !== 0) {
+            this.handleKeyPress(DONE_BUTTON.key, false, true, false, event);
+          }
+        }}
+      >
+        ${DONE_BUTTON.label}
+      </button>
+    `;
   }
 
   private renderStyles() {
@@ -533,263 +626,44 @@ export class TerminalQuickKeys extends LitElement {
   render() {
     if (!this.visible) return '';
 
-    // Use the same layout for all mobile devices (phones and tablets)
+    const rows = this.getQuickKeyRows();
+
     return html`
       <div
         class="terminal-quick-keys-container"
         style="position: fixed !important; bottom: var(--keyboard-offset, 0px) !important; left: 0 !important; right: 0 !important;"
       >
         <div class="quick-keys-bar">
-          <!-- Row 1 -->
-          <div class="flex gap-0.5 mb-0.5">
-            ${TERMINAL_QUICK_KEYS.filter((k) => k.row === 1).map(
-              ({ key, label, modifier, arrow, toggle }) => html`
-                <button
-                  type="button"
-                  tabindex="-1"
-                  class="quick-key-btn ${this.getButtonFontClass(label)} min-w-0 ${this.getButtonSizeClass(label)} bg-bg-tertiary text-primary font-mono rounded border border-border hover:bg-surface hover:border-primary transition-all whitespace-nowrap ${modifier ? 'modifier-key' : ''} ${arrow ? 'arrow-key' : ''} ${toggle ? 'toggle-key' : ''} ${toggle && ((key === 'CtrlExpand' && this.showCtrlKeys) || (key === 'F' && this.showFunctionKeys)) ? 'active' : ''} ${modifier && key === 'Option' && this.activeModifiers.has('Option') ? 'active' : ''}"
-                  data-key="${key}"
-                  ?data-modifier="${modifier}"
-                  ?data-arrow="${arrow}"
-                  ?data-toggle="${toggle}"
-                  @mousedown=${(e: Event) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                  @touchend=${(e: TouchEvent) => {
-                    this.handleTouchEnd(e, () => {
-                      // Stop key repeat
-                      if (arrow) {
-                        this.stopKeyRepeat();
-                      } else {
-                        this.handleKeyPress(key, modifier, false, toggle, e);
-                      }
-                    });
-                  }}
-                  @touchcancel=${(_e: Event) => {
-                    // Also stop on touch cancel
-                    if (arrow) {
-                      this.stopKeyRepeat();
-                    }
-                  }}
-                  @click=${(e: MouseEvent) => {
-                    if (e.detail !== 0 && !arrow) {
-                      this.handleKeyPress(key, modifier, false, toggle, e);
-                    }
-                  }}>
-                  ${label}
-                </button>
-              `
-            )}
-          </div>
-          
-          <!-- Row 2 or Function Keys or Ctrl Shortcuts (with Done button always visible) -->
+          <div class="flex gap-0.5 mb-0.5">${rows[0].map((key) => this.renderQuickKey(key))}</div>
+
           ${
             this.showCtrlKeys
               ? html`
-              <!-- Ctrl shortcuts row with Done button -->
-              <div class="flex gap-0.5 mb-0.5">
-                ${CTRL_SHORTCUTS.map(
-                  ({ key, label, combo, special }) => html`
-                    <button
-                      type="button"
-                      tabindex="-1"
-                      class="ctrl-shortcut-btn ${this.getButtonFontClass(label)} min-w-0 ${this.getButtonSizeClass(label)} bg-bg-tertiary text-primary font-mono rounded border border-border hover:bg-surface hover:border-primary transition-all whitespace-nowrap ${combo ? 'combo-key' : ''} ${special ? 'special-key' : ''}"
-                      data-key="${key}"
-                      ?data-combo="${combo}"
-                      ?data-special="${special}"
-                      @mousedown=${(e: Event) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                      }}
-                      @touchend=${(e: TouchEvent) => {
-                        this.handleTouchEnd(e, () => {
-                          this.handleKeyPress(key, false, special, false, e);
-                        });
-                      }}
-                      @click=${(e: MouseEvent) => {
-                        if (e.detail !== 0) {
-                          this.handleKeyPress(key, false, special, false, e);
-                        }
-                      }}>
-                      ${label}
-                    </button>
-                  `
-                )}
-                <!-- Done button -->
-                <button
-                  type="button"
-                  tabindex="-1"
-                  class="quick-key-btn ${this.getButtonFontClass(DONE_BUTTON.label)} min-w-0 ${this.getButtonSizeClass(DONE_BUTTON.label)} bg-bg-tertiary text-primary font-mono rounded border border-border hover:bg-surface hover:border-primary transition-all whitespace-nowrap special-key"
-                  data-key="${DONE_BUTTON.key}"
-                  ?data-special="${DONE_BUTTON.special}"
-                  @mousedown=${(e: Event) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                  @touchend=${(e: TouchEvent) => {
-                    this.handleTouchEnd(e, () => {
-                      this.handleKeyPress(DONE_BUTTON.key, false, DONE_BUTTON.special, false, e);
-                    });
-                  }}
-                  @click=${(e: MouseEvent) => {
-                    if (e.detail !== 0) {
-                      this.handleKeyPress(DONE_BUTTON.key, false, DONE_BUTTON.special, false, e);
-                    }
-                  }}
-                >
-                  ${DONE_BUTTON.label}
-                </button>
+              <div class="flex gap-0.5 ${rows.length > 2 ? 'mb-0.5' : ''}">
+                ${CTRL_SHORTCUTS.map((key) => this.renderAuxiliaryKey(key))}
+                ${this.renderDoneButton()}
               </div>
             `
               : this.showFunctionKeys
                 ? html`
-              <!-- Function keys row with Done button -->
-              <div class="flex gap-0.5 mb-0.5">
-                ${FUNCTION_KEYS.map(
-                  ({ key, label }) => html`
-                    <button
-                      type="button"
-                      tabindex="-1"
-                      class="func-key-btn ${this.getButtonFontClass(label)} min-w-0 ${this.getButtonSizeClass(label)} bg-bg-tertiary text-primary font-mono rounded border border-border hover:bg-surface hover:border-primary transition-all whitespace-nowrap"
-                      data-key="${key}"
-                      @mousedown=${(e: Event) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                      }}
-                      @touchend=${(e: Event) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        this.handleKeyPress(key, false, false, false, e);
-                      }}
-                      @click=${(e: MouseEvent) => {
-                        if (e.detail !== 0) {
-                          this.handleKeyPress(key, false, false, false, e);
-                        }
-                      }}     >
-                      ${label}
-                    </button>
-                  `
-                )}
-                <!-- Done button -->
-                <button
-                  type="button"
-                  tabindex="-1"
-                  class="quick-key-btn ${this.getButtonFontClass(DONE_BUTTON.label)} min-w-0 ${this.getButtonSizeClass(DONE_BUTTON.label)} bg-bg-tertiary text-primary font-mono rounded border border-border hover:bg-surface hover:border-primary transition-all whitespace-nowrap special-key"
-                  data-key="${DONE_BUTTON.key}"
-                  ?data-special="${DONE_BUTTON.special}"
-                  @mousedown=${(e: Event) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                  @touchend=${(e: TouchEvent) => {
-                    this.handleTouchEnd(e, () => {
-                      this.handleKeyPress(DONE_BUTTON.key, false, DONE_BUTTON.special, false, e);
-                    });
-                  }}
-                  @click=${(e: MouseEvent) => {
-                    if (e.detail !== 0) {
-                      this.handleKeyPress(DONE_BUTTON.key, false, DONE_BUTTON.special, false, e);
-                    }
-                  }}
-                >
-                  ${DONE_BUTTON.label}
-                </button>
+              <div class="flex gap-0.5 ${rows.length > 2 ? 'mb-0.5' : ''}">
+                ${FUNCTION_KEYS.map((key) => this.renderAuxiliaryKey(key))}
+                ${this.renderDoneButton()}
               </div>
             `
                 : html`
-              <!-- Regular row 2 -->
-              <div class="flex gap-0.5 mb-0.5 ">
-                ${TERMINAL_QUICK_KEYS.filter((k) => k.row === 2).map(
-                  ({ key, label, modifier, combo, toggle }) => html`
-                    <button
-                      type="button"
-                      tabindex="-1"
-                      class="quick-key-btn ${this.getButtonFontClass(label)} min-w-0 ${this.getButtonSizeClass(label)} bg-bg-tertiary text-primary font-mono rounded border border-border hover:bg-surface hover:border-primary transition-all whitespace-nowrap ${modifier ? 'modifier-key' : ''} ${combo ? 'combo-key' : ''} ${toggle ? 'toggle-key' : ''} ${toggle && this.showFunctionKeys ? 'active' : ''}"
-                      data-key="${key}"
-                      ?data-modifier="${modifier}"
-                      ?data-combo="${combo}"
-                      ?data-toggle="${toggle}"
-                      @mousedown=${(e: Event) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                      }}
-                      @touchend=${(e: TouchEvent) => {
-                        this.handleTouchEnd(e, () => {
-                          if (key === 'Paste') {
-                            this.handlePasteImmediate(e);
-                          } else {
-                            this.handleKeyPress(key, modifier || combo, false, false, e);
-                          }
-                        });
-                      }}
-                      @click=${(e: MouseEvent) => {
-                        if (e.detail !== 0) {
-                          this.handleKeyPress(key, modifier || combo, false, false, e);
-                        }
-                      }}     >
-                      ${label}
-                    </button>
-                  `
-                )}
-                <!-- Done button (in regular row 2) -->
-                <button
-                  type="button"
-                  tabindex="-1"
-                  class="quick-key-btn ${this.getButtonFontClass(DONE_BUTTON.label)} min-w-0 ${this.getButtonSizeClass(DONE_BUTTON.label)} bg-bg-tertiary text-primary font-mono rounded border border-border hover:bg-surface hover:border-primary transition-all whitespace-nowrap special-key"
-                  data-key="${DONE_BUTTON.key}"
-                  ?data-special="${DONE_BUTTON.special}"
-                  @mousedown=${(e: Event) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                  @touchend=${(e: TouchEvent) => {
-                    this.handleTouchEnd(e, () => {
-                      this.handleKeyPress(DONE_BUTTON.key, false, DONE_BUTTON.special, false, e);
-                    });
-                  }}
-                  @click=${(e: MouseEvent) => {
-                    if (e.detail !== 0) {
-                      this.handleKeyPress(DONE_BUTTON.key, false, DONE_BUTTON.special, false, e);
-                    }
-                  }}
-                >
-                  ${DONE_BUTTON.label}
-                </button>
+              <div class="flex gap-0.5 ${rows.length > 2 ? 'mb-0.5' : ''}">
+                ${rows[1].map((key) => this.renderQuickKey(key))}
+                ${this.renderDoneButton()}
               </div>
             `
           }
 
-          <!-- Row 3 - Additional special characters (always visible) -->
-          <div class="flex gap-0.5 ">
-            ${TERMINAL_QUICK_KEYS.filter((k) => k.row === 3).map(
-              ({ key, label, modifier, combo }) => html`
-                <button
-                  type="button"
-                  tabindex="-1"
-                  class="quick-key-btn ${this.getButtonFontClass(label)} min-w-0 ${this.getButtonSizeClass(label)} bg-bg-tertiary text-primary font-mono rounded border border-border hover:bg-surface hover:border-primary transition-all whitespace-nowrap ${modifier ? 'modifier-key' : ''} ${combo ? 'combo-key' : ''} ${modifier && key === 'Option' && this.activeModifiers.has('Option') ? 'active' : ''}"
-                  data-key="${key}"
-                  ?data-modifier="${modifier}"
-                  ?data-combo="${combo}"
-                  @mousedown=${(e: Event) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                  }}
-                  @touchend=${(e: TouchEvent) => {
-                    this.handleTouchEnd(e, () => {
-                      this.handleKeyPress(key, modifier || combo, false, false, e);
-                    });
-                  }}
-                  @click=${(e: MouseEvent) => {
-                    if (e.detail !== 0) {
-                      this.handleKeyPress(key, modifier || combo, false, false, e);
-                    }
-                  }}>
-                  ${label}
-                </button>
-              `
-            )}
-          </div>
+          ${rows.slice(2).map(
+            (row) => html`
+              <div class="flex gap-0.5">${row.map((key) => this.renderQuickKey(key))}</div>
+            `
+          )}
         </div>
       </div>
       ${this.renderStyles()}

--- a/web/src/client/utils/quick-keys-layout.test.ts
+++ b/web/src/client/utils/quick-keys-layout.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { restoreLocalStorage, setupLocalStorageMock } from '../../test/utils/component-helpers.js';
+import {
+  COMPACT_QUICK_KEYS_LAYOUT,
+  DEFAULT_QUICK_KEYS_LAYOUT,
+  isValidQuickKeysLayout,
+  loadQuickKeysLayout,
+  QUICK_KEYS_LAYOUT_CHANGED_EVENT,
+  QUICK_KEYS_STORAGE_KEY,
+  resetQuickKeysLayout,
+  saveQuickKeysLayout,
+} from './quick-keys-layout.js';
+
+describe('quick keys layout preferences', () => {
+  beforeEach(() => {
+    setupLocalStorageMock();
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+  });
+
+  it('uses the current fixed layout as the default', () => {
+    expect(loadQuickKeysLayout()).toEqual(DEFAULT_QUICK_KEYS_LAYOUT);
+  });
+
+  it('round-trips a versioned browser-local layout', () => {
+    expect(saveQuickKeysLayout(COMPACT_QUICK_KEYS_LAYOUT)).toBe(true);
+    expect(loadQuickKeysLayout()).toEqual(COMPACT_QUICK_KEYS_LAYOUT);
+    expect(JSON.parse(localStorage.getItem(QUICK_KEYS_STORAGE_KEY) ?? '')).toEqual({
+      version: 1,
+      rows: COMPACT_QUICK_KEYS_LAYOUT,
+    });
+  });
+
+  it('rejects unknown, duplicate, empty, oversized, and unsupported row layouts', () => {
+    expect(isValidQuickKeysLayout([['Escape'], ['not-a-key']])).toBe(false);
+    expect(isValidQuickKeysLayout([['Escape'], ['Escape']])).toBe(false);
+    expect(isValidQuickKeysLayout([['Escape'], []])).toBe(false);
+    expect(
+      isValidQuickKeysLayout([
+        [
+          'Escape',
+          'Control',
+          'CtrlExpand',
+          'F',
+          'Tab',
+          'shift_tab',
+          'ArrowUp',
+          'ArrowDown',
+          'ArrowLeft',
+          'ArrowRight',
+          'PageUp',
+          'PageDown',
+          'Home',
+        ],
+        ['Paste'],
+      ])
+    ).toBe(false);
+    expect(isValidQuickKeysLayout([['Escape']])).toBe(false);
+    expect(isValidQuickKeysLayout([['Escape'], ['Tab'], ['Home'], ['End']])).toBe(false);
+  });
+
+  it('falls back to defaults for malformed or future storage values', () => {
+    localStorage.setItem(QUICK_KEYS_STORAGE_KEY, '{');
+    expect(loadQuickKeysLayout()).toEqual(DEFAULT_QUICK_KEYS_LAYOUT);
+
+    localStorage.setItem(
+      QUICK_KEYS_STORAGE_KEY,
+      JSON.stringify({ version: 2, rows: COMPACT_QUICK_KEYS_LAYOUT })
+    );
+    expect(loadQuickKeysLayout()).toEqual(DEFAULT_QUICK_KEYS_LAYOUT);
+  });
+
+  it('removes customization when reset and notifies live components', () => {
+    const listener = vi.fn();
+    window.addEventListener(QUICK_KEYS_LAYOUT_CHANGED_EVENT, listener);
+    saveQuickKeysLayout(COMPACT_QUICK_KEYS_LAYOUT);
+
+    expect(resetQuickKeysLayout()).toBe(true);
+    expect(localStorage.getItem(QUICK_KEYS_STORAGE_KEY)).toBeNull();
+    expect(loadQuickKeysLayout()).toEqual(DEFAULT_QUICK_KEYS_LAYOUT);
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    window.removeEventListener(QUICK_KEYS_LAYOUT_CHANGED_EVENT, listener);
+  });
+});

--- a/web/src/client/utils/quick-keys-layout.ts
+++ b/web/src/client/utils/quick-keys-layout.ts
@@ -1,0 +1,201 @@
+interface QuickKeyAttributes {
+  key: string;
+  label: string;
+  modifier?: boolean;
+  toggle?: boolean;
+  arrow?: boolean;
+  combo?: boolean;
+}
+
+export const QUICK_KEY_DEFINITIONS = [
+  { key: 'Escape', label: 'Esc' },
+  { key: 'Control', label: 'Ctrl', modifier: true },
+  { key: 'CtrlExpand', label: '⌃', toggle: true },
+  { key: 'F', label: 'F', toggle: true },
+  { key: 'Tab', label: 'Tab' },
+  { key: 'shift_tab', label: '⇤' },
+  { key: 'ArrowUp', label: '↑', arrow: true },
+  { key: 'ArrowDown', label: '↓', arrow: true },
+  { key: 'ArrowLeft', label: '←', arrow: true },
+  { key: 'ArrowRight', label: '→', arrow: true },
+  { key: 'PageUp', label: 'PgUp' },
+  { key: 'PageDown', label: 'PgDn' },
+  { key: 'Home', label: 'Home' },
+  { key: 'Paste', label: 'Paste' },
+  { key: 'End', label: 'End' },
+  { key: 'Delete', label: 'Del' },
+  { key: '`', label: '`' },
+  { key: '~', label: '~' },
+  { key: '|', label: '|' },
+  { key: '/', label: '/' },
+  { key: '\\', label: '\\' },
+  { key: '-', label: '-' },
+  { key: 'Option', label: '⌥', modifier: true },
+  { key: 'Command', label: '⌘', modifier: true },
+  { key: 'Ctrl+C', label: '^C', combo: true },
+  { key: 'Ctrl+Z', label: '^Z', combo: true },
+  { key: "'", label: "'" },
+  { key: '"', label: '"' },
+  { key: '{', label: '{' },
+  { key: '}', label: '}' },
+  { key: '[', label: '[' },
+  { key: ']', label: ']' },
+  { key: '(', label: '(' },
+  { key: ')', label: ')' },
+] as const satisfies readonly QuickKeyAttributes[];
+
+export type QuickKeyId = (typeof QUICK_KEY_DEFINITIONS)[number]['key'];
+export type QuickKeyDefinition = QuickKeyAttributes & { key: QuickKeyId };
+export type QuickKeysLayout = QuickKeyId[][];
+
+export const DEFAULT_QUICK_KEYS_LAYOUT: QuickKeysLayout = [
+  [
+    'Escape',
+    'Control',
+    'CtrlExpand',
+    'F',
+    'Tab',
+    'shift_tab',
+    'ArrowUp',
+    'ArrowDown',
+    'ArrowLeft',
+    'ArrowRight',
+    'PageUp',
+    'PageDown',
+  ],
+  ['Home', 'Paste', 'End', 'Delete', '`', '~', '|', '/', '\\', '-'],
+  ['Option', 'Command', 'Ctrl+C', 'Ctrl+Z', "'", '"', '{', '}', '[', ']', '(', ')'],
+];
+
+export const COMPACT_QUICK_KEYS_LAYOUT: QuickKeysLayout = [
+  [
+    'Escape',
+    'Control',
+    'Tab',
+    'shift_tab',
+    'ArrowUp',
+    'ArrowDown',
+    'ArrowLeft',
+    'ArrowRight',
+    'PageUp',
+    'PageDown',
+  ],
+  ['Home', 'Paste', 'End', 'Delete', 'Option', 'Command', 'Ctrl+C', 'Ctrl+Z', '/', '-'],
+];
+
+export const QUICK_KEYS_PRESETS = [
+  { id: 'default', name: 'Default', layout: DEFAULT_QUICK_KEYS_LAYOUT },
+  { id: 'compact', name: 'Compact', layout: COMPACT_QUICK_KEYS_LAYOUT },
+] as const;
+
+export const QUICK_KEYS_STORAGE_KEY = 'vibetunnel.quickKeys.v1';
+export const QUICK_KEYS_LAYOUT_CHANGED_EVENT = 'vibetunnel-quick-keys-layout-changed';
+
+const STORAGE_VERSION = 1;
+const MIN_ROWS = 2;
+const MAX_ROWS = 3;
+const MAX_KEYS_PER_ROW = 12;
+const VALID_KEY_IDS = new Set<string>(QUICK_KEY_DEFINITIONS.map(({ key }) => key));
+const DEFINITION_BY_ID = new Map<QuickKeyId, QuickKeyDefinition>(
+  QUICK_KEY_DEFINITIONS.map((definition) => [definition.key, definition as QuickKeyDefinition])
+);
+
+function cloneLayout(layout: QuickKeysLayout): QuickKeysLayout {
+  return layout.map((row) => [...row]);
+}
+
+export function isValidQuickKeysLayout(value: unknown): value is QuickKeysLayout {
+  if (!Array.isArray(value) || value.length < MIN_ROWS || value.length > MAX_ROWS) {
+    return false;
+  }
+
+  const usedKeys = new Set<string>();
+  for (const row of value) {
+    if (!Array.isArray(row) || row.length === 0 || row.length > MAX_KEYS_PER_ROW) {
+      return false;
+    }
+
+    for (const key of row) {
+      if (typeof key !== 'string' || !VALID_KEY_IDS.has(key) || usedKeys.has(key)) {
+        return false;
+      }
+      usedKeys.add(key);
+    }
+  }
+
+  return true;
+}
+
+export function loadQuickKeysLayout(): QuickKeysLayout {
+  try {
+    const stored = localStorage.getItem(QUICK_KEYS_STORAGE_KEY);
+    if (!stored) {
+      return cloneLayout(DEFAULT_QUICK_KEYS_LAYOUT);
+    }
+
+    const parsed = JSON.parse(stored) as { version?: unknown; rows?: unknown };
+    if (parsed.version === STORAGE_VERSION && isValidQuickKeysLayout(parsed.rows)) {
+      return cloneLayout(parsed.rows);
+    }
+  } catch {
+    // Storage can be unavailable in private browsing or restricted embedded contexts.
+  }
+
+  return cloneLayout(DEFAULT_QUICK_KEYS_LAYOUT);
+}
+
+export function saveQuickKeysLayout(layout: QuickKeysLayout): boolean {
+  if (!isValidQuickKeysLayout(layout)) {
+    return false;
+  }
+
+  try {
+    localStorage.setItem(
+      QUICK_KEYS_STORAGE_KEY,
+      JSON.stringify({ version: STORAGE_VERSION, rows: layout })
+    );
+    window.dispatchEvent(new CustomEvent(QUICK_KEYS_LAYOUT_CHANGED_EVENT));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function resetQuickKeysLayout(): boolean {
+  try {
+    localStorage.removeItem(QUICK_KEYS_STORAGE_KEY);
+    window.dispatchEvent(new CustomEvent(QUICK_KEYS_LAYOUT_CHANGED_EVENT));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function subscribeToQuickKeysLayout(listener: () => void): () => void {
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === QUICK_KEYS_STORAGE_KEY) {
+      listener();
+    }
+  };
+
+  window.addEventListener(QUICK_KEYS_LAYOUT_CHANGED_EVENT, listener);
+  window.addEventListener('storage', handleStorage);
+
+  return () => {
+    window.removeEventListener(QUICK_KEYS_LAYOUT_CHANGED_EVENT, listener);
+    window.removeEventListener('storage', handleStorage);
+  };
+}
+
+export function getQuickKeyDefinition(key: QuickKeyId): QuickKeyDefinition {
+  const definition = DEFINITION_BY_ID.get(key);
+  if (!definition) {
+    throw new Error(`Unknown quick key: ${key}`);
+  }
+  return definition;
+}
+
+export function getHiddenQuickKeys(layout: QuickKeysLayout): QuickKeyDefinition[] {
+  const visible = new Set(layout.flat());
+  return QUICK_KEY_DEFINITIONS.filter(({ key }) => !visible.has(key)) as QuickKeyDefinition[];
+}


### PR DESCRIPTION
Supersedes #564 with a focused reconstruction on current `main`. The original branch could not be updated because the available maintainer credential is not authorized to rewrite its historical workflow change.

## Summary
- add a small browser-local editor for reordering, moving, and hiding mobile terminal quick keys
- preserve the existing three-row layout as the default and add a generic compact preset
- keep `Done` fixed, validate versioned persisted layouts, and update open keyboards immediately
- avoid the stale branch's unrelated macOS settings, provider-specific assets, cache busting, signing, and workflow changes

Credit: based on the feature proposed by @ndraiman; the implementation commit retains co-author credit and the changelog thanks the contributor.

## Live proof
- exact production web build served through real Chrome at 434x965, 390x844, and 320x700 touch viewports
- edited/reordered/hidden keys, applied the compact layout, reloaded, and confirmed persistence
- verified a sanitized quick-key input reached the terminal and `Done` restored the mobile action bar
- verified no clipping or horizontal overflow at all tested mobile widths
- verified the desktop session and settings path at 1280x900 with no horizontal overflow and no quick-key bar shown by default

## Verification
- `pnpm check`
- `pnpm build` with the repository-pinned Zig 0.15.2
- focused quick-key tests: 22 passed
- full client tests: 725 passed, 14 skipped
- full server tests: 593 passed, 75 skipped
- macOS workspace tests: passed
- structured autoreview: no actionable findings

## Public safety
The exact diff, changed tests, generated-output scope, unchanged workflows, existing discussion, and this public proof contain no model identifiers. Private terminal content and raw local review logs are excluded.
