### PR TITLE
Fix macOS releases to require the custom Node runtime

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -147,14 +147,14 @@ node build-native.js --custom-node=".node-builds/node-v24.2.0-minimal/out/Releas
 
 ## Optimization Details
 
-The custom Node.js build removes:
-- International support (`--without-intl`)
+The custom Node.js build reduces:
+- ICU locale data (`--with-intl=small-icu`)
 - npm and corepack (`--without-npm --without-corepack`)
 - Inspector/debugging (`--without-inspector`)
 - Code cache and snapshots
 - Uses `-Os` optimization for size
 
-This reduces the Node.js binary from ~120MB to ~50-60MB.
+This reduces the Node.js binary from ~110MB to ~68MB.
 
 ## Future Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Require macOS releases to rebuild the server with the trimmed Node.js runtime instead of silently embedding the full system binary (#271)
 - Clarify whether browser login expects a system or configured VibeTunnel password, that verification happens on the host without saving it, and that SSH keys avoid browser password entry (reported by [@tleyden](https://github.com/tleyden)) (#555)
 - Guide first-time users from local access through Tailscale setup and directly into Remote settings (reported by [@carlosjunod](https://github.com/carlosjunod)) (#539)
 - Focus the matching Ghostty tab when opening a macOS session instead of stopping after focusing its window (reported by [@singiamtel](https://github.com/singiamtel)) (#273)

--- a/docs/custom-node.md
+++ b/docs/custom-node.md
@@ -5,17 +5,17 @@
 VibeTunnel uses Node.js Single Executable Applications (SEA) to create a standalone terminal server. However, the standard Node.js binary is quite large:
 
 - **Standard Node.js binary**: ~110MB
-- **Custom minimal Node.js**: ~43MB (61% reduction)
-- **Final executable size**: ~45MB (down from ~105MB)
-- **Final app size impact**: Reduces app from ~130MB to ~88MB
+- **Custom minimal Node.js**: ~68MB (38% reduction)
+- **Final executable size**: ~72MB
+- **Final app size impact**: Saves roughly 40MB compared with embedding the standard runtime
 
 We don't need many Node.js features for VibeTunnel:
-- No internationalization (ICU) support needed
+- Small ICU data is sufficient for Unicode-aware JavaScript and English locale data
 - No npm package manager in the binary
 - No inspector/debugging protocol
 - No V8 snapshots or code cache
 
-By building a custom Node.js without these features, we achieve a significantly smaller app bundle while maintaining full functionality.
+By building a custom Node.js with small ICU and without the remaining features, we achieve a significantly smaller app bundle while maintaining full functionality.
 
 ## Build Behavior
 
@@ -47,7 +47,7 @@ The build script will automatically use these tools if available, falling back t
 ## Build Automation
 
 ### Release Builds
-The release script (`mac/scripts/release.sh`) automatically checks for and builds custom Node.js if needed. You don't need to manually build it before releases.
+The release script (`mac/scripts/release.sh`) forces a fresh web/native build and requires the pinned custom Node.js runtime. It builds and caches the runtime when needed; releases fail instead of silently embedding the full system Node.js binary.
 
 ### Manual Custom Node.js Build
 
@@ -55,7 +55,7 @@ To build the custom Node.js manually (outside of Xcode):
 
 ```bash
 cd web
-node build-custom-node.js --latest
+node build-custom-node.js
 ```
 
 This will:
@@ -93,7 +93,7 @@ Note: You may see a warning about "invalidating the code signature" during the s
 ## Technical Details
 
 ### Features Disabled
-- `--without-intl` - Removes internationalization support
+- `--with-intl=small-icu` - Keeps Unicode semantics with reduced locale data
 - `--without-npm` - Excludes npm from the binary
 - `--without-corepack` - Removes package manager wrapper
 - `--without-inspector` - Disables debugging protocol

--- a/mac/scripts/build-web-frontend.sh
+++ b/mac/scripts/build-web-frontend.sh
@@ -2,6 +2,9 @@
 set -e  # Exit on any error
 set -o pipefail  # Exit if any command in a pipeline fails
 
+# Preserve the caller's CI state before exporting CI for noninteractive package commands.
+RUNNING_IN_CI="${CI:-false}"
+
 # Get the project directory
 if [ -z "${SRCROOT}" ]; then
     # If SRCROOT is not set (running outside Xcode), determine it from script location
@@ -12,6 +15,11 @@ else
 fi
 
 WEB_DIR="${PROJECT_DIR}/../web"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/custom-node-policy.sh"
+
+FORCE_WEB_BUILD="${VIBETUNNEL_FORCE_WEB_BUILD:-false}"
+REQUIRE_CUSTOM_NODE="${VIBETUNNEL_REQUIRE_CUSTOM_NODE:-false}"
 HASH_FILE="${BUILT_PRODUCTS_DIR}/.web-content-hash"
 PREVIOUS_HASH_FILE="${BUILT_PRODUCTS_DIR}/.web-content-hash.previous"
 PUBLIC_DIR="${WEB_DIR}/public"
@@ -26,8 +34,12 @@ fi
 
 APP_RESOURCES="${BUILT_PRODUCTS_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"
 
-# In CI with pre-built artifacts, skip the entire build process
-if [ "${CI}" = "true" ] && [ -f "${WEB_DIR}/dist/server/server.js" ]; then
+# In ordinary CI with pre-built artifacts, skip the entire build process.
+# Release automation forces a fresh build so the embedded runtime is verifiable.
+if vibetunnel_is_truthy "$RUNNING_IN_CI" &&
+    ! vibetunnel_is_truthy "$FORCE_WEB_BUILD" &&
+    ! vibetunnel_is_truthy "$REQUIRE_CUSTOM_NODE" &&
+    [ -f "${WEB_DIR}/dist/server/server.js" ]; then
     echo "✓ CI environment detected with pre-built web artifacts"
     echo "✓ Skipping web frontend build entirely"
     
@@ -97,7 +109,9 @@ fi
 NEED_REBUILD=1
 
 # Check if previous hash exists and matches current
-if [ -f "${PREVIOUS_HASH_FILE}" ]; then
+if vibetunnel_is_truthy "$FORCE_WEB_BUILD"; then
+    echo "Forced web rebuild requested."
+elif [ -f "${PREVIOUS_HASH_FILE}" ]; then
     PREVIOUS_HASH=$(cat "${PREVIOUS_HASH_FILE}")
     if [ "${CURRENT_HASH}" = "${PREVIOUS_HASH}" ]; then
         # Also check if the built files actually exist
@@ -122,7 +136,6 @@ fi
 echo "Building web frontend..."
 
 # Setup Node.js PATH (Homebrew, nvm, Volta, fnm)
-SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 # Set environment variable to use clean build environment
 export VIBETUNNEL_BUILD_CLEAN_ENV=true
 source "${SCRIPT_DIR}/node-path-setup.sh"
@@ -135,7 +148,7 @@ export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 export PUPPETEER_SKIP_DOWNLOAD=1
 
 # Check if pnpm is available (skip in CI when web artifacts are pre-built)
-if [ "${SKIP_NODE_CHECK}" = "true" ] && [ "${CI}" = "true" ]; then
+if [ "${SKIP_NODE_CHECK}" = "true" ] && vibetunnel_is_truthy "$RUNNING_IN_CI"; then
     echo "✓ Skipping pnpm check in CI (web artifacts are pre-built)"
     echo "✓ This script should not be running in CI - web build should already be complete"
     exit 0
@@ -261,35 +274,43 @@ fi
 # Build the web frontend
 if [ "$BUILD_CONFIG" = "Release" ]; then
     echo "Release build - checking for custom Node.js..."
-    
-    # Skip custom Node.js build in CI to avoid timeout
-    if [ "${CI:-false}" = "true" ]; then
-        echo "CI environment detected - skipping custom Node.js build to avoid timeout"
-        echo "The app will be larger than optimal but will build within CI time limits."
-        pnpm run build 2>&1 | filter_build_output
-    elif [ ! -f "$CUSTOM_NODE_PATH" ]; then
-        echo "Custom Node.js not found, building it for optimal size..."
-        echo "This will take 10-20 minutes on first run but will be cached."
-        node build-custom-node.js --latest 2>&1 | filter_build_output
-        if [ -d "${WEB_DIR}/.node-builds" ]; then
-            CUSTOM_NODE_DIR=$(find "${WEB_DIR}/.node-builds" -name "node-v*-minimal" -type d -exec test -f {}/out/Release/node \; -print 2>/dev/null | sort -V | tail -n1)
-        else
-            CUSTOM_NODE_DIR=""
-        fi
+
+    CUSTOM_NODE_ACTION="$(
+        vibetunnel_custom_node_action \
+            "$BUILD_CONFIG" \
+            "$RUNNING_IN_CI" \
+            "$REQUIRE_CUSTOM_NODE" \
+            "$CUSTOM_NODE_PATH"
+    )"
+
+    if [ "$CUSTOM_NODE_ACTION" = "prepare" ]; then
+        PINNED_CUSTOM_NODE_VERSION=$(node -e 'process.stdout.write(require("./build-custom-node.js").DEFAULT_NODE_VERSION)')
+        echo "Validating the pinned custom Node.js build..."
+        echo "A missing or stale build will be rebuilt and cached."
+        node build-custom-node.js --version="$PINNED_CUSTOM_NODE_VERSION" 2>&1 | filter_build_output
+        CUSTOM_NODE_DIR="${WEB_DIR}/.node-builds/node-v${PINNED_CUSTOM_NODE_VERSION}-minimal"
         CUSTOM_NODE_PATH="${CUSTOM_NODE_DIR}/out/Release/node"
+        if [ -f "$CUSTOM_NODE_PATH" ]; then
+            CUSTOM_NODE_ACTION="use"
+        else
+            CUSTOM_NODE_ACTION="system"
+        fi
     fi
-    
-    if [ "${CI:-false}" != "true" ] && [ -f "$CUSTOM_NODE_PATH" ]; then
+
+    if [ "$CUSTOM_NODE_ACTION" = "use" ]; then
         CUSTOM_NODE_VERSION=$("$CUSTOM_NODE_PATH" --version 2>/dev/null || echo "unknown")
         CUSTOM_NODE_SIZE=$(ls -lh "$CUSTOM_NODE_PATH" 2>/dev/null | awk '{print $5}' || echo "unknown")
         echo "Using custom Node.js for release build:"
         echo "  Version: $CUSTOM_NODE_VERSION"
         echo "  Size: $CUSTOM_NODE_SIZE (vs ~110MB for standard Node.js)"
         echo "  Path: $CUSTOM_NODE_PATH"
-        pnpm run build -- --custom-node 2>&1 | filter_build_output
+        pnpm run build -- --custom-node="$CUSTOM_NODE_PATH" 2>&1 | filter_build_output
+    elif vibetunnel_is_truthy "$REQUIRE_CUSTOM_NODE"; then
+        echo "error: Release requires a custom Node.js build, but none is available."
+        exit 1
     else
-        echo "WARNING: Custom Node.js build failed, using system Node.js"
-        echo "The app will be larger than optimal."
+        echo "CI build without cached custom Node.js - using system Node.js."
+        echo "Release automation must set VIBETUNNEL_REQUIRE_CUSTOM_NODE=YES."
         pnpm run build 2>&1 | filter_build_output
     fi
 else
@@ -361,6 +382,24 @@ if [ -f "${NATIVE_DIR}/authenticate_pam.node" ]; then
     cp "${NATIVE_DIR}/authenticate_pam.node" "${APP_RESOURCES}/"
 else
     echo "Warning: authenticate_pam.node not found. PAM authentication may not work."
+fi
+
+# Required release builds must carry an explicit custom-runtime attestation.
+if vibetunnel_is_truthy "$REQUIRE_CUSTOM_NODE"; then
+    BUILD_INFO="${NATIVE_DIR}/vibetunnel-build.json"
+    if [ ! -f "$BUILD_INFO" ]; then
+        echo "error: Missing native build attestation at ${BUILD_INFO}"
+        exit 1
+    fi
+    node -e '
+        const fs = require("fs");
+        const info = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        if (info.schemaVersion !== 1 || info.customNode !== true) {
+            console.error("error: Native server was not built with custom Node.js");
+            process.exit(1);
+        }
+        console.log(`Verified custom Node.js ${info.nodeVersion} build (${info.arch})`);
+    ' "$BUILD_INFO"
 fi
 
 # Copy unified vt script

--- a/mac/scripts/custom-node-policy.sh
+++ b/mac/scripts/custom-node-policy.sh
@@ -1,0 +1,29 @@
+#!/bin/zsh
+
+vibetunnel_is_truthy() {
+    case "${1:l}" in
+        1|true|yes|on)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+vibetunnel_custom_node_action() {
+    local build_config="$1"
+    local running_in_ci="$2"
+    local require_custom_node="$3"
+    local custom_node_path="$4"
+
+    if [[ "$build_config" == "Release" ]] && vibetunnel_is_truthy "$require_custom_node"; then
+        echo "prepare"
+    elif [[ -f "$custom_node_path" ]]; then
+        echo "use"
+    elif [[ "$build_config" != "Release" ]]; then
+        echo "system"
+    elif ! vibetunnel_is_truthy "$running_in_ci"; then
+        echo "prepare"
+    else
+        echo "system"
+    fi
+}

--- a/mac/scripts/release.sh
+++ b/mac/scripts/release.sh
@@ -508,9 +508,7 @@ else
     fi
     
     if [[ ! -f "$CUSTOM_NODE_PATH" ]]; then
-        echo -e "${YELLOW}⚠️  Custom Node.js not found. Using system Node.js...${NC}"
-        echo "   Note: Release will work but app size will be larger."
-        # Continue with default Node.js
+        echo -e "${YELLOW}⚠️  Custom Node.js not found; the build will create it.${NC}"
     else
         CUSTOM_NODE_SIZE=$(ls -lh "$CUSTOM_NODE_PATH" | awk '{print $5}')
         CUSTOM_NODE_VERSION=$("$CUSTOM_NODE_PATH" --version 2>/dev/null || echo "unknown")
@@ -518,6 +516,10 @@ else
         echo "   Version: $CUSTOM_NODE_VERSION"
         echo "   Size: $CUSTOM_NODE_SIZE"
     fi
+
+    # Release artifacts must never reuse a system-Node or stale web build.
+    export VIBETUNNEL_REQUIRE_CUSTOM_NODE=YES
+    export VIBETUNNEL_FORCE_WEB_BUILD=YES
     
     # For pre-release builds, set the environment variable
     if [[ "$RELEASE_TYPE" != "stable" ]]; then
@@ -567,6 +569,21 @@ else
             echo -e "${RED}❌ Error: Binary is not ARM64: $ARCH_INFO${NC}"
             exit 1
         fi
+    fi
+
+    BUILD_INFO="$WEB_DIR/native/vibetunnel-build.json"
+    if [[ ! -f "$BUILD_INFO" ]]; then
+        echo -e "${RED}❌ Missing custom Node.js build attestation: $BUILD_INFO${NC}"
+        exit 1
+    fi
+    if ! node -e '
+        const fs = require("fs");
+        const info = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+        if (info.schemaVersion !== 1 || info.customNode !== true) process.exit(1);
+        console.log(`✅ Embedded server built with custom Node.js ${info.nodeVersion} (${info.arch})`);
+    ' "$BUILD_INFO"; then
+        echo -e "${RED}❌ Release server was not built with custom Node.js${NC}"
+        exit 1
     fi
     
     echo -e "${GREEN}✅ Build complete${NC}"

--- a/mac/scripts/test-custom-node-policy.sh
+++ b/mac/scripts/test-custom-node-policy.sh
@@ -1,0 +1,30 @@
+#!/bin/zsh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/custom-node-policy.sh"
+
+assert_action() {
+    local expected="$1"
+    shift
+    local actual
+    actual="$(vibetunnel_custom_node_action "$@")"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "Expected '$expected', got '$actual' for: $*"
+        exit 1
+    fi
+}
+
+missing_node="/definitely/missing/vibetunnel-custom-node"
+existing_node="/bin/sh"
+
+assert_action use Release true false "$existing_node"
+assert_action use Release false false "$existing_node"
+assert_action prepare Release false false "$missing_node"
+assert_action prepare Release true true "$missing_node"
+assert_action prepare Release true true "$existing_node"
+assert_action system Release true false "$missing_node"
+assert_action use Debug true false "$existing_node"
+assert_action system Debug false true "$missing_node"
+
+echo "Custom Node policy tests passed"

--- a/web/build-custom-node.js
+++ b/web/build-custom-node.js
@@ -6,10 +6,10 @@
  * This script automatically adapts to CI and local environments.
  * 
  * Usage:
- *   node build-custom-node.js                    # Builds Node.js 24.2.0 (recommended)
+ *   node build-custom-node.js                    # Builds the pinned Node.js 24 LTS release
  *   node build-custom-node.js --latest           # Latest version
- *   node build-custom-node.js --version=24.2.0   # Specific version
- *   NODE_VERSION=24.2.0 node build-custom-node.js  # Via environment variable (CI)
+ *   node build-custom-node.js --version=24.16.0  # Specific version
+ *   NODE_VERSION=24.16.0 node build-custom-node.js  # Via environment variable (CI)
  * 
  * In CI environments:
  *   - Outputs GitHub Actions variables
@@ -17,10 +17,12 @@
  *   - Creates build summary files
  */
 
-const { execSync } = require('child_process');
+const { execFileSync, execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const https = require('https');
+
+const DEFAULT_NODE_VERSION = '24.16.0';
 
 // Detect if running in CI
 const isCI = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
@@ -43,6 +45,42 @@ function setOutput(name, value) {
   if (process.env.GITHUB_OUTPUT) {
     fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`);
   }
+}
+
+function verifyCustomNodeDependencies(customNodePath, platform) {
+  if (platform !== 'darwin') {
+    return;
+  }
+
+  const dependencies = execFileSync('otool', ['-L', customNodePath], { encoding: 'utf8' });
+  const nonSystemDependencies = dependencies
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line.includes(' (compatibility version'))
+    .map(line => line.split(' (compatibility version', 1)[0])
+    .filter(dependency => {
+      return !dependency.startsWith('/usr/lib/') && !dependency.startsWith('/System/Library/');
+    });
+  if (nonSystemDependencies.length > 0) {
+    throw new Error(
+      `Custom Node.js linked non-system libraries:\n${nonSystemDependencies.join('\n')}`
+    );
+  }
+  console.log('Verified custom Node.js uses only system dynamic libraries.');
+}
+
+function verifyCustomNodeRuntime(customNodePath, platform) {
+  const version = execFileSync(customNodePath, ['--version'], { encoding: 'utf8' }).trim();
+  execFileSync(
+    customNodePath,
+    [
+      '-e',
+      'require("node:crypto"); require("node:http"); require("node:zlib"); if (!/^[$_\\p{ID_Start}]$/u.test("a")) process.exit(1);',
+    ],
+    { stdio: 'inherit' }
+  );
+  verifyCustomNodeDependencies(customNodePath, platform);
+  return version;
 }
 
 // Helper to download files
@@ -98,8 +136,8 @@ async function buildCustomNode() {
     // Support CI environment variable
     nodeSourceVersion = process.env.NODE_VERSION;
   } else {
-    // Default to Node.js 24.3.0 (recommended version)
-    nodeSourceVersion = '24.3.0';
+    // Pin release builds to the maintained Node.js 24 LTS line.
+    nodeSourceVersion = DEFAULT_NODE_VERSION;
   }
   
   const platform = process.platform;
@@ -116,23 +154,48 @@ async function buildCustomNode() {
   const versionDir = path.join(buildDir, `node-v${nodeSourceVersion}-minimal`);
   const markerFile = path.join(versionDir, '.build-complete');
   const customNodePath = path.join(versionDir, 'out', 'Release', 'node');
+  const requiredConfigureArgs = [
+    '--with-intl=small-icu',
+    '--without-npm',
+    '--without-corepack',
+    '--without-inspector',
+    '--without-node-code-cache',
+    '--without-node-snapshot',
+    '--shared-zlib',
+  ];
   
   // Check if already built
   if (fs.existsSync(markerFile) && fs.existsSync(customNodePath)) {
-    console.log(`Using cached custom Node.js build from ${customNodePath}`);
-    const stats = fs.statSync(customNodePath);
-    console.log(`Cached custom Node.js size: ${(stats.size / 1024 / 1024).toFixed(2)} MB`);
-    
-    if (isCI) {
-      // Set outputs for GitHub Actions
-      setOutput('node-path', customNodePath);
-      setOutput('node-size', stats.size);
-      setOutput('cache-hit', 'true');
-    } else {
-      console.log(`\nTo use this custom Node.js with build-native.js:`);
-      console.log(`node build-native.js --custom-node="${customNodePath}"`);
+    let configuredArgs = [];
+    try {
+      const buildInfo = JSON.parse(fs.readFileSync(markerFile, 'utf8'));
+      configuredArgs = buildInfo.configureArgs || [];
+    } catch {
+      console.log('Cached custom Node.js metadata is invalid; rebuilding.');
     }
-    return customNodePath;
+    const semanticConfigureArgs = configuredArgs.filter(arg => arg !== '--ninja');
+    const cacheMatches =
+      semanticConfigureArgs.length === requiredConfigureArgs.length &&
+      semanticConfigureArgs.every((arg, index) => arg === requiredConfigureArgs[index]);
+    if (cacheMatches) {
+      console.log(`Using cached custom Node.js build from ${customNodePath}`);
+      verifyCustomNodeRuntime(customNodePath, platform);
+      const stats = fs.statSync(customNodePath);
+      console.log(`Cached custom Node.js size: ${(stats.size / 1024 / 1024).toFixed(2)} MB`);
+
+      if (isCI) {
+        // Set outputs for GitHub Actions
+        setOutput('node-path', customNodePath);
+        setOutput('node-size', stats.size);
+        setOutput('cache-hit', 'true');
+      } else {
+        console.log(`\nTo use this custom Node.js with build-native.js:`);
+        console.log(`node build-native.js --custom-node="${customNodePath}"`);
+      }
+      return customNodePath;
+    }
+    console.log('Cached custom Node.js configuration changed; rebuilding.');
+    fs.rmSync(versionDir, { recursive: true, force: true });
   }
   
   // Create build directory
@@ -170,15 +233,7 @@ async function buildCustomNode() {
     process.chdir(versionDir);
     
     console.log('Configuring Node.js build...');
-    const configureArgs = [
-      '--without-intl',  // Remove internationalization support
-      '--without-npm',   // Don't include npm
-      '--without-corepack', // Don't include corepack
-      '--without-inspector', // Remove debugging/profiling features
-      '--without-node-code-cache', // Disable code cache
-      '--without-node-snapshot',  // Don't create/use startup snapshot
-      '--shared-zlib',     // Use system zlib instead of building custom
-    ];
+    const configureArgs = [...requiredConfigureArgs];
     
     // Check if ninja is available
     try {
@@ -228,24 +283,30 @@ async function buildCustomNode() {
     }
     
     // Test the binary
-    const version = execSync(`"${customNodePath}" --version`, { encoding: 'utf8' }).trim();
+    const version = verifyCustomNodeRuntime(customNodePath, platform);
     console.log(`Built Node.js version: ${version}`);
     
     // Strip the binary (different command for Linux vs macOS)
     console.log('Stripping Node.js binary...');
     const stripCmd = platform === 'darwin' ? 'strip -S' : 'strip -s';
     execSync(`${stripCmd} "${customNodePath}"`, { stdio: 'inherit' });
-    
+
     // Check final size
     const stats = fs.statSync(customNodePath);
     console.log(`\n✅ Custom Node.js built successfully!`);
     console.log(`Size: ${(stats.size / 1024 / 1024).toFixed(2)} MB`);
     
-    // Compare with system Node.js
+    // Homebrew can use a small launcher, so compare only monolithic Node.js binaries.
     try {
       const systemNodeStats = fs.statSync(process.execPath);
-      const reduction = ((systemNodeStats.size - stats.size) / systemNodeStats.size * 100).toFixed(1);
-      console.log(`Size reduction: ${reduction}% compared to system Node.js`);
+      if (systemNodeStats.size > stats.size) {
+        const reduction = (
+          (systemNodeStats.size - stats.size) /
+          systemNodeStats.size *
+          100
+        ).toFixed(1);
+        console.log(`Size reduction: ${reduction}% compared to system Node.js`);
+      }
     } catch (e) {
       // Ignore if we can't stat system node
     }
@@ -319,4 +380,4 @@ if (require.main === module) {
 }
 
 // Export for use as a module
-module.exports = { buildCustomNode };
+module.exports = { buildCustomNode, DEFAULT_NODE_VERSION };

--- a/web/build-native.js
+++ b/web/build-native.js
@@ -26,6 +26,7 @@
 const { execFileSync, execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const { createNativeRebuildEnv } = require('./scripts/native-rebuild-env.js');
 
 // Parse command line arguments
 const includeSourcemaps = process.argv.includes('--sourcemap');
@@ -198,40 +199,28 @@ async function main() {
       const customVersion = selectedNodeVersion;
       console.log(`Custom Node.js version: ${customVersion}`);
       
-      // Save original PATH and use clean environment
-      const originalPath = process.env.PATH;
-      const cleanEnv = {
-        ...process.env,
-        // Use only system paths to avoid Homebrew contamination
-        PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
-        npm_config_runtime: 'node',
-        npm_config_target: customVersion.substring(1), // Remove 'v' prefix
-        npm_config_arch: process.arch,
-        npm_config_target_arch: process.arch,
-        npm_config_disturl: 'https://nodejs.org/dist',
-        npm_config_build_from_source: 'true',
-        // Node.js 24 requires C++20
-        CXXFLAGS: '-std=c++20',
-        npm_config_cxxflags: '-std=c++20'
-      };
-      
-      // Remove any Homebrew-related environment variables
-      delete cleanEnv.LDFLAGS;
-      delete cleanEnv.LIBRARY_PATH;
-      delete cleanEnv.CPATH;
-      delete cleanEnv.C_INCLUDE_PATH;
-      delete cleanEnv.CPLUS_INCLUDE_PATH;
-      delete cleanEnv.PKG_CONFIG_PATH;
+      const cleanEnv = createNativeRebuildEnv(
+        process.env,
+        process.execPath,
+        customVersion,
+        process.arch
+      );
       
       console.log('Using clean PATH to avoid Homebrew dependencies during native module rebuild...');
-      
-      execSync(`pnpm rebuild node-pty authenticate-pam`, {
-        stdio: 'inherit',
-        env: cleanEnv
-      });
-      
-      // Restore original PATH
-      process.env.PATH = originalPath;
+
+      const pnpmCli = process.env.npm_execpath;
+      if (pnpmCli && fs.existsSync(pnpmCli)) {
+        execFileSync(process.execPath, [pnpmCli, 'rebuild', 'node-pty', 'authenticate-pam'], {
+          stdio: 'inherit',
+          env: cleanEnv
+        });
+      } else {
+        const pnpmExecutable = execSync('command -v pnpm', { encoding: 'utf8' }).trim();
+        execFileSync(pnpmExecutable, ['rebuild', 'node-pty', 'authenticate-pam'], {
+          stdio: 'inherit',
+          env: cleanEnv
+        });
+      }
     }
 
     // 2. Bundle TypeScript with esbuild
@@ -323,8 +312,10 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
     fs.writeFileSync('build/sea-config.json', JSON.stringify(seaConfig, null, 2));
 
     // 4. Generate SEA blob
-    console.log('Generating SEA blob...');
-    execSync('node --experimental-sea-config build/sea-config.json', { stdio: 'inherit' });
+    console.log(`Generating SEA blob with ${selectedNodeVersion}...`);
+    execFileSync(nodeExe, ['--experimental-sea-config', 'build/sea-config.json'], {
+      stdio: 'inherit'
+    });
 
     // 5. Create executable
     console.log('\nCreating executable...');
@@ -372,7 +363,9 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
     // Check final size
     const finalStats = fs.statSync(targetExe);
     console.log(`Final executable size: ${(finalStats.size / 1024 / 1024).toFixed(2)} MB`);
-    console.log(`Size reduction: ${((nodeStats.size - finalStats.size) / 1024 / 1024).toFixed(2)} MB`);
+    console.log(
+      `Embedded payload overhead: ${((finalStats.size - nodeStats.size) / 1024 / 1024).toFixed(2)} MB`
+    );
 
     // 9. Copy native modules
     console.log('\nCopying native modules...');
@@ -422,6 +415,17 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
       process.exit(1);
     }
 
+    const buildInfo = {
+      schemaVersion: 1,
+      customNode: Boolean(customNodePath),
+      nodeVersion: selectedNodeVersion,
+      nodeSize: nodeStats.size,
+      executableSize: finalStats.size,
+      platform: process.platform,
+      arch: process.arch
+    };
+    fs.writeFileSync('native/vibetunnel-build.json', `${JSON.stringify(buildInfo, null, 2)}\n`);
+
     console.log('\n✅ Build complete!');
     console.log(`\nPortable executable created in native/ directory:`);
     console.log(`  - vibetunnel (executable)`);
@@ -430,6 +434,7 @@ if (typeof process !== 'undefined' && process.versions && process.versions.node)
       console.log(`  - spawn-helper`);
     }
     console.log(`  - authenticate_pam.node`);
+    console.log(`  - vibetunnel-build.json`);
     console.log('\nAll files must be kept together in the same directory.');
     console.log('This bundle will work on any machine with the same OS/architecture.');
     

--- a/web/scripts/build.js
+++ b/web/scripts/build.js
@@ -1,9 +1,10 @@
-const { execSync } = require('child_process');
+const { execFileSync, execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const esbuild = require('esbuild');
 const { prodOptions } = require('./esbuild-config.js');
 const { buildCli } = require('./build-cli.js');
+const { getCustomNodeBuildArgs } = require('./custom-node-args.js');
 
 async function build() {
   console.log('Starting build process...');
@@ -96,15 +97,14 @@ async function build() {
     console.log('  - pty.node: ✓');
     console.log('  - spawn-helper: ✓');
   } else {
-    // Check for --custom-node flag
-    const useCustomNode = process.argv.includes('--custom-node');
+    const customNodeArgs = getCustomNodeBuildArgs(process.argv);
 
-    if (useCustomNode) {
+    if (customNodeArgs) {
       console.log('Using custom Node.js for smaller binary size...');
-      execSync('node build-native.js --custom-node', { stdio: 'inherit' });
+      execFileSync(process.execPath, ['build-native.js', ...customNodeArgs], { stdio: 'inherit' });
     } else {
       console.log('Using system Node.js...');
-      execSync('node build-native.js', { stdio: 'inherit' });
+      execFileSync(process.execPath, ['build-native.js'], { stdio: 'inherit' });
     }
   }
 

--- a/web/scripts/custom-node-args.js
+++ b/web/scripts/custom-node-args.js
@@ -1,0 +1,15 @@
+function getCustomNodeBuildArgs(argv) {
+  const index = argv.findIndex(arg => arg === '--custom-node' || arg.startsWith('--custom-node='));
+  if (index === -1) {
+    return null;
+  }
+
+  const argument = argv[index];
+  const separatePath = argv[index + 1];
+  if (argument === '--custom-node' && separatePath && !separatePath.startsWith('-')) {
+    return [argument, separatePath];
+  }
+  return [argument];
+}
+
+module.exports = { getCustomNodeBuildArgs };

--- a/web/scripts/native-rebuild-env.js
+++ b/web/scripts/native-rebuild-env.js
@@ -1,0 +1,40 @@
+const path = require('path');
+
+function createNativeRebuildEnv(sourceEnv, nodeExecutable, nodeVersion, arch) {
+  const toolDirs = [
+    sourceEnv.VIBETUNNEL_NODE_SHIM_DIR,
+    path.dirname(nodeExecutable),
+    '/usr/bin',
+    '/bin',
+    '/usr/sbin',
+    '/sbin',
+  ].filter(Boolean);
+
+  const cleanEnv = {
+    ...sourceEnv,
+    PATH: [...new Set(toolDirs)].join(':'),
+    npm_config_runtime: 'node',
+    npm_config_target: nodeVersion.replace(/^v/, ''),
+    npm_config_arch: arch,
+    npm_config_target_arch: arch,
+    npm_config_disturl: 'https://nodejs.org/dist',
+    npm_config_build_from_source: 'true',
+    CXXFLAGS: '-std=c++20',
+    npm_config_cxxflags: '-std=c++20',
+  };
+
+  for (const name of [
+    'LDFLAGS',
+    'LIBRARY_PATH',
+    'CPATH',
+    'C_INCLUDE_PATH',
+    'CPLUS_INCLUDE_PATH',
+    'PKG_CONFIG_PATH',
+  ]) {
+    delete cleanEnv[name];
+  }
+
+  return cleanEnv;
+}
+
+module.exports = { createNativeRebuildEnv };

--- a/web/src/test/unit/custom-node-args.test.ts
+++ b/web/src/test/unit/custom-node-args.test.ts
@@ -1,0 +1,21 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { getCustomNodeBuildArgs } = require('../../../scripts/custom-node-args.js');
+
+describe('custom Node build arguments', () => {
+  it('preserves explicit and automatic custom Node forms', () => {
+    expect(getCustomNodeBuildArgs(['node', 'build.js'])).toBeNull();
+    expect(getCustomNodeBuildArgs(['node', 'build.js', '--custom-node'])).toEqual([
+      '--custom-node',
+    ]);
+    expect(getCustomNodeBuildArgs(['node', 'build.js', '--custom-node=/tmp/node'])).toEqual([
+      '--custom-node=/tmp/node',
+    ]);
+    expect(getCustomNodeBuildArgs(['node', 'build.js', '--custom-node', '/tmp/node'])).toEqual([
+      '--custom-node',
+      '/tmp/node',
+    ]);
+  });
+});

--- a/web/src/test/unit/native-rebuild-env.test.ts
+++ b/web/src/test/unit/native-rebuild-env.test.ts
@@ -1,0 +1,38 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { createNativeRebuildEnv } = require('../../../scripts/native-rebuild-env.js');
+
+describe('native rebuild environment', () => {
+  it('keeps exact Node tools available without inheriting library search paths', () => {
+    const env = createNativeRebuildEnv(
+      {
+        PATH: '/opt/homebrew/bin:/usr/bin',
+        VIBETUNNEL_NODE_SHIM_DIR: '/tmp/node-shims',
+        LDFLAGS: '-L/opt/homebrew/lib',
+        CPATH: '/opt/homebrew/include',
+        PKG_CONFIG_PATH: '/opt/homebrew/lib/pkgconfig',
+      },
+      '/tmp/node/bin/node',
+      'v24.16.0',
+      'arm64'
+    );
+
+    expect(env.PATH.split(path.delimiter)).toEqual([
+      '/tmp/node-shims',
+      '/tmp/node/bin',
+      '/usr/bin',
+      '/bin',
+      '/usr/sbin',
+      '/sbin',
+    ]);
+    expect(env.npm_config_target).toBe('24.16.0');
+    expect(env.npm_config_arch).toBe('arm64');
+    expect(env.npm_config_target_arch).toBe('arm64');
+    expect(env.LDFLAGS).toBeUndefined();
+    expect(env.CPATH).toBeUndefined();
+    expect(env.PKG_CONFIG_PATH).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- force release builds to rebuild and attest the embedded server with the pinned custom Node runtime
- validate cached Node configuration, Unicode/runtime behavior, architecture dependencies, and exact runtime path
- generate SEA blobs with the embedded Node version and keep native rebuild tooling available without Homebrew library contamination
- update custom Node documentation and add focused policy/argument/environment regression tests

## Proof

- custom Node v24.16.0: 68.34 MB; final server: 71.72 MB
- direct Xcode web Release phase passed, including runtime launch and attestation
- unsigned arm64 macOS Release build passed; produced app: 120 MB
- embedded server reports Node v24.16.0 and links only system dylibs
- hostile `NODE_VERSION=1.2.3` still selected pinned v24.16.0
- 2 focused Vitest tests passed
- server/client/service-worker TypeScript passed
- Biome, JS/shell syntax, policy tests, and diff checks passed
- autoreview clean after accepted P2/P3 fixes

Fixes #271