### PR TITLE
feat(ios): add OpenAI voice transcription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### ✨ Improvements
+- Add OpenAI BYOK voice transcription to the iOS terminal keyboard toolbar, with secure Keychain storage and review-before-execution input (via [@jblwilliams](https://github.com/jblwilliams)) (#523)
 - Let mobile users reorder, hide, and choose layouts for terminal quick keys, with browser-local persistence and an unchanged default layout (via [@ndraiman](https://github.com/ndraiman)) (#564)
 - Restore clickable Ctrl+letter shortcuts in the Ghostty terminal renderer (reported by [@manmal](https://github.com/manmal), based on the original implementation by [@hjanuschka](https://github.com/hjanuschka)) (#51)
 - Show returning users only the CLI maintenance page after updates, while keeping the full onboarding flow available manually (reported by [@MrMage](https://github.com/MrMage), with earlier investigation by [@gioneill](https://github.com/gioneill)) (#411)
@@ -63,6 +64,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
+- Thanks [@jblwilliams](https://github.com/jblwilliams) for the original iOS voice-transcription implementation.
 - Thanks [@cameroncooke](https://github.com/cameroncooke) for reporting stuck `vt` processes after suspending terminal jobs.
 - Thanks [@ndraiman](https://github.com/ndraiman) for proposing customizable mobile terminal quick-key layouts.
 - Thanks [@manmal](https://github.com/manmal) and [@hjanuschka](https://github.com/hjanuschka) for proposing and originally implementing clickable terminal shortcuts.

--- a/docs/ios-spec.md
+++ b/docs/ios-spec.md
@@ -55,6 +55,7 @@ VibeTunnel iOS is a native SwiftUI application that provides a beautiful, native
 - **Input/Output**:
   - Native iOS keyboard integration
   - Special keys toolbar (arrows, escape, tab, ctrl)
+  - Optional OpenAI BYOK voice transcription that inserts text without executing it
   - Copy/paste support
   - URL detection and tap-to-open
   - Smooth scrolling with momentum

--- a/ios/README.md
+++ b/ios/README.md
@@ -9,6 +9,7 @@
 - **Full terminal emulation** using ghostty-web (WASM + canvas)
 - **Real-time session management** with WebSocket buffer streaming
 - **Keyboard toolbar** with special keys (arrows, ESC, CTRL combinations)
+- **OpenAI voice input** with tap-to-record transcription for terminal commands
 - **Font size adjustment** with live preview
 - **Haptic feedback** throughout the interface
 - **Session operations**: Create, kill, cleanup sessions
@@ -127,6 +128,7 @@ VibeTunnel/
 3. **Use Terminal**
    - Full terminal emulation with ghostty-web
    - Special keys toolbar for mobile input
+   - Add an OpenAI API key under Settings → General → Voice Input, then tap the microphone in the keyboard toolbar to insert transcribed text
    - Pinch to zoom or use menu for font size
    - Long press for copy/paste
 

--- a/ios/VibeTunnel/Resources/Info.plist
+++ b/ios/VibeTunnel/Resources/Info.plist
@@ -121,6 +121,8 @@
 	<true/>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>VibeTunnel uses the local network to discover servers on your network.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>VibeTunnel records audio when you use voice input so it can transcribe text for the terminal.</string>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_vibetunnel._tcp</string>

--- a/ios/VibeTunnel/Services/AudioRecordingService.swift
+++ b/ios/VibeTunnel/Services/AudioRecordingService.swift
@@ -1,0 +1,123 @@
+import AVFoundation
+import Foundation
+
+@MainActor
+protocol AudioRecording: AnyObject {
+    var isRecording: Bool { get }
+
+    func startRecording() async throws
+    func stopRecording() throws -> URL
+    func cancelRecording()
+}
+
+@MainActor
+final class AudioRecordingService: NSObject, AudioRecording {
+    private var recorder: AVAudioRecorder?
+    private var recordingURL: URL?
+
+    var isRecording: Bool {
+        self.recorder?.isRecording == true
+    }
+
+    func startRecording() async throws {
+        guard !self.isRecording else {
+            throw AudioRecordingError.alreadyRecording
+        }
+        guard await self.requestMicrophonePermission() else {
+            throw AudioRecordingError.microphonePermissionDenied
+        }
+
+        let audioSession = AVAudioSession.sharedInstance()
+        try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try audioSession.setActive(true)
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vibetunnel-voice-\(UUID().uuidString)")
+            .appendingPathExtension("m4a")
+        let settings: [String: Any] = [
+            AVFormatIDKey: kAudioFormatMPEG4AAC,
+            AVSampleRateKey: 16000,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue,
+        ]
+
+        do {
+            let recorder = try AVAudioRecorder(url: url, settings: settings)
+            recorder.prepareToRecord()
+            guard recorder.record() else {
+                throw AudioRecordingError.unableToStart
+            }
+            self.recorder = recorder
+            self.recordingURL = url
+        } catch {
+            try? audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+            try? FileManager.default.removeItem(at: url)
+            throw error
+        }
+    }
+
+    func stopRecording() throws -> URL {
+        guard let recorder = self.recorder,
+              recorder.isRecording,
+              let recordingURL = self.recordingURL
+        else {
+            throw AudioRecordingError.notRecording
+        }
+
+        recorder.stop()
+        self.recorder = nil
+        self.recordingURL = nil
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        return recordingURL
+    }
+
+    func cancelRecording() {
+        let shouldDeactivateAudioSession = self.recorder != nil || self.recordingURL != nil
+        self.recorder?.stop()
+        self.recorder = nil
+        if let recordingURL {
+            try? FileManager.default.removeItem(at: recordingURL)
+        }
+        self.recordingURL = nil
+        if shouldDeactivateAudioSession {
+            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+        }
+    }
+
+    private func requestMicrophonePermission() async -> Bool {
+        switch AVAudioApplication.shared.recordPermission {
+        case .granted:
+            true
+        case .denied:
+            false
+        case .undetermined:
+            await withCheckedContinuation { continuation in
+                AVAudioApplication.requestRecordPermission { granted in
+                    continuation.resume(returning: granted)
+                }
+            }
+        @unknown default:
+            false
+        }
+    }
+
+    enum AudioRecordingError: LocalizedError {
+        case alreadyRecording
+        case microphonePermissionDenied
+        case notRecording
+        case unableToStart
+
+        var errorDescription: String? {
+            switch self {
+            case .alreadyRecording:
+                "A voice recording is already in progress."
+            case .microphonePermissionDenied:
+                "Microphone access is required for voice input."
+            case .notRecording:
+                "No voice recording is in progress."
+            case .unableToStart:
+                "Voice recording could not be started."
+            }
+        }
+    }
+}

--- a/ios/VibeTunnel/Services/AudioRecordingService.swift
+++ b/ios/VibeTunnel/Services/AudioRecordingService.swift
@@ -28,7 +28,7 @@ final class AudioRecordingService: NSObject, AudioRecording {
         }
 
         let audioSession = AVAudioSession.sharedInstance()
-        try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try audioSession.setCategory(.record, mode: .measurement)
         try audioSession.setActive(true)
 
         let url = FileManager.default.temporaryDirectory

--- a/ios/VibeTunnel/Services/OpenAITranscriptionService.swift
+++ b/ios/VibeTunnel/Services/OpenAITranscriptionService.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+@MainActor
+protocol TranscriptionServicing {
+    func transcribe(audioFileURL: URL, prompt: String) async throws -> String
+}
+
+@MainActor
+struct OpenAITranscriptionService: TranscriptionServicing {
+    private let apiKey: String
+    private let session: URLSession
+    private let endpoint: URL
+
+    init(
+        apiKey: String,
+        session: URLSession = .shared,
+        endpoint: URL = URL(string: "https://api.openai.com/v1/audio/transcriptions")!)
+    {
+        self.apiKey = apiKey
+        self.session = session
+        self.endpoint = endpoint
+    }
+
+    func transcribe(audioFileURL: URL, prompt: String) async throws -> String {
+        let request = try self.makeRequest(audioFileURL: audioFileURL, prompt: prompt)
+
+        let (data, response) = try await self.session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw TranscriptionError.invalidResponse
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            let apiError = try? JSONDecoder().decode(APIErrorResponse.self, from: data)
+            throw TranscriptionError.apiError(
+                apiError?.error.message ?? "OpenAI returned HTTP \(httpResponse.statusCode).")
+        }
+
+        guard let result = try? JSONDecoder().decode(TranscriptionResponse.self, from: data),
+              !result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            throw TranscriptionError.invalidResponse
+        }
+        return result.text
+    }
+
+    func makeRequest(audioFileURL: URL, prompt: String) throws -> URLRequest {
+        guard !self.apiKey.isEmpty else {
+            throw TranscriptionError.missingAPIKey
+        }
+
+        let audioData = try Data(contentsOf: audioFileURL)
+        var form = MultipartFormData()
+        form.append(name: "model", value: VoiceTranscriptionConfiguration.model)
+        form.append(name: "response_format", value: "json")
+        form.append(name: "prompt", value: prompt)
+        form.append(
+            name: "file",
+            filename: audioFileURL.lastPathComponent,
+            contentType: "audio/mp4",
+            data: audioData)
+
+        var request = URLRequest(url: self.endpoint)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 90
+        request.setValue("Bearer \(self.apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue(form.contentType, forHTTPHeaderField: "Content-Type")
+        request.httpBody = form.finalizedData
+        return request
+    }
+
+    private struct TranscriptionResponse: Decodable {
+        let text: String
+    }
+
+    private struct APIErrorResponse: Decodable {
+        struct APIError: Decodable {
+            let message: String
+        }
+
+        let error: APIError
+    }
+
+    enum TranscriptionError: LocalizedError {
+        case apiError(String)
+        case invalidResponse
+        case missingAPIKey
+
+        var errorDescription: String? {
+            switch self {
+            case let .apiError(message):
+                "Voice transcription failed: \(message)"
+            case .invalidResponse:
+                "OpenAI returned an invalid transcription response."
+            case .missingAPIKey:
+                "Add an OpenAI API key in Settings > General > Voice Input."
+            }
+        }
+    }
+}
+
+private struct MultipartFormData {
+    private let boundary = "VibeTunnel-\(UUID().uuidString)"
+    private var data = Data()
+
+    var contentType: String {
+        "multipart/form-data; boundary=\(self.boundary)"
+    }
+
+    var finalizedData: Data {
+        var result = self.data
+        result.appendUTF8("--\(self.boundary)--\r\n")
+        return result
+    }
+
+    mutating func append(name: String, value: String) {
+        self.data.appendUTF8("--\(self.boundary)\r\n")
+        self.data.appendUTF8("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n")
+        self.data.appendUTF8("\(value)\r\n")
+    }
+
+    mutating func append(name: String, filename: String, contentType: String, data: Data) {
+        self.data.appendUTF8("--\(self.boundary)\r\n")
+        self.data.appendUTF8(
+            "Content-Disposition: form-data; name=\"\(name)\"; filename=\"\(filename)\"\r\n")
+        self.data.appendUTF8("Content-Type: \(contentType)\r\n\r\n")
+        self.data.append(data)
+        self.data.appendUTF8("\r\n")
+    }
+}
+
+extension Data {
+    fileprivate mutating func appendUTF8(_ value: String) {
+        self.append(contentsOf: value.utf8)
+    }
+}

--- a/ios/VibeTunnel/ViewModels/VoiceInputViewModel.swift
+++ b/ios/VibeTunnel/ViewModels/VoiceInputViewModel.swift
@@ -1,0 +1,205 @@
+import Foundation
+import Observation
+
+enum VoiceTranscriptionConfiguration {
+    static let apiKeyAccount = "openai-transcription-api-key"
+    static let model = "gpt-4o-transcribe"
+    static let prompt =
+        """
+        Terminal command or programming text. Preserve command names, flags, paths, package names, \
+        punctuation, and capitalization. Common terms include git, gh, npm, pnpm, bun, docker, \
+        kubectl, Swift, JavaScript, TypeScript, Python, JSON, YAML, and VibeTunnel.
+        """
+}
+
+protocol VoiceTranscriptionKeyStoring {
+    func savePassword(_ password: String, for key: String) throws
+    func loadPassword(for key: String) throws -> String
+    func deletePassword(for key: String) throws
+}
+
+extension KeychainService: VoiceTranscriptionKeyStoring {}
+
+@MainActor
+@Observable
+final class VoiceInputViewModel {
+    enum State: Equatable {
+        case idle
+        case preparing
+        case recording
+        case transcribing
+    }
+
+    struct CompletedTranscript: Equatable {
+        let id = UUID()
+        let text: String
+    }
+
+    private(set) var state: State = .idle
+    private(set) var completedTranscript: CompletedTranscript?
+    private(set) var errorMessage: String?
+
+    private let audioRecorder: any AudioRecording
+    private let keyStore: any VoiceTranscriptionKeyStoring
+    private let transcriptionServiceFactory: (String) -> any TranscriptionServicing
+    private let maximumRecordingDuration: Duration
+    private var apiKey: String?
+    private var autoStopTask: Task<Void, Never>?
+    private var operationID = UUID()
+
+    init(
+        audioRecorder: any AudioRecording = AudioRecordingService(),
+        keyStore: any VoiceTranscriptionKeyStoring = KeychainService(),
+        maximumRecordingDuration: Duration = .seconds(60),
+        transcriptionServiceFactory: @escaping (String) -> any TranscriptionServicing = {
+            OpenAITranscriptionService(apiKey: $0)
+        })
+    {
+        self.audioRecorder = audioRecorder
+        self.keyStore = keyStore
+        self.maximumRecordingDuration = maximumRecordingDuration
+        self.transcriptionServiceFactory = transcriptionServiceFactory
+    }
+
+    func toggleRecording() async {
+        switch self.state {
+        case .idle:
+            await self.startRecording()
+        case .preparing:
+            break
+        case .recording:
+            await self.stopAndTranscribe()
+        case .transcribing:
+            break
+        }
+    }
+
+    func cancelRecording() {
+        self.operationID = UUID()
+        self.autoStopTask?.cancel()
+        self.autoStopTask = nil
+        self.audioRecorder.cancelRecording()
+        self.apiKey = nil
+        self.state = .idle
+    }
+
+    func clearError() {
+        self.errorMessage = nil
+    }
+
+    func consumeCompletedTranscript() {
+        self.completedTranscript = nil
+    }
+
+    private func startRecording() async {
+        let operationID = UUID()
+        self.operationID = operationID
+        self.errorMessage = nil
+        self.completedTranscript = nil
+        self.state = .preparing
+
+        do {
+            let storedAPIKey: String
+            do {
+                storedAPIKey = try self.keyStore.loadPassword(
+                    for: VoiceTranscriptionConfiguration.apiKeyAccount)
+            } catch {
+                throw OpenAITranscriptionService.TranscriptionError.missingAPIKey
+            }
+
+            let apiKey = storedAPIKey
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !apiKey.isEmpty else {
+                throw OpenAITranscriptionService.TranscriptionError.missingAPIKey
+            }
+
+            self.apiKey = apiKey
+            try await self.audioRecorder.startRecording()
+            guard self.operationID == operationID else {
+                self.audioRecorder.cancelRecording()
+                return
+            }
+            self.state = .recording
+            self.scheduleAutomaticStop()
+        } catch {
+            guard self.operationID == operationID else { return }
+            self.apiKey = nil
+            self.state = .idle
+            self.errorMessage = self.message(for: error)
+        }
+    }
+
+    private func stopAndTranscribe(cancelAutomaticStop: Bool = true) async {
+        let operationID = self.operationID
+        if cancelAutomaticStop {
+            self.autoStopTask?.cancel()
+        }
+        self.autoStopTask = nil
+
+        guard let apiKey = self.apiKey else {
+            self.state = .idle
+            self.errorMessage = OpenAITranscriptionService.TranscriptionError.missingAPIKey.localizedDescription
+            return
+        }
+
+        let audioURL: URL
+        do {
+            audioURL = try self.audioRecorder.stopRecording()
+        } catch {
+            self.state = .idle
+            self.errorMessage = self.message(for: error)
+            return
+        }
+
+        self.state = .transcribing
+        defer {
+            try? FileManager.default.removeItem(at: audioURL)
+            if self.operationID == operationID {
+                self.apiKey = nil
+                self.state = .idle
+            }
+        }
+
+        do {
+            let service = self.transcriptionServiceFactory(apiKey)
+            let transcript = try await service.transcribe(
+                audioFileURL: audioURL,
+                prompt: VoiceTranscriptionConfiguration.prompt)
+            guard self.operationID == operationID else { return }
+            let normalizedTranscript = Self.normalizeTranscript(transcript)
+            guard !normalizedTranscript.isEmpty else {
+                throw OpenAITranscriptionService.TranscriptionError.invalidResponse
+            }
+            self.completedTranscript = CompletedTranscript(text: normalizedTranscript)
+        } catch {
+            guard self.operationID == operationID else { return }
+            self.errorMessage = self.message(for: error)
+        }
+    }
+
+    private func scheduleAutomaticStop() {
+        self.autoStopTask?.cancel()
+        self.autoStopTask = Task { [weak self, maximumRecordingDuration] in
+            try? await Task.sleep(for: maximumRecordingDuration)
+            guard !Task.isCancelled else { return }
+            await self?.stopAndTranscribe(cancelAutomaticStop: false)
+        }
+    }
+
+    private func message(for error: Error) -> String {
+        if let localizedError = error as? LocalizedError,
+           let description = localizedError.errorDescription
+        {
+            return description
+        }
+        return error.localizedDescription
+    }
+
+    private static func normalizeTranscript(_ transcript: String) -> String {
+        transcript.unicodeScalars
+            .map { CharacterSet.controlCharacters.contains($0) ? " " : String($0) }
+            .joined()
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+    }
+}

--- a/ios/VibeTunnel/Views/Settings/SettingsView.swift
+++ b/ios/VibeTunnel/Views/Settings/SettingsView.swift
@@ -134,6 +134,15 @@ struct GeneralSettingsView: View {
     private var enableLivePreviews = true
     @AppStorage("colorSchemePreference")
     private var colorSchemePreferenceRaw = "system"
+    @State private var openAIAPIKey = ""
+    @State private var hasOpenAIAPIKey = false
+    @State private var voiceInputStatus: VoiceInputStatus?
+    private let voiceInputKeyStore: any VoiceTranscriptionKeyStoring = KeychainService()
+
+    private struct VoiceInputStatus {
+        let message: String
+        let isError: Bool
+    }
 
     enum ColorSchemePreference: String, CaseIterable {
         case system
@@ -276,7 +285,101 @@ struct GeneralSettingsView: View {
                 }
             }
 
+            // Voice Input Section
+            VStack(alignment: .leading, spacing: Theme.Spacing.medium) {
+                Text("Voice Input")
+                    .font(.headline)
+                    .foregroundColor(Theme.Colors.terminalForeground)
+
+                VStack(alignment: .leading, spacing: Theme.Spacing.medium) {
+                    Label("OpenAI transcription", systemImage: "waveform")
+                        .font(Theme.Typography.terminalSystem(size: 14))
+                        .foregroundColor(Theme.Colors.terminalForeground)
+
+                    Text(
+                        "Recordings are sent to OpenAI after you tap Stop, or automatically after 60 seconds. Transcribed text is inserted into the terminal without executing it.")
+                        .font(Theme.Typography.terminalSystem(size: 12))
+                        .foregroundColor(Theme.Colors.terminalForeground.opacity(0.6))
+
+                    SecureField(
+                        self.hasOpenAIAPIKey ? "Replace saved API key" : "OpenAI API key",
+                        text: self.$openAIAPIKey)
+                        .font(Theme.Typography.terminalSystem(size: 14))
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                        .autocorrectionDisabled()
+                        .textInputAutocapitalization(.never)
+
+                    HStack {
+                        Button(self.hasOpenAIAPIKey ? "Replace Key" : "Save Key") {
+                            self.saveOpenAIAPIKey()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(Theme.Colors.primaryAccent)
+                        .disabled(self.openAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+
+                        if self.hasOpenAIAPIKey {
+                            Button("Remove Key", role: .destructive) {
+                                self.removeOpenAIAPIKey()
+                            }
+                            .buttonStyle(.bordered)
+                        }
+
+                        Spacer()
+
+                        Link(
+                            "Create Key",
+                            destination: URL(string: "https://platform.openai.com/api-keys")!)
+                            .font(Theme.Typography.terminalSystem(size: 12))
+                    }
+
+                    if let voiceInputStatus {
+                        Text(voiceInputStatus.message)
+                            .font(Theme.Typography.terminalSystem(size: 12))
+                            .foregroundColor(
+                                voiceInputStatus.isError ? Theme.Colors.errorAccent : Theme.Colors.successAccent)
+                    }
+                }
+                .padding()
+                .background(Theme.Colors.cardBackground)
+                .cornerRadius(Theme.CornerRadius.card)
+            }
+
             Spacer()
+        }
+        .task {
+            self.refreshOpenAIAPIKeyStatus()
+        }
+    }
+
+    private func refreshOpenAIAPIKeyStatus() {
+        self.hasOpenAIAPIKey = ((try? self.voiceInputKeyStore.loadPassword(
+            for: VoiceTranscriptionConfiguration.apiKeyAccount))?.isEmpty == false)
+    }
+
+    private func saveOpenAIAPIKey() {
+        let apiKey = self.openAIAPIKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !apiKey.isEmpty else { return }
+
+        do {
+            try self.voiceInputKeyStore.savePassword(
+                apiKey,
+                for: VoiceTranscriptionConfiguration.apiKeyAccount)
+            self.openAIAPIKey = ""
+            self.hasOpenAIAPIKey = true
+            self.voiceInputStatus = VoiceInputStatus(message: "API key saved in Keychain.", isError: false)
+        } catch {
+            self.voiceInputStatus = VoiceInputStatus(message: "Could not save the API key.", isError: true)
+        }
+    }
+
+    private func removeOpenAIAPIKey() {
+        do {
+            try self.voiceInputKeyStore.deletePassword(for: VoiceTranscriptionConfiguration.apiKeyAccount)
+            self.openAIAPIKey = ""
+            self.hasOpenAIAPIKey = false
+            self.voiceInputStatus = VoiceInputStatus(message: "API key removed.", isError: false)
+        } catch {
+            self.voiceInputStatus = VoiceInputStatus(message: "Could not remove the API key.", isError: true)
         }
     }
 }

--- a/ios/VibeTunnel/Views/Terminal/TerminalToolbar.swift
+++ b/ios/VibeTunnel/Views/Terminal/TerminalToolbar.swift
@@ -8,17 +8,20 @@ struct TerminalToolbar: View {
     let onSpecialKey: (TerminalInput.SpecialKey) -> Void
     let onDismissKeyboard: () -> Void
     let onRawInput: ((String) -> Void)?
+    let voiceInputViewModel: VoiceInputViewModel?
     @State private var showMoreKeys = false
     @State private var showAdvancedKeyboard = false
 
     init(
         onSpecialKey: @escaping (TerminalInput.SpecialKey) -> Void,
         onDismissKeyboard: @escaping () -> Void,
-        onRawInput: ((String) -> Void)? = nil)
+        onRawInput: ((String) -> Void)? = nil,
+        voiceInputViewModel: VoiceInputViewModel? = nil)
     {
         self.onSpecialKey = onSpecialKey
         self.onDismissKeyboard = onDismissKeyboard
         self.onRawInput = onRawInput
+        self.voiceInputViewModel = voiceInputViewModel
     }
 
     var body: some View {
@@ -75,6 +78,10 @@ struct TerminalToolbar: View {
                 }
 
                 Spacer()
+
+                if let voiceInputViewModel {
+                    self.voiceInputButton(viewModel: voiceInputViewModel)
+                }
 
                 // Advanced keyboard
                 ToolbarButton(systemImage: "keyboard") {
@@ -257,6 +264,52 @@ struct TerminalToolbar: View {
             AdvancedKeyboardView(isPresented: self.$showAdvancedKeyboard) { input in
                 self.onRawInput?(input)
             }
+        }
+    }
+
+    private func voiceInputButton(viewModel: VoiceInputViewModel) -> some View {
+        ToolbarButton(
+            systemImage: self.voiceInputIcon(for: viewModel.state),
+            isActive: viewModel.state == .recording)
+        {
+            HapticFeedback.impact(viewModel.state == .recording ? .medium : .light)
+            Task {
+                await viewModel.toggleRecording()
+            }
+        }
+        .disabled(viewModel.state == .preparing || viewModel.state == .transcribing)
+        .overlay {
+            if viewModel.state == .preparing || viewModel.state == .transcribing {
+                ProgressView()
+                    .controlSize(.small)
+            }
+        }
+        .accessibilityLabel(self.voiceInputAccessibilityLabel(for: viewModel.state))
+    }
+
+    private func voiceInputIcon(for state: VoiceInputViewModel.State) -> String {
+        switch state {
+        case .idle:
+            "mic"
+        case .preparing:
+            "mic"
+        case .recording:
+            "stop.fill"
+        case .transcribing:
+            "mic"
+        }
+    }
+
+    private func voiceInputAccessibilityLabel(for state: VoiceInputViewModel.State) -> String {
+        switch state {
+        case .idle:
+            "Start voice input"
+        case .preparing:
+            "Preparing voice input"
+        case .recording:
+            "Stop and transcribe voice input"
+        case .transcribing:
+            "Transcribing voice input"
         }
     }
 }

--- a/ios/VibeTunnel/Views/Terminal/TerminalView.swift
+++ b/ios/VibeTunnel/Views/Terminal/TerminalView.swift
@@ -28,6 +28,7 @@ struct TerminalView: View {
     @State private var currentTerminalWidth: TerminalWidth = .unlimited
     @State private var showingFullscreenInput = false
     @State private var showingCtrlKeyGrid = false
+    @State private var voiceInputViewModel = VoiceInputViewModel()
     @FocusState private var isInputFocused: Bool
 
     init(session: Session) {
@@ -54,6 +55,7 @@ struct TerminalView: View {
             self.isInputFocused = true
         }
         .onDisappear {
+            self.voiceInputViewModel.cancelRecording()
             self.viewModel.disconnect()
         }
         .sheet(isPresented: self.$showingFontSizeSheet) {
@@ -141,6 +143,26 @@ struct TerminalView: View {
             withAnimation(Theme.Animation.smooth) {
                 self.showScrollToBottom = !newValue
             }
+        }
+        .onChange(of: self.voiceInputViewModel.completedTranscript) { _, completedTranscript in
+            guard let completedTranscript else { return }
+            self.viewModel.sendInput(completedTranscript.text)
+            self.voiceInputViewModel.consumeCompletedTranscript()
+        }
+        .alert(
+            "Voice Input",
+            isPresented: Binding(
+                get: { self.voiceInputViewModel.errorMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        self.voiceInputViewModel.clearError()
+                    }
+                })) {
+            Button("OK") {
+                self.voiceInputViewModel.clearError()
+            }
+        } message: {
+            Text(self.voiceInputViewModel.errorMessage ?? "")
         }
         // iPad keyboard shortcuts
         .onKeyPress(keys: ["o"]) { press in
@@ -569,7 +591,8 @@ struct TerminalView: View {
                     },
                     onRawInput: { input in
                         self.viewModel.sendInput(input)
-                    })
+                    },
+                    voiceInputViewModel: self.voiceInputViewModel)
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
         }

--- a/ios/VibeTunnelTests/Services/OpenAITranscriptionServiceTests.swift
+++ b/ios/VibeTunnelTests/Services/OpenAITranscriptionServiceTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import VibeTunnel
+
+@Suite("OpenAI Transcription Service Tests", .serialized)
+@MainActor
+struct OpenAITranscriptionServiceTests {
+    @Test("Uploads bounded audio with model and terminal prompt")
+    func uploadsAudio() async throws {
+        let audioURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voice.m4a")
+        try Data("audio-data".utf8).write(to: audioURL)
+        defer { try? FileManager.default.removeItem(at: audioURL) }
+
+        let session = URLSession(configuration: .mockConfiguration)
+        MockURLProtocol.requestHandler = { request in
+            #expect(request.url?.absoluteString == "https://api.openai.com/v1/audio/transcriptions")
+            #expect(request.httpMethod == "POST")
+            #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-key")
+            #expect(request.value(forHTTPHeaderField: "Content-Type")?.hasPrefix("multipart/form-data") == true)
+
+            return try MockURLProtocol.jsonResponse(
+                for: request.url!,
+                json: ["text": "git status"])
+        }
+
+        let service = OpenAITranscriptionService(apiKey: "test-key", session: session)
+        let request = try service.makeRequest(
+            audioFileURL: audioURL,
+            prompt: VoiceTranscriptionConfiguration.prompt)
+        let body = String(decoding: request.httpBody ?? Data(), as: UTF8.self)
+        #expect(body.contains("name=\"model\""))
+        #expect(body.contains(VoiceTranscriptionConfiguration.model))
+        #expect(body.contains("name=\"prompt\""))
+        #expect(body.contains("filename=\"voice.m4a\""))
+        #expect(body.contains("audio-data"))
+
+        let transcript = try await service.transcribe(
+            audioFileURL: audioURL,
+            prompt: VoiceTranscriptionConfiguration.prompt)
+
+        #expect(transcript == "git status")
+        MockURLProtocol.requestHandler = nil
+    }
+
+    @Test("Returns the OpenAI API error message")
+    func apiError() async throws {
+        let audioURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voice-error.m4a")
+        try Data("audio-data".utf8).write(to: audioURL)
+        defer { try? FileManager.default.removeItem(at: audioURL) }
+
+        let session = URLSession(configuration: .mockConfiguration)
+        MockURLProtocol.requestHandler = { request in
+            try MockURLProtocol.jsonResponse(
+                for: request.url!,
+                statusCode: 401,
+                json: ["error": ["message": "Invalid API key"]])
+        }
+
+        let service = OpenAITranscriptionService(apiKey: "test-key", session: session)
+
+        await #expect(throws: OpenAITranscriptionService.TranscriptionError.self) {
+            try await service.transcribe(
+                audioFileURL: audioURL,
+                prompt: VoiceTranscriptionConfiguration.prompt)
+        }
+        MockURLProtocol.requestHandler = nil
+    }
+}

--- a/ios/VibeTunnelTests/ViewModels/VoiceInputViewModelTests.swift
+++ b/ios/VibeTunnelTests/ViewModels/VoiceInputViewModelTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import VibeTunnel
+
+@Suite("Voice Input View Model Tests")
+@MainActor
+struct VoiceInputViewModelTests {
+    @Test("Requires an OpenAI API key before recording")
+    func requiresAPIKey() async {
+        let recorder = MockAudioRecorder()
+        let viewModel = VoiceInputViewModel(
+            audioRecorder: recorder,
+            keyStore: TestKeyStore())
+
+        await viewModel.toggleRecording()
+
+        #expect(viewModel.state == .idle)
+        #expect(viewModel.errorMessage?.contains("OpenAI API key") == true)
+        #expect(recorder.startCount == 0)
+    }
+
+    @Test("Records, transcribes, normalizes, and deletes temporary audio")
+    func successfulTranscription() async throws {
+        let audioURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voice-input-test-\(UUID().uuidString).m4a")
+        try Data("audio".utf8).write(to: audioURL)
+
+        let recorder = MockAudioRecorder(audioURL: audioURL)
+        let service = MockTranscriptionService(result: .success("git status\n\u{1B}\t--short"))
+        let viewModel = VoiceInputViewModel(
+            audioRecorder: recorder,
+            keyStore: TestKeyStore(apiKey: "test-key"),
+            transcriptionServiceFactory: { _ in service })
+
+        await viewModel.toggleRecording()
+        #expect(viewModel.state == .recording)
+
+        await viewModel.toggleRecording()
+
+        #expect(viewModel.state == .idle)
+        #expect(viewModel.completedTranscript?.text == "git status --short")
+        #expect(recorder.stopCount == 1)
+        #expect(!FileManager.default.fileExists(atPath: audioURL.path))
+    }
+
+    @Test("Ignores repeated taps while microphone startup is pending")
+    func ignoresRepeatedTapsWhilePreparing() async throws {
+        let recorder = MockAudioRecorder(startDelay: .milliseconds(50))
+        let viewModel = VoiceInputViewModel(
+            audioRecorder: recorder,
+            keyStore: TestKeyStore(apiKey: "test-key"))
+
+        let startTask = Task {
+            await viewModel.toggleRecording()
+        }
+        try await Task.sleep(for: .milliseconds(10))
+
+        #expect(viewModel.state == .preparing)
+        await viewModel.toggleRecording()
+        await startTask.value
+
+        #expect(viewModel.state == .recording)
+        #expect(recorder.startCount == 1)
+        viewModel.cancelRecording()
+    }
+
+    @Test("Surfaces transcription errors and deletes temporary audio")
+    func transcriptionFailure() async throws {
+        let audioURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voice-input-failure-\(UUID().uuidString).m4a")
+        try Data("audio".utf8).write(to: audioURL)
+
+        let recorder = MockAudioRecorder(audioURL: audioURL)
+        let service = MockTranscriptionService(
+            result: .failure(OpenAITranscriptionService.TranscriptionError.apiError("Invalid key")))
+        let viewModel = VoiceInputViewModel(
+            audioRecorder: recorder,
+            keyStore: TestKeyStore(apiKey: "test-key"),
+            transcriptionServiceFactory: { _ in service })
+
+        await viewModel.toggleRecording()
+        await viewModel.toggleRecording()
+
+        #expect(viewModel.state == .idle)
+        #expect(viewModel.errorMessage?.contains("Invalid key") == true)
+        #expect(!FileManager.default.fileExists(atPath: audioURL.path))
+    }
+
+    @Test("Automatically stops bounded recordings")
+    func automaticallyStopsRecording() async throws {
+        let audioURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voice-input-timeout-\(UUID().uuidString).m4a")
+        try Data("audio".utf8).write(to: audioURL)
+
+        let recorder = MockAudioRecorder(audioURL: audioURL)
+        let service = MockTranscriptionService(
+            result: .success("pwd"),
+            failWhenCancelled: true)
+        let viewModel = VoiceInputViewModel(
+            audioRecorder: recorder,
+            keyStore: TestKeyStore(apiKey: "test-key"),
+            maximumRecordingDuration: .milliseconds(10),
+            transcriptionServiceFactory: { _ in service })
+
+        await viewModel.toggleRecording()
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(viewModel.state == .idle)
+        #expect(viewModel.completedTranscript?.text == "pwd")
+        #expect(recorder.stopCount == 1)
+    }
+}
+
+@MainActor
+private final class MockAudioRecorder: AudioRecording {
+    private let audioURL: URL
+    private let startDelay: Duration?
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+    var isRecording = false
+
+    init(
+        audioURL: URL = FileManager.default.temporaryDirectory.appendingPathComponent("unused.m4a"),
+        startDelay: Duration? = nil)
+    {
+        self.audioURL = audioURL
+        self.startDelay = startDelay
+    }
+
+    func startRecording() async throws {
+        self.startCount += 1
+        if let startDelay {
+            try await Task.sleep(for: startDelay)
+        }
+        self.isRecording = true
+    }
+
+    func stopRecording() throws -> URL {
+        self.stopCount += 1
+        self.isRecording = false
+        return self.audioURL
+    }
+
+    func cancelRecording() {
+        self.isRecording = false
+    }
+}
+
+private struct TestKeyStore: VoiceTranscriptionKeyStoring {
+    var apiKey: String?
+
+    func savePassword(_: String, for _: String) throws {}
+
+    func loadPassword(for _: String) throws -> String {
+        guard let apiKey else {
+            throw KeychainService.KeychainError.itemNotFound
+        }
+        return apiKey
+    }
+
+    func deletePassword(for _: String) throws {}
+}
+
+@MainActor
+private struct MockTranscriptionService: TranscriptionServicing {
+    let result: Result<String, Error>
+    var failWhenCancelled = false
+
+    func transcribe(audioFileURL _: URL, prompt _: String) async throws -> String {
+        if self.failWhenCancelled, Task.isCancelled {
+            throw CancellationError()
+        }
+        return try self.result.get()
+    }
+}


### PR DESCRIPTION
## Summary

- add OpenAI BYOK voice transcription to the iOS terminal keyboard toolbar
- record bounded 60-second M4A audio with AVFoundation and upload directly through `URLSession`
- store the API key in Keychain and disclose manual/automatic upload behavior in Settings
- insert sanitized transcript text without line breaks, control characters, or command execution
- add focused request, lifecycle, cancellation, cleanup, and auto-stop tests

## Architecture

This keeps voice input inside the existing terminal input owner and adds no package dependency. It replaces the stale shape in #523, whose contributor-fork Tachikoma dependency no longer compiles on the current iOS toolchain (`TachikomaError.permissionDenied`). Justin Williams is preserved as a commit co-author and thanked in the changelog.

Addresses #340. Supersedes #523 without closing it.

## Proof

- iOS 26.5 simulator, iPhone 17 Pro: 333 tests, 319 passed, 14 skipped, 0 failed
- focused voice/transcription suite: 7 tests passed
- app installed and launched on iOS 26.5; Settings accessibility tree exposes Voice Input disclosure, secure API-key field, and Create Key action
- touched SwiftLint: 0 violations
- `./scripts/validate-docs.sh`: passed
- Zig 0.15.2 `zig build`: passed
- `pnpm run build`: passed with Zig 0.15.2
- `pnpm run check`: passed
- autoreview: clean after fixing auto-stop cancellation and consent-copy findings

## Local baseline note

The repository-wide `pnpm run test` command times out in the shared `web/src/test/setup.ts` six-port cleanup hook on this machine under both Node 24 and Node 26 (93 suites fail before tests run). This PR does not change `web/**`; the iOS CI path is the relevant gate.
