### PR TITLE
feat(web): show git line change counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### ✨ Improvements
+- Show line insertion and deletion counts alongside file changes in web session Git status badges (thanks [@abhinavgautam01](https://github.com/abhinavgautam01)) (#48)
 - Let mobile users reorder, hide, and choose layouts for terminal quick keys, with browser-local persistence and an unchanged default layout (via [@ndraiman](https://github.com/ndraiman)) (#564)
 - Restore clickable Ctrl+letter shortcuts in the Ghostty terminal renderer (reported by [@manmal](https://github.com/manmal), based on the original implementation by [@hjanuschka](https://github.com/hjanuschka)) (#51)
 - Show returning users only the CLI maintenance page after updates, while keeping the full onboarding flow available manually (reported by [@MrMage](https://github.com/MrMage), with earlier investigation by [@gioneill](https://github.com/gioneill)) (#411)
@@ -63,6 +64,7 @@
 - Reset CLI outdated status after successful install and add regression coverage
 
 ### 👥 Contributors
+- Thanks [@abhinavgautam01](https://github.com/abhinavgautam01) for adding web session Git line-change counts.
 - Thanks [@cameroncooke](https://github.com/cameroncooke) for reporting stuck `vt` processes after suspending terminal jobs.
 - Thanks [@ndraiman](https://github.com/ndraiman) for proposing customizable mobile terminal quick-key layouts.
 - Thanks [@manmal](https://github.com/manmal) and [@hjanuschka](https://github.com/hjanuschka) for proposing and originally implementing clickable terminal shortcuts.

--- a/web/src/client/components/git-status-badge.test.ts
+++ b/web/src/client/components/git-status-badge.test.ts
@@ -29,4 +29,25 @@ describe('GitStatusBadge', () => {
     expect(branchSpan?.classList.contains('min-w-0')).toBe(true);
     expect(branchSpan?.getAttribute('title')).toBe('feature/super-long-branch-name');
   });
+
+  it('renders line insertion and deletion counts', async () => {
+    const session = {
+      ...createMockSession(),
+      gitRepoPath: '/tmp/repo',
+      gitBranch: 'main',
+      gitInsertionCount: 12,
+      gitDeletionCount: 3,
+    } as Session;
+
+    const element = await fixture<GitStatusBadge>(html`
+      <git-status-badge .session=${session}></git-status-badge>
+    `);
+
+    await element.updateComplete;
+
+    expect(element.textContent).toContain('+12');
+    expect(element.textContent).toContain('-3');
+    expect(element.querySelector('[title="Line insertions"]')).toBeTruthy();
+    expect(element.querySelector('[title="Line deletions"]')).toBeTruthy();
+  });
 });

--- a/web/src/client/components/git-status-badge.ts
+++ b/web/src/client/components/git-status-badge.ts
@@ -2,7 +2,7 @@
  * Git Status Badge Component
  *
  * Displays git repository status information in a compact badge format.
- * Shows counts for added, modified, deleted files, and ahead/behind commits.
+ * Shows counts for changed files, line changes, and ahead/behind commits.
  */
 import { html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
@@ -47,7 +47,9 @@ export class GitStatusBadge extends LitElement {
     const _hasLocalChanges =
       (this.session?.gitModifiedCount ?? 0) > 0 ||
       (this.session?.gitAddedCount ?? 0) > 0 ||
-      (this.session?.gitDeletedCount ?? 0) > 0;
+      (this.session?.gitDeletedCount ?? 0) > 0 ||
+      (this.session?.gitInsertionCount ?? 0) > 0 ||
+      (this.session?.gitDeletionCount ?? 0) > 0;
 
     const _hasRemoteChanges =
       (this.session?.gitAheadCount ?? 0) > 0 || (this.session?.gitBehindCount ?? 0) > 0;
@@ -59,6 +61,7 @@ export class GitStatusBadge extends LitElement {
       <div class="flex items-center gap-1.5 text-xs">
         ${this.renderBranchInfo()}
         ${this.renderLocalChanges()}
+        ${this.renderLineChanges()}
         ${this.renderRemoteChanges()}
       </div>
     `;
@@ -153,6 +156,38 @@ export class GitStatusBadge extends LitElement {
             ? html`
           <span class="text-red-600 dark:text-red-400" title="Commits behind">
             ↓${behindCount}
+          </span>
+        `
+            : null
+        }
+      </span>
+    `;
+  }
+
+  private renderLineChanges() {
+    if (!this.session) return null;
+
+    const insertionCount = this.session.gitInsertionCount ?? 0;
+    const deletionCount = this.session.gitDeletionCount ?? 0;
+
+    if (insertionCount === 0 && deletionCount === 0) return null;
+
+    return html`
+      <span class="flex items-center gap-0.5">
+        ${
+          insertionCount > 0
+            ? html`
+          <span class="text-green-600 dark:text-green-400" title="Line insertions">
+            +${insertionCount}
+          </span>
+        `
+            : null
+        }
+        ${
+          deletionCount > 0
+            ? html`
+          <span class="text-red-600 dark:text-red-400" title="Line deletions">
+            -${deletionCount}
           </span>
         `
             : null

--- a/web/src/client/components/session-view/connection-manager.ts
+++ b/web/src/client/components/session-view/connection-manager.ts
@@ -114,6 +114,10 @@ export class ConnectionManager {
               gitAheadCount: (e.gitAheadCount as number | undefined) ?? this.session.gitAheadCount,
               gitBehindCount:
                 (e.gitBehindCount as number | undefined) ?? this.session.gitBehindCount,
+              gitInsertionCount:
+                (e.gitInsertionCount as number | undefined) ?? this.session.gitInsertionCount,
+              gitDeletionCount:
+                (e.gitDeletionCount as number | undefined) ?? this.session.gitDeletionCount,
             };
             this.session = updatedSession;
             this.onSessionUpdate(updatedSession);

--- a/web/src/server/services/git-status-hub.ts
+++ b/web/src/server/services/git-status-hub.ts
@@ -20,6 +20,8 @@ export type GitStatusHubEvent = {
   gitDeletedCount: number;
   gitAheadCount: number;
   gitBehindCount: number;
+  gitInsertionCount: number;
+  gitDeletionCount: number;
 };
 
 export type GitStatusHubListener = (event: GitStatusHubEvent) => void;
@@ -157,7 +159,9 @@ export class GitStatusHub {
       oldStatus.staged !== newStatus.staged ||
       oldStatus.deleted !== newStatus.deleted ||
       oldStatus.ahead !== newStatus.ahead ||
-      oldStatus.behind !== newStatus.behind
+      oldStatus.behind !== newStatus.behind ||
+      oldStatus.insertions !== newStatus.insertions ||
+      oldStatus.deletions !== newStatus.deletions
     );
   }
 
@@ -174,6 +178,8 @@ export class GitStatusHub {
       gitDeletedCount: status.deleted,
       gitAheadCount: status.ahead,
       gitBehindCount: status.behind,
+      gitInsertionCount: status.insertions,
+      gitDeletionCount: status.deletions,
     });
   }
 

--- a/web/src/server/utils/git-status.test.ts
+++ b/web/src/server/utils/git-status.test.ts
@@ -1,0 +1,61 @@
+import { execFile } from 'child_process';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { promisify } from 'util';
+import { afterEach, describe, expect, it } from 'vitest';
+import { getDetailedGitStatus } from './git-status.js';
+
+const execFileAsync = promisify(execFile);
+
+describe('getDetailedGitStatus', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  async function createTempDir() {
+    const dir = await mkdtemp(join(tmpdir(), 'vibetunnel-git-status-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  async function git(cwd: string, args: string[]) {
+    await execFileAsync('git', args, {
+      cwd,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    });
+  }
+
+  it('includes line insertion and deletion counts', async () => {
+    const repoDir = await createTempDir();
+
+    await git(repoDir, ['init']);
+    await git(repoDir, ['config', 'user.email', 'test@example.com']);
+    await git(repoDir, ['config', 'user.name', 'Test User']);
+
+    const filePath = join(repoDir, 'example.txt');
+    await writeFile(filePath, 'alpha\nbeta\ngamma\n');
+    await git(repoDir, ['add', 'example.txt']);
+    await git(repoDir, ['commit', '-m', 'initial']);
+
+    await writeFile(filePath, 'alpha\ngamma\ndelta\nepsilon\n');
+
+    const status = await getDetailedGitStatus(repoDir);
+
+    expect(status.modified).toBe(1);
+    expect(status.insertions).toBe(2);
+    expect(status.deletions).toBe(1);
+  });
+
+  it('returns zero line counts outside a git repository', async () => {
+    const dir = await createTempDir();
+
+    const status = await getDetailedGitStatus(dir);
+
+    expect(status.insertions).toBe(0);
+    expect(status.deletions).toBe(0);
+  });
+});

--- a/web/src/server/utils/git-status.test.ts
+++ b/web/src/server/utils/git-status.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'child_process';
-import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { promisify } from 'util';
@@ -48,6 +48,77 @@ describe('getDetailedGitStatus', () => {
     expect(status.modified).toBe(1);
     expect(status.insertions).toBe(2);
     expect(status.deletions).toBe(1);
+  });
+
+  it('includes lines from untracked files', async () => {
+    const repoDir = await createTempDir();
+
+    await git(repoDir, ['init']);
+    await git(repoDir, ['config', 'user.email', 'test@example.com']);
+    await git(repoDir, ['config', 'user.name', 'Test User']);
+    await git(repoDir, ['commit', '--allow-empty', '-m', 'initial']);
+
+    await writeFile(join(repoDir, 'untracked.txt'), 'alpha\nbeta');
+    await writeFile(join(repoDir, 'binary.dat'), Buffer.from([0, 1, 2, 3]));
+
+    const status = await getDetailedGitStatus(repoDir);
+
+    expect(status.added).toBe(2);
+    expect(status.insertions).toBe(2);
+    expect(status.deletions).toBe(0);
+  });
+
+  it('bounds line counting for large untracked files', async () => {
+    const repoDir = await createTempDir();
+
+    await git(repoDir, ['init']);
+    await git(repoDir, ['config', 'user.email', 'test@example.com']);
+    await git(repoDir, ['config', 'user.name', 'Test User']);
+    await git(repoDir, ['commit', '--allow-empty', '-m', 'initial']);
+
+    await writeFile(join(repoDir, 'large.txt'), Buffer.alloc(2 * 1024 * 1024, 0x61));
+    await writeFile(join(repoDir, 'small.txt'), 'counted\n');
+
+    const status = await getDetailedGitStatus(repoDir);
+
+    expect(status.added).toBe(2);
+    expect(status.insertions).toBe(1);
+    expect(status.deletions).toBe(0);
+  });
+
+  it('includes tracked and untracked lines before the first commit', async () => {
+    const repoDir = await createTempDir();
+
+    await git(repoDir, ['init']);
+    await writeFile(join(repoDir, 'first.txt'), 'first\nsecond\n');
+    await git(repoDir, ['add', 'first.txt']);
+    await writeFile(join(repoDir, 'second.txt'), 'third\n');
+
+    const status = await getDetailedGitStatus(repoDir);
+
+    expect(status.added).toBe(1);
+    expect(status.staged).toBe(1);
+    expect(status.insertions).toBe(3);
+    expect(status.deletions).toBe(0);
+  });
+
+  it('includes repository-wide untracked lines from a subdirectory', async () => {
+    const repoDir = await createTempDir();
+    const subdirectory = join(repoDir, 'nested');
+
+    await git(repoDir, ['init']);
+    await git(repoDir, ['config', 'user.email', 'test@example.com']);
+    await git(repoDir, ['config', 'user.name', 'Test User']);
+    await git(repoDir, ['commit', '--allow-empty', '-m', 'initial']);
+    await mkdir(subdirectory);
+    await writeFile(join(repoDir, 'root.txt'), 'root\nlines\n');
+    await writeFile(join(subdirectory, 'nested.txt'), 'nested\n');
+
+    const status = await getDetailedGitStatus(subdirectory);
+
+    expect(status.added).toBe(2);
+    expect(status.insertions).toBe(3);
+    expect(status.deletions).toBe(0);
   });
 
   it('returns zero line counts outside a git repository', async () => {

--- a/web/src/server/utils/git-status.ts
+++ b/web/src/server/utils/git-status.ts
@@ -17,6 +17,26 @@ export interface GitStatusCounts {
   deleted: number;
   ahead: number;
   behind: number;
+  insertions: number;
+  deletions: number;
+}
+
+function parseNumstat(output: string): { insertions: number; deletions: number } {
+  let insertions = 0;
+  let deletions = 0;
+
+  for (const line of output.trim().split('\n')) {
+    if (!line) continue;
+
+    const [inserted, deleted] = line.split('\t');
+    const insertedCount = Number.parseInt(inserted ?? '', 10);
+    const deletedCount = Number.parseInt(deleted ?? '', 10);
+
+    if (Number.isFinite(insertedCount)) insertions += insertedCount;
+    if (Number.isFinite(deletedCount)) deletions += deletedCount;
+  }
+
+  return { insertions, deletions };
 }
 
 /**
@@ -45,6 +65,8 @@ export async function getDetailedGitStatus(workingDir: string): Promise<GitStatu
     let addedCount = 0;
     let stagedCount = 0;
     let deletedCount = 0;
+    let insertions = 0;
+    let deletions = 0;
 
     // Parse branch line for ahead/behind info
     if (branchLine?.startsWith('##')) {
@@ -86,6 +108,19 @@ export async function getDetailedGitStatus(workingDir: string): Promise<GitStatu
       }
     }
 
+    try {
+      const { stdout: diffOutput } = await execFileAsync('git', ['diff', '--numstat', 'HEAD'], {
+        cwd: workingDir,
+        timeout: 5000,
+        env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+      });
+      const stats = parseNumstat(diffOutput);
+      insertions = stats.insertions;
+      deletions = stats.deletions;
+    } catch {
+      // Repositories without an initial commit cannot diff against HEAD.
+    }
+
     return {
       modified: modifiedCount,
       added: addedCount,
@@ -93,6 +128,8 @@ export async function getDetailedGitStatus(workingDir: string): Promise<GitStatu
       deleted: deletedCount,
       ahead: aheadCount,
       behind: behindCount,
+      insertions,
+      deletions,
     };
   } catch (_error) {
     // Not a git repository or git command failed
@@ -103,6 +140,8 @@ export async function getDetailedGitStatus(workingDir: string): Promise<GitStatu
       deleted: 0,
       ahead: 0,
       behind: 0,
+      insertions: 0,
+      deletions: 0,
     };
   }
 }

--- a/web/src/server/utils/git-status.ts
+++ b/web/src/server/utils/git-status.ts
@@ -6,9 +6,17 @@
  */
 
 import { execFile } from 'child_process';
+import { createReadStream } from 'fs';
+import { lstat } from 'fs/promises';
+import { join } from 'path';
 import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
+const GIT_BINARY_CHECK_BYTES = 8000;
+const LINE_COUNT_MAX_FILE_BYTES = 1024 * 1024;
+const LINE_COUNT_MAX_FILES = 256;
+const LINE_COUNT_MAX_TOTAL_BYTES = 4 * 1024 * 1024;
+const UNTRACKED_FILE_READ_CONCURRENCY = 16;
 
 export interface GitStatusCounts {
   modified: number;
@@ -37,6 +45,94 @@ function parseNumstat(output: string): { insertions: number; deletions: number }
   }
 
   return { insertions, deletions };
+}
+
+async function countUntrackedFileInsertions(workingDir: string, relativePath: string) {
+  const filePath = join(workingDir, relativePath);
+  let insertions = 0;
+  let bytesInspectedForBinary = 0;
+  let hasContent = false;
+  let lastByte = 0;
+
+  for await (const chunk of createReadStream(filePath)) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    const binaryBytesRemaining = Math.max(0, GIT_BINARY_CHECK_BYTES - bytesInspectedForBinary);
+
+    if (binaryBytesRemaining > 0) {
+      const bytesToInspect = Math.min(binaryBytesRemaining, buffer.length);
+      if (buffer.subarray(0, bytesToInspect).includes(0)) return 0;
+      bytesInspectedForBinary += bytesToInspect;
+    }
+
+    hasContent ||= buffer.length > 0;
+    for (const byte of buffer) {
+      if (byte === 0x0a) insertions++;
+    }
+    if (buffer.length > 0) lastByte = buffer[buffer.length - 1];
+  }
+
+  return insertions + (hasContent && lastByte !== 0x0a ? 1 : 0);
+}
+
+async function getFileInsertions(workingDir: string, includeTracked: boolean) {
+  const { stdout: repositoryRootOutput } = await execFileAsync(
+    'git',
+    ['rev-parse', '--show-toplevel'],
+    {
+      cwd: workingDir,
+      timeout: 5000,
+      env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    }
+  );
+  const repositoryRoot = repositoryRootOutput.trim();
+  const args = ['ls-files'];
+  if (includeTracked) args.push('--cached');
+  args.push('--others', '--exclude-standard', '-z');
+
+  const { stdout } = await execFileAsync('git', args, {
+    cwd: repositoryRoot,
+    timeout: 5000,
+    encoding: 'buffer',
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+  });
+  const paths = stdout
+    .toString()
+    .split('\0')
+    .filter((path) => path.length > 0);
+  let insertions = 0;
+  let bytesScheduled = 0;
+  const filesToRead: string[] = [];
+
+  // This runs in a two-second polling loop. Keep filesystem work bounded when
+  // repositories contain large or numerous generated files that are not ignored.
+  for (const path of paths.slice(0, LINE_COUNT_MAX_FILES)) {
+    try {
+      const stats = await lstat(join(repositoryRoot, path));
+      if (stats.isSymbolicLink()) {
+        insertions++;
+      } else if (
+        stats.isFile() &&
+        stats.size <= LINE_COUNT_MAX_FILE_BYTES &&
+        bytesScheduled + stats.size <= LINE_COUNT_MAX_TOTAL_BYTES
+      ) {
+        bytesScheduled += stats.size;
+        filesToRead.push(path);
+      }
+    } catch {
+      // Files can disappear between git listing them and the status refresh.
+    }
+  }
+
+  for (let index = 0; index < filesToRead.length; index += UNTRACKED_FILE_READ_CONCURRENCY) {
+    const counts = await Promise.all(
+      filesToRead
+        .slice(index, index + UNTRACKED_FILE_READ_CONCURRENCY)
+        .map((path) => countUntrackedFileInsertions(repositoryRoot, path).catch(() => 0))
+    );
+    insertions += counts.reduce((total, count) => total + count, 0);
+  }
+
+  return insertions;
 }
 
 /**
@@ -108,17 +204,39 @@ export async function getDetailedGitStatus(workingDir: string): Promise<GitStatu
       }
     }
 
+    let hasHead: boolean | null = null;
     try {
-      const { stdout: diffOutput } = await execFileAsync('git', ['diff', '--numstat', 'HEAD'], {
+      await execFileAsync('git', ['rev-parse', '--verify', '--quiet', 'HEAD'], {
         cwd: workingDir,
         timeout: 5000,
         env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
       });
-      const stats = parseNumstat(diffOutput);
-      insertions = stats.insertions;
-      deletions = stats.deletions;
-    } catch {
-      // Repositories without an initial commit cannot diff against HEAD.
+      hasHead = true;
+    } catch (error) {
+      const exitCode =
+        typeof error === 'object' && error !== null && 'code' in error
+          ? (error as { code?: unknown }).code
+          : undefined;
+      if (exitCode === 1) hasHead = false;
+    }
+
+    if (hasHead) {
+      try {
+        const { stdout: diffOutput } = await execFileAsync('git', ['diff', '--numstat', 'HEAD'], {
+          cwd: workingDir,
+          timeout: 5000,
+          env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+        });
+        const stats = parseNumstat(diffOutput);
+        insertions = stats.insertions;
+        deletions = stats.deletions;
+      } catch {
+        // Keep line counts conservative when diff fails for an existing repository.
+      }
+      insertions += await getFileInsertions(workingDir, false).catch(() => 0);
+    } else if (hasHead === false) {
+      // Without HEAD, every tracked and untracked file is new relative to the empty repository.
+      insertions = await getFileInsertions(workingDir, true).catch(() => 0);
     }
 
     return {

--- a/web/src/shared/types.ts
+++ b/web/src/shared/types.ts
@@ -87,6 +87,8 @@ export interface SessionInfo {
   gitStagedCount?: number; // Number of staged files
   gitAddedCount?: number; // Number of added files
   gitDeletedCount?: number; // Number of deleted files
+  gitInsertionCount?: number; // Number of inserted lines
+  gitDeletionCount?: number; // Number of deleted lines
   /**
    * Whether this session was spawned from within VibeTunnel itself.
    * Used to distinguish between direct terminal sessions and nested VibeTunnel sessions.


### PR DESCRIPTION
closes #48
## Summary

- Add insertion/deletion counts to the existing Git status calculation
- Forward line change counts through Git status WebSocket updates
- Show compact `+N` / `-N` line stats in the web Git status badge
- Add focused tests for Git line stats and badge rendering

## Testing

- `pnpm exec vitest run src/server/utils/git-status.test.ts src/client/components/git-status-badge.test.ts`
- `pnpm exec biome check src/server/utils/git-status.ts src/server/utils/git-status.test.ts src/server/services/git-status-hub.ts src/shared/types.ts src/client/components/session-view/connection-manager.ts src/client/components/git-status-badge.ts src/client/components/git-status-badge.test.ts`
- `pnpm exec tsc --noEmit --project tsconfig.server.json`
- `pnpm exec tsc --noEmit --project tsconfig.client.json`
- `git diff --check`

## Note

`pnpm install` linked dependencies, but the repo postinstall step requires `zig` to build the forwarder. The focused tests and TypeScript checks above passed directly.