### PR TITLE
fix: clarify password authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
-- Clarify that browser password login sends the host account password for operating system verification, does not save it, and can be replaced with SSH keys (reported by [@tleyden](https://github.com/tleyden)) (#555)
+- Clarify whether browser login expects a system or configured VibeTunnel password, that verification happens on the host without saving it, and that SSH keys avoid browser password entry (reported by [@tleyden](https://github.com/tleyden)) (#555)
 - Guide first-time users from local access through Tailscale setup and directly into Remote settings (reported by [@carlosjunod](https://github.com/carlosjunod)) (#539)
 - Focus the matching Ghostty tab when opening a macOS session instead of stopping after focusing its window (reported by [@singiamtel](https://github.com/singiamtel)) (#273)
 - Let force-terminated `vt` sessions exit instead of rerunning commands outside VibeTunnel, including suspended jobs (reported by [@cameroncooke](https://github.com/cameroncooke)) (#278)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Clarify that browser password login sends the host account password for operating system verification, does not save it, and can be replaced with SSH keys (reported by [@tleyden](https://github.com/tleyden)) (#555)
 - Guide first-time users from local access through Tailscale setup and directly into Remote settings (reported by [@carlosjunod](https://github.com/carlosjunod)) (#539)
 - Focus the matching Ghostty tab when opening a macOS session instead of stopping after focusing its window (reported by [@singiamtel](https://github.com/singiamtel)) (#273)
 - Let force-terminated `vt` sessions exit instead of rerunning commands outside VibeTunnel, including suspended jobs (reported by [@cameroncooke](https://github.com/cameroncooke)) (#278)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -169,7 +169,7 @@ npm run dev -- --no-auth
 
 ### Password Authentication
 - Uses system PAM authentication
-- Uses the configured VibeTunnel credential instead when both `VIBETUNNEL_USERNAME` and `VIBETUNNEL_PASSWORD` are set
+- Uses the configured VibeTunnel username and password instead when both `VIBETUNNEL_USERNAME` and `VIBETUNNEL_PASSWORD` are set
 - Sends the password to the VibeTunnel host over the current connection for verification
 - Does not persist the password
 - Use an encrypted connection; SSH key mode avoids sending a password through the browser

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -169,6 +169,9 @@ npm run dev -- --no-auth
 
 ### Password Authentication
 - Uses system PAM authentication
+- Sends the password to the VibeTunnel host over the current connection for verification
+- Does not persist the password
+- Use an encrypted connection; SSH key mode avoids sending the system password through the browser
 - Validates against actual system user passwords
 - JWT tokens expire after 24 hours
 - Secure session management

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -169,10 +169,11 @@ npm run dev -- --no-auth
 
 ### Password Authentication
 - Uses system PAM authentication
+- Uses the configured VibeTunnel credential instead when both `VIBETUNNEL_USERNAME` and `VIBETUNNEL_PASSWORD` are set
 - Sends the password to the VibeTunnel host over the current connection for verification
 - Does not persist the password
-- Use an encrypted connection; SSH key mode avoids sending the system password through the browser
-- Validates against actual system user passwords
+- Use an encrypted connection; SSH key mode avoids sending a password through the browser
+- Otherwise validates against actual system user passwords
 - JWT tokens expire after 24 hours
 - Secure session management
 

--- a/mac/VibeTunnel/Core/Models/ConfigurationEnums.swift
+++ b/mac/VibeTunnel/Core/Models/ConfigurationEnums.swift
@@ -23,9 +23,9 @@ enum AuthenticationMode: String, CaseIterable {
     var description: String {
         switch self {
         case .none: "Anyone can access the dashboard (not recommended)"
-        case .osAuth: "Use your macOS username and password"
+        case .osAuth: "Verify your macOS login password with macOS. VibeTunnel does not save it."
         case .sshKeys: "Use SSH keys from ~/.ssh/authorized_keys"
-        case .both: "Allow both authentication methods"
+        case .both: "Allow macOS password verification or SSH keys"
         }
     }
 }

--- a/mac/VibeTunnel/Presentation/Views/Settings/AuthenticationSection.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/AuthenticationSection.swift
@@ -52,7 +52,7 @@ struct AuthenticationSection: View {
                             .foregroundColor(.blue)
                             .font(.system(size: 12))
                             .frame(width: 16, height: 16)
-                        Text("Uses your macOS username: \(NSUserName())")
+                        Text("Account: \(NSUserName()). SSH Keys avoids entering your Mac password in a browser.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         Spacer()

--- a/mac/VibeTunnel/Presentation/Views/Settings/AuthenticationSection.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/AuthenticationSection.swift
@@ -52,7 +52,7 @@ struct AuthenticationSection: View {
                             .foregroundColor(.blue)
                             .font(.system(size: 12))
                             .frame(width: 16, height: 16)
-                        Text("Account: \(NSUserName()). SSH Keys avoids entering your Mac password in a browser.")
+                        Text("Account: \(NSUserName()). SSH keys avoid entering your Mac password in a browser.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         Spacer()

--- a/mac/VibeTunnel/Presentation/Views/Settings/SecurityPermissionsSettingsView.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/SecurityPermissionsSettingsView.swift
@@ -137,7 +137,7 @@ private struct SecuritySection: View {
                             .foregroundColor(.blue)
                             .font(.system(size: 12))
                             .frame(width: 16, height: 16)
-                        Text("Account: \(NSUserName()). SSH Keys avoids entering your Mac password in a browser.")
+                        Text("Account: \(NSUserName()). SSH keys avoid entering your Mac password in a browser.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         Spacer()

--- a/mac/VibeTunnel/Presentation/Views/Settings/SecurityPermissionsSettingsView.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/SecurityPermissionsSettingsView.swift
@@ -137,7 +137,7 @@ private struct SecuritySection: View {
                             .foregroundColor(.blue)
                             .font(.system(size: 12))
                             .frame(width: 16, height: 16)
-                        Text("Uses your macOS username: \(NSUserName())")
+                        Text("Account: \(NSUserName()). SSH Keys avoids entering your Mac password in a browser.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         Spacer()

--- a/mac/VibeTunnel/Presentation/Views/Welcome/ProtectDashboardPageView.swift
+++ b/mac/VibeTunnel/Presentation/Views/Welcome/ProtectDashboardPageView.swift
@@ -29,7 +29,7 @@ struct ProtectDashboardPageView: View {
                     .fontWeight(.semibold)
 
                 Text(
-                    "Your dashboard is protected using your macOS username and password.\nNo additional setup is required.")
+                    "Your dashboard can verify your macOS login password or use SSH keys.\nVibeTunnel does not save your Mac password.")
                     .font(.body)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
@@ -45,7 +45,7 @@ struct ProtectDashboardPageView: View {
                                 Text("macOS Authentication")
                                     .font(.callout)
                                     .fontWeight(.medium)
-                                Text("Uses your system username and password")
+                                Text("Sends your login password to this Mac for system verification")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                             }
@@ -59,7 +59,7 @@ struct ProtectDashboardPageView: View {
                                 Text("SSH Key Authentication")
                                     .font(.callout)
                                     .fontWeight(.medium)
-                                Text("Available as an alternative in Settings")
+                                Text("Avoids entering your Mac password in a browser")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                             }

--- a/web/src/client/components/auth-login.test.ts
+++ b/web/src/client/components/auth-login.test.ts
@@ -145,7 +145,32 @@ describe('AuthLogin', () => {
       expect(element.textContent).toContain('VibeTunnel does not save it');
       expect(element.textContent).toContain('enable SSH Keys in VibeTunnel Settings > Remote');
       expect(passwordInput.autocomplete).toBe('current-password');
-      expect(passwordInput.getAttribute('aria-describedby')).toBe('system-password-help');
+      expect(passwordInput.getAttribute('aria-describedby')).toBe('password-help');
+    });
+
+    it('should describe configured password authentication without requesting a system password', async () => {
+      fetchMock.mockResponse(
+        '/api/auth/config',
+        createAuthConfig({
+          enableSSHKeys: true,
+          passwordAuthMode: 'configured',
+        })
+      );
+
+      const configuredAuthElement = await fixture<AuthLogin>(html`
+        <auth-login .authClient=${mockAuthClient}></auth-login>
+      `);
+      await waitForAsync(10);
+
+      expect(configuredAuthElement.textContent).toContain('Configured VibeTunnel password');
+      expect(configuredAuthElement.textContent).toContain(
+        'Sent to the VibeTunnel host for verification'
+      );
+      expect(configuredAuthElement.textContent).not.toContain('operating system verification');
+      expect(configuredAuthElement.textContent).not.toContain('Computer login password');
+      expect(configuredAuthElement.textContent).toContain('Log in with configured password');
+
+      configuredAuthElement.remove();
     });
 
     it('should handle successful password login', async () => {

--- a/web/src/client/components/auth-login.test.ts
+++ b/web/src/client/components/auth-login.test.ts
@@ -133,9 +133,19 @@ describe('AuthLogin', () => {
   describe('password authentication', () => {
     it('should show password form', () => {
       const passwordForm = element.querySelector('form');
-      const passwordInput = element.querySelector('[data-testid="password-input"]');
+      const passwordInput = element.querySelector(
+        '[data-testid="password-input"]'
+      ) as HTMLInputElement;
       expect(passwordForm).toBeTruthy();
       expect(passwordInput).toBeTruthy();
+      expect(element.textContent).toContain('Computer login password');
+      expect(element.textContent).toContain(
+        'Sent to the VibeTunnel host for operating system verification'
+      );
+      expect(element.textContent).toContain('VibeTunnel does not save it');
+      expect(element.textContent).toContain('enable SSH Keys in VibeTunnel Settings > Remote');
+      expect(passwordInput.autocomplete).toBe('current-password');
+      expect(passwordInput.getAttribute('aria-describedby')).toBe('system-password-help');
     });
 
     it('should handle successful password login', async () => {

--- a/web/src/client/components/auth-login.ts
+++ b/web/src/client/components/auth-login.ts
@@ -22,6 +22,7 @@ export class AuthLogin extends LitElement {
     enableSSHKeys: false,
     disallowUserPassword: false,
     noAuth: false,
+    passwordAuthMode: 'system' as 'system' | 'configured',
   };
   @state() private isMobile = false;
   private unsubscribeResponsive?: () => void;
@@ -149,6 +150,10 @@ export class AuthLogin extends LitElement {
     this.dispatchEvent(new CustomEvent('open-settings'));
   };
 
+  private get usesConfiguredPassword(): boolean {
+    return this.authConfig.passwordAuthMode === 'configured';
+  }
+
   render() {
     console.log(
       '🔍 Rendering auth login',
@@ -271,16 +276,24 @@ export class AuthLogin extends LitElement {
                           for="system-password"
                           class="block text-xs font-medium text-text mb-1.5"
                         >
-                          Computer login password
+                          ${
+                            this.usesConfiguredPassword
+                              ? 'Configured VibeTunnel password'
+                              : 'Computer login password'
+                          }
                         </label>
                         <input
                           id="system-password"
                           type="password"
                           class="input-field"
                           data-testid="password-input"
-                          placeholder="Enter your login password"
+                          placeholder=${
+                            this.usesConfiguredPassword
+                              ? 'Enter the configured password'
+                              : 'Enter your login password'
+                          }
                           autocomplete="current-password"
-                          aria-describedby="system-password-help"
+                          aria-describedby="password-help"
                           .value=${this.loginPassword}
                           @input=${(e: Event) => {
                             this.loginPassword = (e.target as HTMLInputElement).value;
@@ -289,12 +302,17 @@ export class AuthLogin extends LitElement {
                           required
                         />
                         <p
-                          id="system-password-help"
+                          id="password-help"
                           class="mt-2 text-xs leading-relaxed text-text-muted"
                         >
-                          Sent to the VibeTunnel host for operating system verification.
-                          VibeTunnel does not save it. To avoid entering your computer password,
-                          enable SSH Keys in VibeTunnel Settings &gt; Remote.
+                          ${
+                            this.usesConfiguredPassword
+                              ? 'Sent to the VibeTunnel host for verification.'
+                              : 'Sent to the VibeTunnel host for operating system verification.'
+                          }
+                          VibeTunnel does not save it. To avoid entering
+                          ${this.usesConfiguredPassword ? 'a password' : 'your computer password'}
+                          in the browser, enable SSH Keys in VibeTunnel Settings &gt; Remote.
                         </p>
                       </div>
                       <button
@@ -303,7 +321,13 @@ export class AuthLogin extends LitElement {
                         data-testid="password-submit"
                         ?disabled=${this.loading || !this.loginPassword}
                       >
-                        ${this.loading ? 'Authenticating...' : 'Log in with computer password'}
+                        ${
+                          this.loading
+                            ? 'Authenticating...'
+                            : this.usesConfiguredPassword
+                              ? 'Log in with configured password'
+                              : 'Log in with computer password'
+                        }
                       </button>
                     </form>
                   </div>

--- a/web/src/client/components/auth-login.ts
+++ b/web/src/client/components/auth-login.ts
@@ -267,11 +267,20 @@ export class AuthLogin extends LitElement {
                     </div>
                     <form @submit=${this.handlePasswordLogin} class="space-y-3">
                       <div>
+                        <label
+                          for="system-password"
+                          class="block text-xs font-medium text-text mb-1.5"
+                        >
+                          Computer login password
+                        </label>
                         <input
+                          id="system-password"
                           type="password"
                           class="input-field"
                           data-testid="password-input"
-                          placeholder="System Password"
+                          placeholder="Enter your login password"
+                          autocomplete="current-password"
+                          aria-describedby="system-password-help"
                           .value=${this.loginPassword}
                           @input=${(e: Event) => {
                             this.loginPassword = (e.target as HTMLInputElement).value;
@@ -279,6 +288,14 @@ export class AuthLogin extends LitElement {
                           ?disabled=${this.loading}
                           required
                         />
+                        <p
+                          id="system-password-help"
+                          class="mt-2 text-xs leading-relaxed text-text-muted"
+                        >
+                          Sent to the VibeTunnel host for operating system verification.
+                          VibeTunnel does not save it. To avoid entering your computer password,
+                          enable SSH Keys in VibeTunnel Settings &gt; Remote.
+                        </p>
                       </div>
                       <button
                         type="submit"
@@ -286,7 +303,7 @@ export class AuthLogin extends LitElement {
                         data-testid="password-submit"
                         ?disabled=${this.loading || !this.loginPassword}
                       >
-                        ${this.loading ? 'Authenticating...' : 'Login with Password'}
+                        ${this.loading ? 'Authenticating...' : 'Log in with computer password'}
                       </button>
                     </form>
                   </div>

--- a/web/src/server/routes/auth.test.ts
+++ b/web/src/server/routes/auth.test.ts
@@ -50,6 +50,31 @@ describe('Auth Routes', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  describe('GET /api/auth/config', () => {
+    it('should report system password authentication by default', async () => {
+      vi.stubEnv('VIBETUNNEL_USERNAME', '');
+      vi.stubEnv('VIBETUNNEL_PASSWORD', '');
+      app.use('/api/auth', createAuthRoutes({ authService: mockAuthService }));
+
+      const response = await request(app).get('/api/auth/config');
+
+      expect(response.status).toBe(200);
+      expect(response.body.passwordAuthMode).toBe('system');
+    });
+
+    it('should report configured password authentication when both credentials are set', async () => {
+      vi.stubEnv('VIBETUNNEL_USERNAME', 'configured-user');
+      vi.stubEnv('VIBETUNNEL_PASSWORD', 'configured-password');
+      app.use('/api/auth', createAuthRoutes({ authService: mockAuthService }));
+
+      const response = await request(app).get('/api/auth/config');
+
+      expect(response.status).toBe(200);
+      expect(response.body.passwordAuthMode).toBe('configured');
+    });
   });
 
   describe('POST /api/auth/tailscale-token', () => {

--- a/web/src/server/routes/auth.test.ts
+++ b/web/src/server/routes/auth.test.ts
@@ -63,6 +63,7 @@ describe('Auth Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body.passwordAuthMode).toBe('system');
+      expect(response.body).not.toHaveProperty('passwordUserId');
     });
 
     it('should report configured password authentication when both credentials are set', async () => {
@@ -74,6 +75,31 @@ describe('Auth Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body.passwordAuthMode).toBe('configured');
+      expect(response.body).not.toHaveProperty('passwordUserId');
+    });
+  });
+
+  describe('POST /api/auth/password', () => {
+    it('should keep the configured username server-side', async () => {
+      vi.stubEnv('VIBETUNNEL_USERNAME', 'configured-user');
+      vi.stubEnv('VIBETUNNEL_PASSWORD', 'configured-password');
+      mockAuthService.authenticateWithPassword = vi.fn().mockResolvedValue({
+        success: true,
+        userId: 'configured-user',
+        token: 'test-token',
+      });
+      app.use('/api/auth', createAuthRoutes({ authService: mockAuthService }));
+
+      const response = await request(app).post('/api/auth/password').send({
+        userId: 'system-user',
+        password: 'configured-password',
+      });
+
+      expect(response.status).toBe(200);
+      expect(mockAuthService.authenticateWithPassword).toHaveBeenCalledWith(
+        'configured-user',
+        'configured-password'
+      );
     });
   });
 

--- a/web/src/server/routes/auth.ts
+++ b/web/src/server/routes/auth.ts
@@ -32,6 +32,11 @@ function getTailscaleLogin(req: AuthenticatedRequest): string | undefined {
   return getHeaderValue(req.headers['tailscale-user-login']);
 }
 
+function getConfiguredPasswordUserId(): string | undefined {
+  const username = process.env.VIBETUNNEL_USERNAME;
+  return username && process.env.VIBETUNNEL_PASSWORD ? username : undefined;
+}
+
 export function createAuthRoutes(config: AuthRoutesConfig): Router {
   const router = Router();
   const { authService } = config;
@@ -121,7 +126,8 @@ export function createAuthRoutes(config: AuthRoutesConfig): Router {
         });
       }
 
-      const result = await authService.authenticateWithPassword(userId, password);
+      const passwordUserId = getConfiguredPasswordUserId() || userId;
+      const result = await authService.authenticateWithPassword(passwordUserId, password);
 
       if (result.success) {
         res.json({
@@ -208,10 +214,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Router {
         enableSSHKeys: config.enableSSHKeys || false,
         disallowUserPassword: config.disallowUserPassword || false,
         noAuth: config.noAuth || false,
-        passwordAuthMode:
-          process.env.VIBETUNNEL_USERNAME && process.env.VIBETUNNEL_PASSWORD
-            ? 'configured'
-            : 'system',
+        passwordAuthMode: getConfiguredPasswordUserId() ? 'configured' : 'system',
       };
 
       // If user is authenticated via Tailscale, indicate this

--- a/web/src/server/routes/auth.ts
+++ b/web/src/server/routes/auth.ts
@@ -198,6 +198,7 @@ export function createAuthRoutes(config: AuthRoutesConfig): Router {
         enableSSHKeys: boolean;
         disallowUserPassword: boolean;
         noAuth: boolean;
+        passwordAuthMode: 'system' | 'configured';
         tailscaleAuth?: boolean;
         authenticatedUser?: string;
         tailscaleUser?: TailscaleUser;
@@ -207,6 +208,10 @@ export function createAuthRoutes(config: AuthRoutesConfig): Router {
         enableSSHKeys: config.enableSSHKeys || false,
         disallowUserPassword: config.disallowUserPassword || false,
         noAuth: config.noAuth || false,
+        passwordAuthMode:
+          process.env.VIBETUNNEL_USERNAME && process.env.VIBETUNNEL_PASSWORD
+            ? 'configured'
+            : 'system',
       };
 
       // If user is authenticated via Tailscale, indicate this

--- a/web/src/test/utils/test-factories.ts
+++ b/web/src/test/utils/test-factories.ts
@@ -32,6 +32,7 @@ interface CreateAuthConfigOptions {
   enableSSHKeys?: boolean;
   disallowUserPassword?: boolean;
   noAuth?: boolean;
+  passwordAuthMode?: 'system' | 'configured';
 }
 
 interface CreateAuthResultOptions {
@@ -97,6 +98,7 @@ export function createAuthConfig(options: CreateAuthConfigOptions = {}): CreateA
     disallowUserPassword:
       options.disallowUserPassword !== undefined ? options.disallowUserPassword : false,
     noAuth: options.noAuth !== undefined ? options.noAuth : false,
+    passwordAuthMode: options.passwordAuthMode || 'system',
   };
 }
 


### PR DESCRIPTION
## Summary

- report whether password auth uses system PAM or configured VibeTunnel credentials
- label the browser password field and verification explanation for the active backend
- keep configured usernames server-side while substituting them for password verification
- explain that the password is sent to the host for verification and is not persisted
- point users to SSH key authentication as the password-free browser alternative
- align macOS settings, onboarding, changelog, and authentication docs

A browser cannot invoke the remote host's native macOS authentication dialog without a separate host-approval protocol. This addresses the actionable security UX concern by making the current trust boundary explicit before submission.

Fixes #555

## Proof

- client auth tests: 20/20
- server auth-route tests: 11/11
- client and server TypeScript type checks
- Biome on touched web files
- `./scripts/lint.sh` (SwiftFormat + SwiftLint)
- macOS Debug app build with repo-supported Zig 0.15.2
- existing Chrome profile: desktop/mobile system-password views and configured-password view
- autoreview after final server-side username fix: no findings