### PR TITLE
fix: prevent vt from rerunning terminated sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Let force-terminated `vt` sessions exit instead of rerunning commands outside VibeTunnel, including suspended jobs (reported by [@cameroncooke](https://github.com/cameroncooke)) (#278)
 - Show long session titles with ellipsis in the compact iPhone header instead of hiding them entirely. (#516)
 - Report Tailscale Serve as running after its background setup command exits successfully, instead of leaving the macOS app stuck on “Starting…” (#556)
 - Preserve the configured Tailscale Serve port when reset fails instead of hiding a persistent non-default proxy.
@@ -62,6 +63,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
+- Thanks [@cameroncooke](https://github.com/cameroncooke) for reporting stuck `vt` processes after suspending terminal jobs.
 - Thanks [@ndraiman](https://github.com/ndraiman) for proposing customizable mobile terminal quick-key layouts.
 - Thanks [@manmal](https://github.com/manmal) and [@hjanuschka](https://github.com/hjanuschka) for proposing and originally implementing clickable terminal shortcuts.
 - Thanks [@MrMage](https://github.com/MrMage) and [@gioneill](https://github.com/gioneill) for reporting and investigating repetitive update onboarding.

--- a/native/vt-fwd/src/main.zig
+++ b/native/vt-fwd/src/main.zig
@@ -132,6 +132,8 @@ fn handleSignal(sig: c_int) callconv(.c) void {
 }
 
 pub fn main() !void {
+    markForwarderStarted();
+
     var gpa = std.heap.GeneralPurposeAllocator(.{ .thread_safe = true }){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
@@ -372,6 +374,18 @@ pub fn main() !void {
     std.process.exit(@intCast(exit_info.exit_code));
 }
 
+fn markForwarderStarted() void {
+    const marker = std.posix.getenv("VIBETUNNEL_FWD_STARTED_FILE") orelse return;
+    const marker_path = std.mem.sliceTo(marker, 0);
+    var file = std.fs.cwd().createFile(marker_path, .{
+        .exclusive = true,
+        .truncate = false,
+        .read = false,
+        .mode = 0o600,
+    }) catch return;
+    file.close();
+}
+
 fn parseArgs(args: []const []const u8, defaults: EnvDefaults) !ParsedArgs {
     var options = Options{};
     if (defaults.title_mode) |mode| options.title_mode = mode;
@@ -467,7 +481,6 @@ fn isTruthy(value: []const u8) bool {
     return std.ascii.eqlIgnoreCase(value, "1") or std.ascii.eqlIgnoreCase(value, "true");
 }
 
-
 fn getHome() []const u8 {
     if (std.posix.getenv("HOME")) |val| return std.mem.sliceTo(val, 0);
     return "";
@@ -562,6 +575,7 @@ fn buildExecEnv(allocator: std.mem.Allocator, command: []const []const u8, sessi
     if (command.len == 0) return error.InvalidArguments;
     var env_map = try std.process.getEnvMap(allocator);
     defer env_map.deinit();
+    _ = env_map.remove("VIBETUNNEL_FWD_STARTED_FILE");
     env_map.put("TERM", "xterm-256color") catch {};
     env_map.put("VIBETUNNEL_SESSION_ID", session_id) catch {};
 

--- a/web/bin/vt
+++ b/web/bin/vt
@@ -385,13 +385,33 @@ EOF
 exec_with_fallback() {
     # Save the command for potential fallback
     local SAVED_CMD=("$@")
+    local STARTED_DIR=""
+    local STARTED_FILE=""
+    local FORWARDER_STARTED=false
+
+    STARTED_DIR=$(mktemp -d "${TMPDIR:-/tmp}/vibetunnel-fwd-started.XXXXXX" 2>/dev/null || true)
+    if [ -n "$STARTED_DIR" ]; then
+        STARTED_FILE="$STARTED_DIR/started"
+    fi
     
     # Try running with VibeTunnel
     local START_TIME=$(date +%s%N 2>/dev/null || echo "0")  # nanoseconds if available
     
     # Run the command (without exec to capture exit code)
-    "$@"
+    if [ -n "$STARTED_FILE" ]; then
+        VIBETUNNEL_FWD_STARTED_FILE="$STARTED_FILE" "$@"
+    else
+        "$@"
+    fi
     local EXIT_CODE=$?
+
+    if [ -n "$STARTED_FILE" ] && [ -e "$STARTED_FILE" ]; then
+        FORWARDER_STARTED=true
+    fi
+    if [ -n "$STARTED_FILE" ]; then
+        rm -f "$STARTED_FILE"
+        rmdir "$STARTED_DIR" 2>/dev/null || true
+    fi
     
     local END_TIME=$(date +%s%N 2>/dev/null || echo "1000000000")  # 1 second if date doesn't support nanoseconds
     
@@ -401,8 +421,9 @@ exec_with_fallback() {
         DURATION=$(( (END_TIME - START_TIME) / 1000000 ))
     fi
     
-    # Check if it was killed by macOS (exit code 137 or very quick failure)
-    if [[ $EXIT_CODE -eq 137 ]] || ([[ $EXIT_CODE -ne 0 ]] && [[ $DURATION -lt 100 ]]); then
+    # Runtime SIGKILL also exits 137, including force-termination from the web UI.
+    # Only use the direct fallback when the forwarder never reached its entrypoint.
+    if [ -n "$STARTED_FILE" ] && [[ "$FORWARDER_STARTED" != "true" ]] && { [[ $EXIT_CODE -eq 137 ]] || ([[ $EXIT_CODE -ne 0 ]] && [[ $DURATION -lt 100 ]]); }; then
         # Log the error
         echo "[vt] VibeTunnel binary killed by macOS (exit code: $EXIT_CODE). Running command directly." >&2
         

--- a/web/src/test/e2e/vt-wrapper.e2e.test.ts
+++ b/web/src/test/e2e/vt-wrapper.e2e.test.ts
@@ -32,6 +32,7 @@ const hasGit = (() => {
 })();
 
 const itWithGit = hasGit ? it : it.skip;
+const itOnUnix = process.platform === 'win32' ? it.skip : it;
 
 function resolveForwarderPath(): string {
   const candidates: string[] = [];
@@ -103,6 +104,54 @@ async function waitForPathExists(pathToCheck: string, timeoutMs = 10000): Promis
     await sleep(50);
   }
   throw new Error(`Path ${pathToCheck} did not appear after ${timeoutMs}ms`);
+}
+
+async function waitForChildExit(
+  child: ReturnType<typeof spawn>,
+  timeoutMs: number
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return { code: child.exitCode, signal: child.signalCode };
+  }
+
+  return await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Process ${child.pid ?? 'unknown'} did not exit after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      resolve({ code, signal });
+    };
+
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.off('exit', onExit);
+      child.off('error', onError);
+    };
+
+    child.once('exit', onExit);
+    child.once('error', onError);
+  });
+}
+
+async function waitForPidExit(pid: number, timeoutMs = 3000): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+    await sleep(50);
+  }
+  return false;
 }
 
 async function waitForSessionText(
@@ -326,7 +375,7 @@ describe('vt wrapper flows', () => {
   it('runs a forwarded command via vt wrapper', async () => {
     const forwarderPath = resolveForwarderPath();
     const marker = `vt-run-ok-${Date.now()}`;
-    const command = `printf "${marker}\\n"; sleep 0.2`;
+    const command = `test -z "\${VIBETUNNEL_FWD_STARTED_FILE+x}" && printf "${marker}\\n"; sleep 0.2`;
 
     if (!server) {
       throw new Error('Server not started');
@@ -363,6 +412,136 @@ describe('vt wrapper flows', () => {
     const text = await waitForSessionText(server.port, sessionId, marker);
     expect(text).toContain(marker);
   }, 20000);
+
+  itOnUnix('falls back when the forwarder is killed before startup', async () => {
+    const fakeForwarder = path.join(homeDir, `killed-forwarder-${Date.now()}`);
+    const fallbackMarker = path.join(homeDir, `fallback-marker-${Date.now()}`);
+    writeFileSync(fakeForwarder, '#!/bin/sh\nkill -KILL $$\n', 'utf-8');
+    chmodSync(fakeForwarder, 0o755);
+
+    const vtPath = path.join(process.cwd(), 'bin', 'vt');
+    const child = spawn(
+      vtPath,
+      ['-S', '/bin/sh', '-c', 'printf fallback > "$VT_FALLBACK_MARKER"'],
+      {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          VIBETUNNEL_FWD_BIN: fakeForwarder,
+          VIBETUNNEL_BIN: vibetunnelBin,
+          VT_FALLBACK_MARKER: fallbackMarker,
+        },
+        stdio: 'ignore',
+      }
+    );
+
+    const exit = await waitForChildExit(child, 5000);
+    expect(exit).toEqual({ code: 0, signal: null });
+    expect(readFileSync(fallbackMarker, 'utf-8')).toBe('fallback');
+  });
+
+  itOnUnix('does not rerun when forwarder startup tracking is unavailable', async () => {
+    const fakeForwarder = path.join(homeDir, `untracked-killed-forwarder-${Date.now()}`);
+    const fallbackMarker = path.join(homeDir, `untracked-fallback-marker-${Date.now()}`);
+    writeFileSync(fakeForwarder, '#!/bin/sh\nkill -KILL $$\n', 'utf-8');
+    chmodSync(fakeForwarder, 0o755);
+
+    const vtPath = path.join(process.cwd(), 'bin', 'vt');
+    const child = spawn(
+      vtPath,
+      ['-S', '/bin/sh', '-c', 'printf fallback > "$VT_FALLBACK_MARKER"'],
+      {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          TMPDIR: path.join(homeDir, 'missing-tmp-dir'),
+          VIBETUNNEL_FWD_BIN: fakeForwarder,
+          VIBETUNNEL_BIN: vibetunnelBin,
+          VT_FALLBACK_MARKER: fallbackMarker,
+        },
+        stdio: 'ignore',
+      }
+    );
+
+    const exit = await waitForChildExit(child, 5000);
+    expect(exit).toEqual({ code: 137, signal: null });
+    expect(existsSync(fallbackMarker)).toBe(false);
+  });
+
+  itOnUnix(
+    'does not rerun a force-terminated stopped command outside VibeTunnel',
+    async () => {
+      const forwarderPath = resolveForwarderPath();
+      const marker = `vt-stopped-ok-${Date.now()}`;
+      const runCountPath = path.join(homeDir, `force-kill-count-${Date.now()}`);
+      const command = `printf x >> "$VT_FORCE_KILL_COUNT"; trap "" TERM; printf "${marker}\\n"; kill -STOP $$; sleep 60`;
+
+      if (!server) {
+        throw new Error('Server not started');
+      }
+
+      const before = new Set(listSessionDirs(controlDir));
+      const vtPath = path.join(process.cwd(), 'bin', 'vt');
+      const child = spawn(vtPath, ['-S', '/bin/sh', '-c', command], {
+        env: {
+          ...process.env,
+          HOME: homeDir,
+          VIBETUNNEL_CONTROL_DIR: controlDir,
+          VIBETUNNEL_FWD_BIN: forwarderPath,
+          VIBETUNNEL_BIN: vibetunnelBin,
+          VT_FORCE_KILL_COUNT: runCountPath,
+        },
+        stdio: 'ignore',
+      });
+
+      let sessionId: string | undefined;
+      let sessionPid: number | undefined;
+      try {
+        sessionId = await waitForNewSessionDir(controlDir, before);
+        await waitForSessionText(server.port, sessionId, marker);
+
+        const sessionJsonPath = path.join(controlDir, sessionId, 'session.json');
+        await waitForPathExists(sessionJsonPath);
+        const sessionInfo = JSON.parse(readFileSync(sessionJsonPath, 'utf-8')) as {
+          pid?: number;
+        };
+        sessionPid = sessionInfo.pid;
+        expect(sessionPid).toBeTypeOf('number');
+
+        const processState = spawnSync('ps', ['-o', 'state=', '-p', String(sessionPid)], {
+          encoding: 'utf-8',
+        }).stdout.trim();
+        expect(processState).toContain('T');
+
+        const response = await fetch(`http://localhost:${server.port}/api/sessions/${sessionId}`, {
+          method: 'DELETE',
+        });
+        expect(response.status).toBe(200);
+
+        const exit = await waitForChildExit(child, 8000);
+        expect(exit).toEqual({ code: 137, signal: null });
+        expect(readFileSync(runCountPath, 'utf-8')).toBe('x');
+        expect(await waitForPidExit(sessionPid as number)).toBe(true);
+      } finally {
+        if (sessionId) {
+          await fetch(`http://localhost:${server.port}/api/sessions/${sessionId}`, {
+            method: 'DELETE',
+          }).catch(() => undefined);
+        }
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill('SIGKILL');
+        }
+        if (sessionPid && !(await waitForPidExit(sessionPid, 100))) {
+          try {
+            process.kill(sessionPid, 'SIGKILL');
+          } catch {
+            // Process already exited.
+          }
+        }
+      }
+    },
+    20000
+  );
 
   it('blocks recursive sessions via vt wrapper', async () => {
     const vtPath = path.join(process.cwd(), 'bin', 'vt');


### PR DESCRIPTION
## Summary

- distinguish forwarder startup failure from a runtime force-termination
- prevent `vt` from rerunning a stopped command outside VibeTunnel after the web UI kills its session
- keep the existing direct-command fallback when the native forwarder is killed before startup
- keep the private startup marker out of the forwarded command environment

Fixes #278.

## Root cause

The wrapper treated every exit code 137 as a native-binary startup failure. Force-killing a stopped, termination-resistant session also returns 137, so the wrapper launched the original command a second time outside VibeTunnel and left it untracked.

## Live proof

- exact built server and wrapper exercised through real Chrome with synthetic terminal content
- created a stopped command that ignores normal termination, then killed it through the session UI
- UI moved the session to exited, the wrapper returned 137, the command ran exactly once, and its stopped child process disappeared
- normal startup-failure fallback and unavailable-marker fail-safe behavior are covered separately

## Verification

- `pnpm run check`
- `pnpm run build` with repository-pinned Zig 0.15.2
- native forwarder compile/tests: passed
- focused wrapper E2E: 8 passed
- full client tests: 727 passed, 14 skipped
- full server tests: 596 passed, 75 skipped
- structured autoreview: clean, no actionable findings

## Public safety

The exact diff, changed tests, native and shell sources, changelog, generated-output scope, unchanged workflows, local test/build output, and this public proof contain no model identifiers. No fixtures or snapshots changed. Private terminal content and unrelated browser state are excluded.
