### PR TITLE
feat(web): expose terminal input target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### ✨ Improvements
+- Expose a stable, labeled terminal input node for browser automation and accessibility tools (reported by [@bharath2020](https://github.com/bharath2020)) (#339)
 - Show line insertion and deletion counts alongside file changes in web session Git status badges (thanks [@abhinavgautam01](https://github.com/abhinavgautam01)) (#48)
 - Let mobile users reorder, hide, and choose layouts for terminal quick keys, with browser-local persistence and an unchanged default layout (via [@ndraiman](https://github.com/ndraiman)) (#564)
 - Restore clickable Ctrl+letter shortcuts in the Ghostty terminal renderer (reported by [@manmal](https://github.com/manmal), based on the original implementation by [@hjanuschka](https://github.com/hjanuschka)) (#51)

--- a/web/src/client/components/terminal.test.ts
+++ b/web/src/client/components/terminal.test.ts
@@ -8,6 +8,7 @@ import {
   waitForElement,
 } from '@/test/utils/component-helpers';
 import { MockFitAddon, MockResizeObserver, MockTerminal } from '@/test/utils/terminal-mocks';
+import { TERMINAL_IDS } from '../utils/terminal-constants';
 
 // Mock ghostty-web before importing the component
 vi.mock('ghostty-web', () => ({
@@ -59,6 +60,17 @@ describe('Terminal', () => {
   });
 
   describe('initialization', () => {
+    it('exposes a stable terminal input target for automation', () => {
+      const terminalInput = element.querySelector(
+        `#${TERMINAL_IDS.TERMINAL_INPUT}`
+      ) as HTMLTextAreaElement | null;
+
+      expect(terminalInput).toBeTruthy();
+      expect(terminalInput?.getAttribute('aria-label')).toBe('Terminal input');
+      expect(terminalInput?.getAttribute('data-testid')).toBe('terminal-input');
+      expect(terminalInput?.hasAttribute('aria-hidden')).toBe(false);
+    });
+
     it('should create terminal with default dimensions', async () => {
       expect(element.getAttribute('session-id')).toBe('test-123');
 

--- a/web/src/client/components/terminal.ts
+++ b/web/src/client/components/terminal.ts
@@ -745,8 +745,10 @@ export class Terminal extends LitElement {
 
       <div class="terminal-root" @click=${this.handleClick} @paste=${this.handlePaste}>
         <textarea
+          id=${TERMINAL_IDS.TERMINAL_INPUT}
           class="terminal-paste-input"
-          aria-hidden="true"
+          aria-label="Terminal input"
+          data-testid="terminal-input"
           tabindex="-1"
           autocapitalize="off"
           autocomplete="off"

--- a/web/src/client/utils/terminal-constants.ts
+++ b/web/src/client/utils/terminal-constants.ts
@@ -14,6 +14,8 @@ export const TERMINAL_IDS = {
   BUFFER_CONTAINER: 'buffer-container',
   /** Terminal container for terminal.ts component */
   TERMINAL_CONTAINER: 'terminal-container',
+  /** Stable browser-automation target for terminal keyboard input */
+  TERMINAL_INPUT: 'terminal-input',
 } as const;
 
 /**


### PR DESCRIPTION
Closes #339

## Summary
- add a stable `terminal-input` ID to the terminal keyboard textarea
- expose the input as a labeled textbox for accessibility and browser automation
- centralize the ID and add focused regression coverage

## Testing
- `pnpm exec vitest run src/client/components/terminal.test.ts src/client/components/session-view/lifecycle-event-manager.test.ts`
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm exec biome check src/client/components/terminal.ts src/client/components/terminal.test.ts src/client/utils/terminal-constants.ts`
- `git diff --check`
- autoreview: no actionable findings