### PR TITLE
fix: focus matching Ghostty tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Focus the matching Ghostty tab when opening a macOS session instead of stopping after focusing its window (reported by [@singiamtel](https://github.com/singiamtel)) (#273)
 - Let force-terminated `vt` sessions exit instead of rerunning commands outside VibeTunnel, including suspended jobs (reported by [@cameroncooke](https://github.com/cameroncooke)) (#278)
 - Show long session titles with ellipsis in the compact iPhone header instead of hiding them entirely. (#516)
 - Report Tailscale Serve as running after its background setup command exits successfully, instead of leaving the macOS app stuck on “Starting…” (#556)

--- a/mac/VibeTunnel/Core/Services/WindowTracking/WindowFocuser.swift
+++ b/mac/VibeTunnel/Core/Services/WindowTracking/WindowFocuser.swift
@@ -321,8 +321,8 @@ final class WindowFocuser {
             // Try window ID attribute for matching
             if let axWindowID = window.windowID {
                 if axWindowID == windowInfo.windowID {
-                    identityScore += 250
-                    matchScore += 100 // High score for exact ID match
+                    identityScore += WindowMatchScore.windowID
+                    matchScore += WindowMatchScore.windowID
                 }
                 self.logger
                     .debug(
@@ -340,8 +340,8 @@ final class WindowFocuser {
                    abs(windowFrame.width - bounds.width) < tolerance,
                    abs(windowFrame.height - bounds.height) < tolerance
                 {
-                    identityScore += 100
-                    matchScore += 50 // Medium score for bounds match
+                    identityScore += WindowMatchScore.bounds
+                    matchScore += WindowMatchScore.bounds
                     self.logger
                         .debug(
                             "Window \(index) bounds match! Position: (\(windowFrame.origin.x), \(windowFrame.origin.y)), Size: (\(windowFrame.width), \(windowFrame.height))")
@@ -352,33 +352,24 @@ final class WindowFocuser {
             if let title = window.title {
                 self.logger.debug("Window \(index) title: '\(title)'")
 
-                // Check for session ID in title (most reliable)
-                if title.contains(windowInfo.sessionID) || title.contains("TTY_SESSION_ID=\(windowInfo.sessionID)") {
-                    matchScore += 200 // Highest score
-                    self.logger.debug("Window \(index) has session ID in title!")
-                }
-
-                // Check for session-specific information
-                if let sessionInfo {
-                    let workingDir = sessionInfo.workingDir
-                    let dirName = (workingDir as NSString).lastPathComponent
-
-                    if !dirName.isEmpty, title.contains(dirName) || title.hasSuffix(dirName) {
-                        matchScore += 100
-                        self.logger.debug("Window \(index) has working directory in title")
-                    }
-
-                    if !sessionInfo.name.isEmpty, title.contains(sessionInfo.name) {
-                        matchScore += 150
-                        self.logger.debug("Window \(index) has session name in title")
-                    }
+                if let sessionInfo,
+                   let titleScore = self.windowMatcher.tabMatchScore(for: title, sessionInfo: sessionInfo)
+                {
+                    matchScore += titleScore
+                    self.logger.debug("Window \(index) has session title evidence worth \(titleScore)")
+                } else if !windowInfo.sessionID.isEmpty,
+                          title.contains(windowInfo.sessionID) ||
+                          title.contains("TTY_SESSION_ID=\(windowInfo.sessionID)")
+                {
+                    matchScore += WindowMatchScore.sessionID
+                    self.logger.debug("Window \(index) has session ID in title")
                 }
 
                 // Original title match logic as fallback
                 if !title
                     .isEmpty, windowInfo.title?.contains(title) ?? false || title.contains(windowInfo.title ?? "")
                 {
-                    matchScore += 25 // Low score for title match
+                    matchScore += WindowMatchScore.storedTitle
                 }
             }
 
@@ -407,14 +398,33 @@ final class WindowFocuser {
             }
         }
 
+        let trackedScore = bestTrackedWindow?.score ?? 0
+        let metadataScore = bestMatchWindow?.score ?? 0
+
         if let bestTabMatch,
-           bestTrackedWindow == nil || bestTabMatch.score > bestTrackedWindow?.score ?? 0
+           bestTabMatch.score >= metadataScore,
+           bestTabMatch.score > trackedScore
         {
             self.logger.info("Focusing matching tab in window with score \(bestTabMatch.score)")
             self.highlightEffect.highlightWindow(bestTabMatch.window, bounds: bestTabMatch.window.frame())
             bestTabMatch.window.setMain(true)
             bestTabMatch.window.setFocused(true)
             self.selectTab(tabs: bestTabMatch.tabs, windowInfo: windowInfo, sessionInfo: sessionInfo)
+            return
+        }
+
+        if let bestMatch = bestMatchWindow, bestMatch.score > trackedScore {
+            self.logger
+                .info("Using best match window with score \(bestMatch.score) for window ID \(windowInfo.windowID)")
+            self.highlightEffect.highlightWindow(bestMatch.window, bounds: bestMatch.window.frame())
+            bestMatch.window.setMain(true)
+            bestMatch.window.setFocused(true)
+
+            if sessionInfo != nil, let tabs = getTabs(from: bestMatch.window) {
+                self.selectTab(tabs: tabs, windowInfo: windowInfo, sessionInfo: sessionInfo)
+            }
+
+            self.logger.info("Focused best match window for session \(windowInfo.sessionID)")
             return
         }
 
@@ -432,39 +442,7 @@ final class WindowFocuser {
             return
         }
 
-        // After checking all windows, use the best match if we found one
-        if let bestMatch = bestMatchWindow {
-            self.logger
-                .info("Using best match window with score \(bestMatch.score) for window ID \(windowInfo.windowID)")
-
-            // Show highlight effect
-            self.highlightEffect.highlightWindow(bestMatch.window, bounds: bestMatch.window.frame())
-
-            // Focus the best matching window
-            bestMatch.window.setMain(true)
-            bestMatch.window.setFocused(true)
-
-            // Try to select tab if available
-            if sessionInfo != nil {
-                // Try to get tabs and select the right one
-                if let tabGroup = getTabGroup(from: bestMatch.window) {
-                    if let tabs = tabGroup.tabs,
-                       !tabs.isEmpty
-                    {
-                        self.selectTab(tabs: tabs, windowInfo: windowInfo, sessionInfo: sessionInfo)
-                    }
-                } else {
-                    // Try direct tabs attribute
-                    if let tabs = bestMatch.window.tabs,
-                       !tabs.isEmpty
-                    {
-                        self.selectTab(tabs: tabs, windowInfo: windowInfo, sessionInfo: sessionInfo)
-                    }
-                }
-            }
-
-            self.logger.info("Focused best match window for session \(windowInfo.sessionID)")
-        } else if windows.count == 1, let window = windows.first {
+        if windows.count == 1, let window = windows.first {
             self.logger.info("No metadata match; focusing the sole window for PID \(windowInfo.ownerPID)")
             self.highlightEffect.highlightWindow(window, bounds: window.frame())
             window.setMain(true)

--- a/mac/VibeTunnel/Core/Services/WindowTracking/WindowFocuser.swift
+++ b/mac/VibeTunnel/Core/Services/WindowTracking/WindowFocuser.swift
@@ -8,7 +8,7 @@ final class WindowFocuser {
     private struct WindowTabMatch {
         let window: AXElement
         let tabs: [AXElement]
-        let score: Int
+        let score: WindowMatchEvidence
     }
 
     private let logger = Logger(
@@ -310,19 +310,18 @@ final class WindowFocuser {
         let sessionInfo = providedSessionInfo ?? SessionMonitor.shared.sessions[windowInfo.sessionID]
 
         // First, try to find window with matching tab content
-        var bestTrackedWindow: (window: AXElement, score: Int)?
-        var bestMatchWindow: (window: AXElement, score: Int)?
+        var bestTrackedWindow: (window: AXElement, score: WindowMatchEvidence)?
+        var bestMatchWindow: (window: AXElement, score: WindowMatchEvidence)?
         var bestTabMatch: WindowTabMatch?
 
         for (index, window) in windows.enumerated() {
             var identityScore = 0
-            var matchScore = 0
+            var contentScore = 0
 
             // Try window ID attribute for matching
             if let axWindowID = window.windowID {
                 if axWindowID == windowInfo.windowID {
                     identityScore += WindowMatchScore.windowID
-                    matchScore += WindowMatchScore.windowID
                 }
                 self.logger
                     .debug(
@@ -341,7 +340,6 @@ final class WindowFocuser {
                    abs(windowFrame.height - bounds.height) < tolerance
                 {
                     identityScore += WindowMatchScore.bounds
-                    matchScore += WindowMatchScore.bounds
                     self.logger
                         .debug(
                             "Window \(index) bounds match! Position: (\(windowFrame.origin.x), \(windowFrame.origin.y)), Size: (\(windowFrame.width), \(windowFrame.height))")
@@ -355,13 +353,13 @@ final class WindowFocuser {
                 if let sessionInfo,
                    let titleScore = self.windowMatcher.tabMatchScore(for: title, sessionInfo: sessionInfo)
                 {
-                    matchScore += titleScore
+                    contentScore = max(contentScore, titleScore)
                     self.logger.debug("Window \(index) has session title evidence worth \(titleScore)")
                 } else if !windowInfo.sessionID.isEmpty,
                           title.contains(windowInfo.sessionID) ||
                           title.contains("TTY_SESSION_ID=\(windowInfo.sessionID)")
                 {
-                    matchScore += WindowMatchScore.sessionID
+                    contentScore = max(contentScore, WindowMatchScore.sessionID)
                     self.logger.debug("Window \(index) has session ID in title")
                 }
 
@@ -369,19 +367,22 @@ final class WindowFocuser {
                 if !title
                     .isEmpty, windowInfo.title?.contains(title) ?? false || title.contains(windowInfo.title ?? "")
                 {
-                    matchScore += WindowMatchScore.storedTitle
+                    contentScore = max(contentScore, WindowMatchScore.storedTitle)
                 }
             }
 
+            let trackedScore = WindowMatchScore.combined(identity: identityScore, content: 0)
             if identityScore > 0,
-               bestTrackedWindow == nil || identityScore > bestTrackedWindow?.score ?? 0
+               bestTrackedWindow == nil || trackedScore > bestTrackedWindow?.score ?? trackedScore
             {
-                bestTrackedWindow = (window, identityScore)
+                bestTrackedWindow = (window, trackedScore)
             }
 
+            let matchScore = WindowMatchScore.combined(identity: identityScore, content: contentScore)
+
             // Keep track of the best metadata match as a fallback.
-            if matchScore > 0 {
-                if bestMatchWindow == nil || matchScore > bestMatchWindow?.score ?? 0 {
+            if matchScore.strongest > 0 {
+                if bestMatchWindow == nil || matchScore > bestMatchWindow?.score ?? matchScore {
                     bestMatchWindow = (window, matchScore)
                     self.logger.debug("Window \(index) is new best match with score: \(matchScore)")
                 }
@@ -390,16 +391,17 @@ final class WindowFocuser {
             if let tabs = getTabs(from: window),
                let tabMatch = self.windowMatcher.findBestMatchingTab(tabs: tabs, sessionInfo: sessionInfo)
             {
-                let tabScore = identityScore + tabMatch.score
-                if bestTabMatch == nil || tabScore > bestTabMatch?.score ?? 0 {
+                let tabScore = WindowMatchScore.combined(identity: identityScore, content: tabMatch.score)
+                if bestTabMatch == nil || tabScore > bestTabMatch?.score ?? tabScore {
                     bestTabMatch = WindowTabMatch(window: window, tabs: tabs, score: tabScore)
                     self.logger.debug("Window \(index) is new best tab match with score: \(tabScore)")
                 }
             }
         }
 
-        let trackedScore = bestTrackedWindow?.score ?? 0
-        let metadataScore = bestMatchWindow?.score ?? 0
+        let noEvidence = WindowMatchScore.combined(identity: 0, content: 0)
+        let trackedScore = bestTrackedWindow?.score ?? noEvidence
+        let metadataScore = bestMatchWindow?.score ?? noEvidence
 
         if let bestTabMatch,
            bestTabMatch.score >= metadataScore,

--- a/mac/VibeTunnel/Core/Services/WindowTracking/WindowFocuser.swift
+++ b/mac/VibeTunnel/Core/Services/WindowTracking/WindowFocuser.swift
@@ -5,6 +5,12 @@ import OSLog
 /// Handles focusing specific terminal windows and tabs.
 @MainActor
 final class WindowFocuser {
+    private struct WindowTabMatch {
+        let window: AXElement
+        let tabs: [AXElement]
+        let score: Int
+    }
+
     private let logger = Logger(
         subsystem: BundleIdentifiers.loggerSubsystem,
         category: "WindowFocuser")
@@ -214,6 +220,22 @@ final class WindowFocuser {
         }
     }
 
+    /// Get tabs from a standard macOS tab group or directly from the window.
+    private func getTabs(from window: AXElement) -> [AXElement]? {
+        if let tabGroup = getTabGroup(from: window),
+           let tabs = tabGroup.tabs,
+           !tabs.isEmpty
+        {
+            return tabs
+        }
+
+        if let tabs = window.tabs, !tabs.isEmpty {
+            return tabs
+        }
+
+        return nil
+    }
+
     /// Select the correct tab in a window that uses macOS standard tabs
     private func selectTab(
         tabs: [AXElement],
@@ -259,158 +281,11 @@ final class WindowFocuser {
         }
     }
 
-    /// Select a tab by index in a tab group (helper method from screenshot)
-    private func selectTab(at index: Int, in group: AXElement) -> Bool {
-        guard let tabs = group.tabs,
-              index < tabs.count
-        else {
-            self.logger.warning("Could not get tabs from group or index out of bounds")
-            return false
-        }
-
-        return tabs[index].press()
-    }
-
-    /// Focuses a window by using the process PID directly
-    private func focusWindowUsingPID(_ windowInfo: WindowInfo) -> Bool {
-        // Get session info for better matching
-        let sessionInfo = SessionMonitor.shared.sessions[windowInfo.sessionID]
-        // Create AXElement directly from the PID
-        let axProcess = AXElement.application(pid: windowInfo.ownerPID)
-
-        // Get windows from this specific process
-        guard let windows = axProcess.windows,
-              !windows.isEmpty
-        else {
-            self.logger.debug("PID-based lookup failed for PID \(windowInfo.ownerPID), no windows found")
-            return false
-        }
-
-        self.logger.info("Found \(windows.count) window(s) for PID \(windowInfo.ownerPID)")
-
-        // Single window case - simple!
-        if windows.count == 1 {
-            self.logger.info("Single window found for PID \(windowInfo.ownerPID), focusing it directly")
-            let window = windows[0]
-
-            // Show highlight effect
-            self.highlightEffect.highlightWindow(window, bounds: window.frame())
-
-            // Focus the window
-            window.setMain(true)
-            window.setFocused(true)
-
-            // Bring app to front
-            if let app = NSRunningApplication(processIdentifier: windowInfo.ownerPID) {
-                app.activate()
-            }
-
-            return true
-        }
-
-        // Multiple windows - need to be smarter
-        self.logger.info("Multiple windows found for PID \(windowInfo.ownerPID), using scoring system")
-
-        // Use our existing scoring logic but only on these PID-specific windows
-        var bestMatch: (window: AXElement, score: Int)?
-
-        for (index, window) in windows.enumerated() {
-            var matchScore = 0
-
-            // Check window title for session ID or working directory (most reliable)
-            if let title = window.title {
-                self.logger.debug("Window \(index) title: '\(title)'")
-
-                // Check for session ID in title
-                if title.contains(windowInfo.sessionID) || title.contains("TTY_SESSION_ID=\(windowInfo.sessionID)") {
-                    matchScore += 200 // Highest score for session ID match
-                    self.logger.debug("Window \(index) has session ID in title!")
-                }
-
-                // Check for working directory in title
-                if let sessionInfo {
-                    let workingDir = sessionInfo.workingDir
-                    let dirName = (workingDir as NSString).lastPathComponent
-
-                    if !dirName
-                        .isEmpty,
-                        title.contains(dirName) || title.hasSuffix(dirName) || title.hasSuffix(" - \(dirName)")
-                    {
-                        matchScore += 100 // High score for directory match
-                        self.logger.debug("Window \(index) has working directory in title: \(dirName)")
-                    }
-
-                    // Check for session name
-                    if !sessionInfo.name.isEmpty, title.contains(sessionInfo.name) {
-                        matchScore += 150 // High score for session name match
-                        self.logger.debug("Window \(index) has session name in title: \(sessionInfo.name)")
-                    }
-                }
-            }
-
-            // Check window ID (less reliable for terminals)
-            if let axWindowID = window.windowID {
-                if axWindowID == windowInfo.windowID {
-                    matchScore += 50 // Lower score since window IDs can be unreliable
-                    self.logger.debug("Window \(index) has matching ID: \(axWindowID)")
-                }
-            }
-
-            // Check bounds if available (least reliable as windows can move)
-            if let bounds = windowInfo.bounds,
-               let windowFrame = window.frame()
-            {
-                let tolerance: CGFloat = 5.0
-                if abs(windowFrame.origin.x - bounds.origin.x) < tolerance,
-                   abs(windowFrame.origin.y - bounds.origin.y) < tolerance,
-                   abs(windowFrame.width - bounds.width) < tolerance,
-                   abs(windowFrame.height - bounds.height) < tolerance
-                {
-                    matchScore += 25 // Lowest score for bounds match
-                    self.logger.debug("Window \(index) bounds match")
-                }
-            }
-
-            if matchScore > 0 {
-                if bestMatch == nil || matchScore > bestMatch?.score ?? 0 {
-                    bestMatch = (window, matchScore)
-                }
-            }
-        }
-
-        if let best = bestMatch {
-            self.logger.info("Focusing best match window with score \(best.score) for PID \(windowInfo.ownerPID)")
-
-            // Show highlight effect
-            self.highlightEffect.highlightWindow(best.window, bounds: best.window.frame())
-
-            // Focus the window
-            best.window.setMain(true)
-            best.window.setFocused(true)
-
-            // Bring app to front
-            if let app = NSRunningApplication(processIdentifier: windowInfo.ownerPID) {
-                app.activate()
-            }
-
-            return true
-        }
-
-        self.logger.error("No matching window found for PID \(windowInfo.ownerPID)")
-        return false
-    }
-
     /// Focuses a window using Accessibility APIs.
-    private func focusWindowUsingAccessibility(_ windowInfo: WindowInfo) {
-        // First try PID-based approach
-        if self.focusWindowUsingPID(windowInfo) {
-            self.logger.info("Successfully focused window using PID-based approach")
-            return
-        }
-
-        // Fallback to the original approach if PID-based fails
-        self.logger.info("Falling back to terminal app-based window search")
-
+    func focusWindowUsingAccessibility(
+        _ windowInfo: WindowInfo,
+        sessionInfo providedSessionInfo: ServerSessionInfo? = nil)
+    {
         // First bring the application to front
         if let app = NSRunningApplication(processIdentifier: windowInfo.ownerPID) {
             app.activate()
@@ -432,24 +307,26 @@ final class WindowFocuser {
                 "Found \(windows.count) windows for \(windowInfo.terminalApp.rawValue), looking for window ID: \(windowInfo.windowID)")
 
         // Get session info for tab matching
-        let sessionInfo = SessionMonitor.shared.sessions[windowInfo.sessionID]
+        let sessionInfo = providedSessionInfo ?? SessionMonitor.shared.sessions[windowInfo.sessionID]
 
         // First, try to find window with matching tab content
+        var bestTrackedWindow: (window: AXElement, score: Int)?
         var bestMatchWindow: (window: AXElement, score: Int)?
+        var bestTabMatch: WindowTabMatch?
 
         for (index, window) in windows.enumerated() {
+            var identityScore = 0
             var matchScore = 0
-            var windowMatches = false
 
             // Try window ID attribute for matching
             if let axWindowID = window.windowID {
                 if axWindowID == windowInfo.windowID {
-                    windowMatches = true
+                    identityScore += 250
                     matchScore += 100 // High score for exact ID match
                 }
                 self.logger
                     .debug(
-                        "Window \(index) windowID: \(axWindowID), target: \(windowInfo.windowID), matches: \(windowMatches)")
+                        "Window \(index) windowID: \(axWindowID), target: \(windowInfo.windowID), matches: \(axWindowID == windowInfo.windowID)")
             }
 
             // Check window position and size as secondary validation
@@ -463,6 +340,7 @@ final class WindowFocuser {
                    abs(windowFrame.width - bounds.width) < tolerance,
                    abs(windowFrame.height - bounds.height) < tolerance
                 {
+                    identityScore += 100
                     matchScore += 50 // Medium score for bounds match
                     self.logger
                         .debug(
@@ -504,7 +382,13 @@ final class WindowFocuser {
                 }
             }
 
-            // Keep track of best match
+            if identityScore > 0,
+               bestTrackedWindow == nil || identityScore > bestTrackedWindow?.score ?? 0
+            {
+                bestTrackedWindow = (window, identityScore)
+            }
+
+            // Keep track of the best metadata match as a fallback.
             if matchScore > 0 {
                 if bestMatchWindow == nil || matchScore > bestMatchWindow?.score ?? 0 {
                     bestMatchWindow = (window, matchScore)
@@ -512,58 +396,40 @@ final class WindowFocuser {
                 }
             }
 
-            // Try the improved approach: get tab group first
-            if let tabGroup = getTabGroup(from: window) {
-                // Get tabs from the tab group
-                if let tabs = tabGroup.tabs,
-                   !tabs.isEmpty
-                {
-                    self.logger.info("Window \(index) has tab group with \(tabs.count) tabs")
-
-                    // Try to find matching tab
-                    if self.windowMatcher.findMatchingTab(tabs: tabs, sessionInfo: sessionInfo) != nil {
-                        // Found the tab! Focus the window and select the tab
-                        self.logger.info("Found matching tab in window \(index)")
-
-                        // Show highlight effect
-                        self.highlightEffect.highlightWindow(window, bounds: window.frame())
-
-                        // Make window main and focused
-                        window.setMain(true)
-                        window.setFocused(true)
-
-                        // Select the tab
-                        self.selectTab(tabs: tabs, windowInfo: windowInfo, sessionInfo: sessionInfo)
-
-                        return
-                    }
-                }
-            } else {
-                // Fallback: Try direct tabs attribute (older approach)
-                if let tabs = window.tabs,
-                   !tabs.isEmpty
-                {
-                    self.logger.info("Window \(index) has \(tabs.count) tabs (direct attribute)")
-
-                    // Try to find matching tab
-                    if self.windowMatcher.findMatchingTab(tabs: tabs, sessionInfo: sessionInfo) != nil {
-                        // Found the tab! Focus the window and select the tab
-                        self.logger.info("Found matching tab in window \(index)")
-
-                        // Show highlight effect
-                        self.highlightEffect.highlightWindow(window, bounds: window.frame())
-
-                        // Make window main and focused
-                        window.setMain(true)
-                        window.setFocused(true)
-
-                        // Select the tab
-                        self.selectTab(tabs: tabs, windowInfo: windowInfo, sessionInfo: sessionInfo)
-
-                        return
-                    }
+            if let tabs = getTabs(from: window),
+               let tabMatch = self.windowMatcher.findBestMatchingTab(tabs: tabs, sessionInfo: sessionInfo)
+            {
+                let tabScore = identityScore + tabMatch.score
+                if bestTabMatch == nil || tabScore > bestTabMatch?.score ?? 0 {
+                    bestTabMatch = WindowTabMatch(window: window, tabs: tabs, score: tabScore)
+                    self.logger.debug("Window \(index) is new best tab match with score: \(tabScore)")
                 }
             }
+        }
+
+        if let bestTabMatch,
+           bestTrackedWindow == nil || bestTabMatch.score > bestTrackedWindow?.score ?? 0
+        {
+            self.logger.info("Focusing matching tab in window with score \(bestTabMatch.score)")
+            self.highlightEffect.highlightWindow(bestTabMatch.window, bounds: bestTabMatch.window.frame())
+            bestTabMatch.window.setMain(true)
+            bestTabMatch.window.setFocused(true)
+            self.selectTab(tabs: bestTabMatch.tabs, windowInfo: windowInfo, sessionInfo: sessionInfo)
+            return
+        }
+
+        if let bestTrackedWindow {
+            self.logger.info("Focusing tracked window with identity score \(bestTrackedWindow.score)")
+            self.highlightEffect.highlightWindow(
+                bestTrackedWindow.window,
+                bounds: bestTrackedWindow.window.frame())
+            bestTrackedWindow.window.setMain(true)
+            bestTrackedWindow.window.setFocused(true)
+
+            if sessionInfo != nil, let tabs = getTabs(from: bestTrackedWindow.window) {
+                self.selectTab(tabs: tabs, windowInfo: windowInfo, sessionInfo: sessionInfo)
+            }
+            return
         }
 
         // After checking all windows, use the best match if we found one
@@ -598,6 +464,11 @@ final class WindowFocuser {
             }
 
             self.logger.info("Focused best match window for session \(windowInfo.sessionID)")
+        } else if windows.count == 1, let window = windows.first {
+            self.logger.info("No metadata match; focusing the sole window for PID \(windowInfo.ownerPID)")
+            self.highlightEffect.highlightWindow(window, bounds: window.frame())
+            window.setMain(true)
+            window.setFocused(true)
         } else {
             // No match found at all - log error but don't focus random window
             self.logger

--- a/mac/VibeTunnel/Core/Services/WindowTracking/WindowMatcher.swift
+++ b/mac/VibeTunnel/Core/Services/WindowTracking/WindowMatcher.swift
@@ -5,6 +5,11 @@ import OSLog
 /// Handles window matching and session-to-window mapping algorithms.
 @MainActor
 final class WindowMatcher {
+    struct TabMatch {
+        let tab: AXElement
+        let score: Int
+    }
+
     private let logger = Logger(
         subsystem: BundleIdentifiers.loggerSubsystem,
         category: "WindowMatcher")
@@ -226,55 +231,65 @@ final class WindowMatcher {
 
     /// Find matching tab using accessibility APIs
     func findMatchingTab(tabs: [AXElement], sessionInfo: ServerSessionInfo?) -> AXElement? {
+        self.findBestMatchingTab(tabs: tabs, sessionInfo: sessionInfo)?.tab
+    }
+
+    /// Find the strongest matching tab and its confidence score.
+    func findBestMatchingTab(tabs: [AXElement], sessionInfo: ServerSessionInfo?) -> TabMatch? {
         guard let sessionInfo else { return nil }
 
-        let workingDir = sessionInfo.workingDir
-        let dirName = (workingDir as NSString).lastPathComponent
-        let sessionID = sessionInfo.id
-        let sessionName = sessionInfo.name
-
-        self.logger.debug("Looking for tab matching session \(sessionID) in \(tabs.count) tabs")
-        self.logger.debug("  Working dir: \(workingDir)")
-        self.logger.debug("  Dir name: \(dirName)")
-        self.logger.debug("  Session name: \(sessionName)")
+        self.logger.debug("Looking for tab matching session \(sessionInfo.id) in \(tabs.count) tabs")
+        var bestMatch: TabMatch?
 
         for (index, tab) in tabs.enumerated() {
             if let title = tab.title {
                 self.logger.debug("Tab \(index) title: \(title)")
 
-                // Check for session ID match first (most precise)
-                if title.contains(sessionID) || title.contains("TTY_SESSION_ID=\(sessionID)") {
-                    self.logger.info("Found tab by session ID match at index \(index)")
-                    return tab
-                }
-
-                // Check for session name match
-                if !sessionName.isEmpty, title.contains(sessionName) {
-                    self.logger.info("Found tab by session name match: \(sessionName) at index \(index)")
-                    return tab
-                }
-
-                // Check for directory match - be more flexible
-                let titleLower = title.lowercased()
-                let dirNameLower = dirName.lowercased()
-                let workingDirLower = workingDir.lowercased()
-
-                if titleLower.contains(dirNameLower) || titleLower.contains(workingDirLower) {
-                    self.logger.info("Found tab by directory match at index \(index)")
-                    return tab
-                }
-
-                // Check if the tab title ends with the directory name (common pattern)
-                if title.hasSuffix(dirName) || title.hasSuffix(" - \(dirName)") {
-                    self.logger.info("Found tab by directory suffix match at index \(index)")
-                    return tab
+                if let score = self.tabMatchScore(for: title, sessionInfo: sessionInfo),
+                   bestMatch == nil || score > bestMatch?.score ?? 0
+                {
+                    bestMatch = TabMatch(tab: tab, score: score)
+                    self.logger.info("Tab \(index) is the best match with score \(score)")
                 }
             } else {
                 self.logger.debug("Tab \(index): Could not get title")
             }
         }
 
-        self.logger.warning("No matching tab found for session \(sessionID)")
+        if bestMatch == nil {
+            self.logger.warning("No matching tab found for session \(sessionInfo.id)")
+        }
+        return bestMatch
+    }
+
+    /// Score tab-title evidence so precise session matches can beat stale window metadata.
+    func tabMatchScore(for title: String, sessionInfo: ServerSessionInfo) -> Int? {
+        if !sessionInfo.id.isEmpty,
+           title.contains(sessionInfo.id) || title.contains("TTY_SESSION_ID=\(sessionInfo.id)")
+        {
+            return 500
+        }
+
+        if !sessionInfo.name.isEmpty, title.contains(sessionInfo.name) {
+            return 400
+        }
+
+        let titleLower = title.lowercased()
+        let workingDirLower = sessionInfo.workingDir.lowercased()
+        if !workingDirLower.isEmpty, titleLower.contains(workingDirLower) {
+            return 200
+        }
+
+        let dirName = (sessionInfo.workingDir as NSString).lastPathComponent
+        let dirNameLower = dirName.lowercased()
+        if !dirNameLower.isEmpty,
+           titleLower.contains(dirNameLower) ||
+           title.hasSuffix(dirName) ||
+           title.hasSuffix(" - \(dirName)")
+        {
+            return 100
+        }
+
         return nil
     }
 }

--- a/mac/VibeTunnel/Core/Services/WindowTracking/WindowMatcher.swift
+++ b/mac/VibeTunnel/Core/Services/WindowTracking/WindowMatcher.swift
@@ -2,6 +2,16 @@ import AppKit
 import Foundation
 import OSLog
 
+enum WindowMatchScore {
+    static let sessionID = 500
+    static let windowID = 250
+    static let sessionName = 200
+    static let workingDirectory = 150
+    static let bounds = 100
+    static let directoryName = 100
+    static let storedTitle = 25
+}
+
 /// Handles window matching and session-to-window mapping algorithms.
 @MainActor
 final class WindowMatcher {
@@ -267,17 +277,17 @@ final class WindowMatcher {
         if !sessionInfo.id.isEmpty,
            title.contains(sessionInfo.id) || title.contains("TTY_SESSION_ID=\(sessionInfo.id)")
         {
-            return 500
+            return WindowMatchScore.sessionID
         }
 
         if !sessionInfo.name.isEmpty, title.contains(sessionInfo.name) {
-            return 400
+            return WindowMatchScore.sessionName
         }
 
         let titleLower = title.lowercased()
         let workingDirLower = sessionInfo.workingDir.lowercased()
         if !workingDirLower.isEmpty, titleLower.contains(workingDirLower) {
-            return 200
+            return WindowMatchScore.workingDirectory
         }
 
         let dirName = (sessionInfo.workingDir as NSString).lastPathComponent
@@ -287,7 +297,7 @@ final class WindowMatcher {
            title.hasSuffix(dirName) ||
            title.hasSuffix(" - \(dirName)")
         {
-            return 100
+            return WindowMatchScore.directoryName
         }
 
         return nil

--- a/mac/VibeTunnel/Core/Services/WindowTracking/WindowMatcher.swift
+++ b/mac/VibeTunnel/Core/Services/WindowTracking/WindowMatcher.swift
@@ -2,6 +2,22 @@ import AppKit
 import Foundation
 import OSLog
 
+struct WindowMatchEvidence: Comparable, CustomStringConvertible {
+    let strongest: Int
+    let identity: Int
+
+    var description: String {
+        "\(self.strongest) (identity \(self.identity))"
+    }
+
+    static func < (lhs: Self, rhs: Self) -> Bool {
+        if lhs.strongest != rhs.strongest {
+            return lhs.strongest < rhs.strongest
+        }
+        return lhs.identity < rhs.identity
+    }
+}
+
 enum WindowMatchScore {
     static let sessionID = 500
     static let windowID = 250
@@ -10,6 +26,10 @@ enum WindowMatchScore {
     static let bounds = 100
     static let directoryName = 100
     static let storedTitle = 25
+
+    static func combined(identity: Int, content: Int) -> WindowMatchEvidence {
+        WindowMatchEvidence(strongest: max(identity, content), identity: identity)
+    }
 }
 
 /// Handles window matching and session-to-window mapping algorithms.

--- a/mac/VibeTunnelTests/WindowFocuserTests.swift
+++ b/mac/VibeTunnelTests/WindowFocuserTests.swift
@@ -1,0 +1,102 @@
+import CoreGraphics
+import Foundation
+import Testing
+@testable import VibeTunnel
+
+@Suite("Window Focuser Tests", .serialized)
+@MainActor
+struct WindowFocuserTests {
+    @Test
+    func ranksSpecificTabMatchesAboveDirectoryMatches() throws {
+        let matcher = WindowMatcher()
+        let sessionInfo = Self.makeSessionInfo(
+            id: "ghostty-tab-focus-test",
+            name: "VT273-A",
+            workingDir: "/tmp/vibetunnel")
+
+        let sessionIDScore = try #require(
+            matcher.tabMatchScore(for: "ghostty-tab-focus-test", sessionInfo: sessionInfo))
+        let sessionNameScore = try #require(matcher.tabMatchScore(for: "VT273-A", sessionInfo: sessionInfo))
+        let workingDirScore = try #require(
+            matcher.tabMatchScore(for: "/tmp/vibetunnel", sessionInfo: sessionInfo))
+        let directoryScore = try #require(matcher.tabMatchScore(for: "vibetunnel", sessionInfo: sessionInfo))
+
+        #expect(sessionIDScore > sessionNameScore)
+        #expect(sessionNameScore > workingDirScore)
+        #expect(workingDirScore > directoryScore)
+        #expect(matcher.tabMatchScore(for: "unrelated", sessionInfo: sessionInfo) == nil)
+    }
+
+    @Test(
+        .disabled(
+            if: ProcessInfo.processInfo.environment["VIBETUNNEL_GHOSTTY_TEST_PID"] == nil ||
+                ProcessInfo.processInfo.environment["VIBETUNNEL_GHOSTTY_TEST_TAB"] == nil,
+            "Set VIBETUNNEL_GHOSTTY_TEST_PID and VIBETUNNEL_GHOSTTY_TEST_TAB for a live Ghostty tab test"))
+    func focusesMatchingGhosttyTab() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        let pid = try #require(environment["VIBETUNNEL_GHOSTTY_TEST_PID"].flatMap(Int32.init))
+        let targetTitle = try #require(environment["VIBETUNNEL_GHOSTTY_TEST_TAB"])
+        let application = AXElement.application(pid: pid)
+        let window = try #require(application.windows?.first)
+        let initialTitle = window.title
+
+        #expect(initialTitle != targetTitle)
+
+        let windowInfo = WindowInfo(
+            windowID: CGWindowID(window.windowID ?? 0),
+            ownerPID: pid,
+            terminalApp: .ghostty,
+            sessionID: "ghostty-tab-focus-test",
+            createdAt: Date(),
+            tabReference: nil,
+            tabID: nil,
+            bounds: window.frame(),
+            title: initialTitle)
+        let sessionInfo = Self.makeSessionInfo(
+            id: windowInfo.sessionID,
+            name: targetTitle,
+            workingDir: "/tmp")
+
+        WindowFocuser().focusWindowUsingAccessibility(windowInfo, sessionInfo: sessionInfo)
+        try await Task.sleep(for: .milliseconds(300))
+
+        let focusedWindow = try #require(AXElement.application(pid: pid).windows?.first)
+        #expect(focusedWindow.title == targetTitle)
+    }
+
+    private static func makeSessionInfo(
+        id: String,
+        name: String,
+        workingDir: String)
+        -> ServerSessionInfo
+    {
+        ServerSessionInfo(
+            id: id,
+            name: name,
+            command: [],
+            workingDir: workingDir,
+            status: "running",
+            exitCode: nil,
+            startedAt: "",
+            pid: nil,
+            initialCols: nil,
+            initialRows: nil,
+            lastClearOffset: nil,
+            version: nil,
+            gitRepoPath: nil,
+            gitBranch: nil,
+            gitAheadCount: nil,
+            gitBehindCount: nil,
+            gitHasChanges: nil,
+            gitIsWorktree: nil,
+            gitMainRepoPath: nil,
+            lastModified: "",
+            active: nil,
+            activityStatus: nil,
+            source: nil,
+            remoteId: nil,
+            remoteName: nil,
+            remoteUrl: nil,
+            attachedViaVT: nil)
+    }
+}

--- a/mac/VibeTunnelTests/WindowFocuserTests.swift
+++ b/mac/VibeTunnelTests/WindowFocuserTests.swift
@@ -27,6 +27,17 @@ struct WindowFocuserTests {
         #expect(sessionIDScore > WindowMatchScore.windowID + WindowMatchScore.bounds)
         #expect(sessionNameScore < WindowMatchScore.windowID)
         #expect(directoryScore < WindowMatchScore.windowID)
+        let exactSession = WindowMatchScore.combined(identity: 0, content: sessionIDScore)
+        let staleWeakMatch = WindowMatchScore.combined(
+            identity: WindowMatchScore.windowID + WindowMatchScore.bounds,
+            content: sessionNameScore)
+        let trackedDuplicate = WindowMatchScore.combined(
+            identity: WindowMatchScore.windowID,
+            content: sessionNameScore)
+        let untrackedDuplicate = WindowMatchScore.combined(identity: 0, content: sessionNameScore)
+
+        #expect(exactSession > staleWeakMatch)
+        #expect(trackedDuplicate > untrackedDuplicate)
         #expect(matcher.tabMatchScore(for: "unrelated", sessionInfo: sessionInfo) == nil)
     }
 

--- a/mac/VibeTunnelTests/WindowFocuserTests.swift
+++ b/mac/VibeTunnelTests/WindowFocuserTests.swift
@@ -24,6 +24,9 @@ struct WindowFocuserTests {
         #expect(sessionIDScore > sessionNameScore)
         #expect(sessionNameScore > workingDirScore)
         #expect(workingDirScore > directoryScore)
+        #expect(sessionIDScore > WindowMatchScore.windowID + WindowMatchScore.bounds)
+        #expect(sessionNameScore < WindowMatchScore.windowID)
+        #expect(directoryScore < WindowMatchScore.windowID)
         #expect(matcher.tabMatchScore(for: "unrelated", sessionInfo: sessionInfo) == nil)
     }
 


### PR DESCRIPTION
Fixes #273

## Summary
- route standard-tab terminals through Accessibility tab matching instead of returning after PID window focus
- score tracked-window and session/tab evidence across multiple windows while preserving the sole-window fallback
- add matcher ordering coverage and an opt-in live Ghostty tab regression test

## Testing
- `swift test --package-path mac --filter WindowFocuserTests`
- live isolated Ghostty proof: active tab changed from `VT273-B` to `VT273-A`
- SwiftFormat, SwiftLint, and `git diff --check`
- full macOS suite: 273 tests ran; only three pre-existing local credential/keychain assertions failed in `NgrokServiceTests` and `DashboardKeychainTests`