### PR TITLE
fix(mac): clarify remote access onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Guide first-time users from local access through Tailscale setup and directly into Remote settings (reported by [@carlosjunod](https://github.com/carlosjunod)) (#539)
 - Focus the matching Ghostty tab when opening a macOS session instead of stopping after focusing its window (reported by [@singiamtel](https://github.com/singiamtel)) (#273)
 - Let force-terminated `vt` sessions exit instead of rerunning commands outside VibeTunnel, including suspended jobs (reported by [@cameroncooke](https://github.com/cameroncooke)) (#278)
 - Show long session titles with ellipsis in the compact iPhone header instead of hiding them entirely. (#516)

--- a/mac/VibeTunnel/Presentation/Views/Welcome/AccessDashboardPageView.swift
+++ b/mac/VibeTunnel/Presentation/Views/Welcome/AccessDashboardPageView.swift
@@ -1,88 +1,78 @@
 import SwiftUI
 
-/// Fifth page showing how to access the dashboard and ngrok integration.
+/// Final onboarding page explaining local and remote dashboard access.
 ///
 /// This view provides information about accessing the VibeTunnel dashboard
-/// from various devices, including options for ngrok tunneling and Tailscale
-/// networking. It also displays project credits.
+/// locally or from another device through Tailscale.
 ///
 /// ## Topics
 ///
 /// ### Overview
 /// The dashboard access page includes:
-/// - Instructions for remote dashboard access
-/// - Open Dashboard button for local access
-/// - Information about tunneling options (ngrok, Tailscale)
-/// - Project credits and contributor links
+/// - Local dashboard access
+/// - Tailscale setup steps
+/// - Direct navigation to Remote settings
 ///
 /// ### Networking Options
 /// - Local access via localhost
-/// - ngrok tunnel configuration
 /// - Tailscale VPN recommendation
 struct AccessDashboardPageView: View {
-    @AppStorage("ngrokEnabled")
-    private var ngrokEnabled = false
     @AppStorage(AppConstants.UserDefaultsKeys.serverPort)
     private var serverPort = "4020"
 
     var body: some View {
-        VStack(spacing: 30) {
-            VStack(spacing: 16) {
-                Text("Accessing Your Dashboard")
-                    .font(.largeTitle)
-                    .fontWeight(.semibold)
+        VStack(spacing: 14) {
+            Text("Access VibeTunnel Anywhere")
+                .font(.largeTitle)
+                .fontWeight(.semibold)
 
-                Text(
-                    "To access your terminals from any device, create a tunnel from your device.\n\nThis can be done via **ngrok** in settings or **Cloudflare** or **Tailscale**.")
-                    .font(.body)
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.center)
-                    .frame(maxWidth: 480)
-                    .fixedSize(horizontal: false, vertical: true)
+            Text(
+                "The dashboard works locally now. For access from your phone or another computer, connect both devices through **Tailscale** (recommended).")
+                .font(.callout)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 500)
+                .fixedSize(horizontal: false, vertical: true)
 
-                VStack(spacing: 12) {
-                    // Open Dashboard button
-                    Button(action: {
-                        if let dashboardURL = DashboardURLBuilder.dashboardURL(port: serverPort) {
-                            NSWorkspace.shared.open(dashboardURL)
-                        }
-                    }, label: {
-                        HStack {
-                            Image(systemName: "safari")
-                            Text("Open Dashboard")
-                        }
-                    })
-                    .buttonStyle(.borderedProminent)
-                    .controlSize(.large)
+            VStack(alignment: .leading, spacing: 7) {
+                RemoteAccessSetupStep(number: 1, text: "Install Tailscale on this Mac and your other device.")
+                RemoteAccessSetupStep(number: 2, text: "Sign in to the same Tailscale account on both devices.")
+                RemoteAccessSetupStep(
+                    number: 3,
+                    text: "Enable Tailscale Integration in Remote settings, then open the displayed URL.")
+            }
+            .frame(maxWidth: 500, alignment: .leading)
 
-                    // Tailscale link button
-                    TailscaleLink()
-                }
+            HStack(spacing: 12) {
+                Button(action: {
+                    if let dashboardURL = DashboardURLBuilder.dashboardURL(port: serverPort) {
+                        NSWorkspace.shared.open(dashboardURL)
+                    }
+                }, label: {
+                    Label("Open Local Dashboard", systemImage: "safari")
+                })
+                .buttonStyle(.bordered)
+                .controlSize(.large)
+
+                Button(action: {
+                    SettingsOpener.openSettingsTab(.remoteAccess)
+                }, label: {
+                    Label("Configure Remote Access", systemImage: "network")
+                })
+                .buttonStyle(.borderedProminent)
+                .controlSize(.large)
+                .accessibilityIdentifier("configure-remote-access")
             }
 
-            // Credits
-            VStack(spacing: 4) {
-                Text("VibeTunnel is open source and brought to you by")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
-                HStack(spacing: 4) {
-                    CreditLink(name: "@badlogic", url: "https://mariozechner.at/")
-
-                    Text("•")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-
-                    CreditLink(name: "@mitsuhiko", url: "https://lucumr.pocoo.org/")
-
-                    Text("•")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-
-                    CreditLink(name: "@steipete", url: "https://steipete.me")
+            Button(action: {
+                if let tailscaleURL = URL(string: URLConstants.tailscaleInstallGuide) {
+                    NSWorkspace.shared.open(tailscaleURL)
                 }
-            }
-            Spacer()
+            }, label: {
+                Label("Tailscale installation guide", systemImage: "questionmark.circle")
+            })
+            .buttonStyle(.link)
+            .pointingHandCursor()
         }
         .padding()
     }
@@ -90,29 +80,24 @@ struct AccessDashboardPageView: View {
 
 // MARK: - Supporting Views
 
-/// Tailscale link component with hover effect
-struct TailscaleLink: View {
-    @State private var isHovering = false
+private struct RemoteAccessSetupStep: View {
+    let number: Int
+    let text: String
 
     var body: some View {
-        Button(action: {
-            if let tailscaleURL = URL(string: "https://tailscale.com/") {
-                NSWorkspace.shared.open(tailscaleURL)
-            }
-        }, label: {
-            HStack {
-                Image(systemName: "link")
-                Text("Learn more about Tailscale")
-                    .underline(self.isHovering, color: .accentColor)
-            }
-        })
-        .buttonStyle(.link)
-        .pointingHandCursor()
-        .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.2)) {
-                self.isHovering = hovering
-            }
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text("\(self.number)")
+                .font(.caption.bold())
+                .foregroundStyle(.white)
+                .frame(width: 20, height: 20)
+                .background(Circle().fill(Color.accentColor))
+
+            Text(self.text)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
         }
+        .accessibilityElement(children: .combine)
     }
 }
 

--- a/mac/VibeTunnel/Presentation/Views/WelcomeView.swift
+++ b/mac/VibeTunnel/Presentation/Views/WelcomeView.swift
@@ -21,8 +21,13 @@ enum WelcomePresentationMode: Equatable {
         self == .full
     }
 
-    var opensSettingsOnFinish: Bool {
-        self == .full
+    var settingsTabOnFinish: SettingsTab? {
+        switch self {
+        case .full:
+            .remoteAccess
+        case .cliMaintenance:
+            nil
+        }
     }
 }
 
@@ -227,11 +232,11 @@ struct WelcomeView: View {
             // Close the window using the SwiftUI dismiss environment
             self.dismiss()
 
-            if self.mode.opensSettingsOnFinish {
+            if let settingsTab = mode.settingsTabOnFinish {
                 // Open settings after a delay to ensure the window is fully closed
                 Task { @MainActor in
                     try? await Task.sleep(for: .milliseconds(200))
-                    SettingsOpener.openSettings()
+                    SettingsOpener.openSettingsTab(settingsTab)
                 }
             }
         }

--- a/mac/VibeTunnel/Utilities/SettingsOpener.swift
+++ b/mac/VibeTunnel/Utilities/SettingsOpener.swift
@@ -95,7 +95,7 @@ enum SettingsOpener {
         Task { @MainActor in
             // Wait until SettingsView exists and has subscribed to tab changes.
             for _ in 0..<20 {
-                guard self.findSettingsWindow() == nil else {
+                if self.findSettingsWindow() != nil {
                     NotificationCenter.default.post(
                         name: .openSettingsTab,
                         object: tab)

--- a/mac/VibeTunnel/Utilities/SettingsOpener.swift
+++ b/mac/VibeTunnel/Utilities/SettingsOpener.swift
@@ -92,8 +92,19 @@ enum SettingsOpener {
     static func openSettingsTab(_ tab: SettingsTab) {
         self.openSettings()
 
-        Task {
-            // Then switch to the specific tab
+        Task { @MainActor in
+            // Wait until SettingsView exists and has subscribed to tab changes.
+            for _ in 0..<20 {
+                guard self.findSettingsWindow() == nil else {
+                    NotificationCenter.default.post(
+                        name: .openSettingsTab,
+                        object: tab)
+                    return
+                }
+                try? await Task.sleep(for: .milliseconds(50))
+            }
+
+            // Preserve the navigation request even if window discovery times out.
             NotificationCenter.default.post(
                 name: .openSettingsTab,
                 object: tab)

--- a/mac/VibeTunnelTests/WelcomePresentationModeTests.swift
+++ b/mac/VibeTunnelTests/WelcomePresentationModeTests.swift
@@ -10,7 +10,7 @@ struct WelcomePresentationModeTests {
         #expect(mode == .full)
         #expect(mode.pageCount == 9)
         #expect(mode.showsPageIndicators)
-        #expect(mode.opensSettingsOnFinish)
+        #expect(mode.settingsTabOnFinish == .remoteAccess)
     }
 
     @Test("Returning users see only CLI maintenance", arguments: [1, 4, 5])
@@ -20,6 +20,6 @@ struct WelcomePresentationModeTests {
         #expect(mode == .cliMaintenance)
         #expect(mode.pageCount == 1)
         #expect(!mode.showsPageIndicators)
-        #expect(!mode.opensSettingsOnFinish)
+        #expect(mode.settingsTabOnFinish == nil)
     }
 }


### PR DESCRIPTION
## Summary
- explain that local dashboard access is immediately available and remote access requires connecting both devices
- add a focused three-step Tailscale setup flow with direct navigation to Remote settings
- make onboarding Finish open Remote settings and avoid dropping tab navigation while the Settings window is opening

## Verification
- `swift test --package-path mac --filter WelcomePresentationModeTests`
- SwiftFormat and SwiftLint
- arm64 Debug app build with Zig 0.15.2
- live macOS UI proof for both Configure Remote Access and Finish paths
- autoreview clean

Fixes #539