### PR TITLE
feat: add Auggie CLI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### ✨ Improvements
+- Recognize Augment Code's Auggie CLI as an AI assistant, add it to default Quick Start commands, and document setup (requested by [@rishitank](https://github.com/rishitank)) (#526)
 - Expose a stable, labeled terminal input node for browser automation and accessibility tools (reported by [@bharath2020](https://github.com/bharath2020)) (#339)
 - Show line insertion and deletion counts alongside file changes in web session Git status badges (thanks [@abhinavgautam01](https://github.com/abhinavgautam01)) (#48)
 - Let mobile users reorder, hide, and choose layouts for terminal quick keys, with browser-local persistence and an unchanged default layout (via [@ndraiman](https://github.com/ndraiman)) (#564)

--- a/docs.json
+++ b/docs.json
@@ -144,6 +144,7 @@
             "pages": [
               "docs/claude",
               "CLAUDE",
+              "docs/auggie",
               "docs/gemini",
               "GEMINI",
               ".github/workflows/README.md"

--- a/docs/auggie.md
+++ b/docs/auggie.md
@@ -1,0 +1,50 @@
+# Auggie CLI
+
+VibeTunnel can monitor and control Augment Code's Auggie CLI like other terminal-based coding agents. Auggie sessions are recognized as AI assistant sessions in both the web dashboard and macOS menu, including the action that asks the agent to update its terminal title.
+
+## Install Auggie
+
+Auggie requires Node.js 20 or later. Install the CLI from npm:
+
+```bash
+npm install -g @augmentcode/auggie
+```
+
+Authenticate once:
+
+```bash
+auggie login
+```
+
+See Augment's [installation](https://docs.augmentcode.com/cli/setup-auggie/install-auggie-cli) and [authentication](https://docs.augmentcode.com/cli/setup-auggie/authentication) guides for current requirements.
+
+## Run with VibeTunnel
+
+Start an interactive Auggie session through the `vt` wrapper:
+
+```bash
+cd /path/to/project
+vt auggie
+```
+
+You can also pass an initial prompt:
+
+```bash
+vt auggie "Review the current changes"
+```
+
+The session then appears in VibeTunnel's web, macOS, and mobile clients. Terminal input, output, reconnection, and session controls work the same as for other interactive CLI tools.
+
+## Quick Start
+
+`auggie` is included in the default Quick Start command list. Existing customized lists are preserved; add `auggie` in **Settings > Quick Start** or reset the list to defaults to expose the button.
+
+## Terminal Titles
+
+For an active Auggie session, use the wand action in the web dashboard or macOS menu. VibeTunnel sends a prompt asking Auggie to run:
+
+```bash
+vt title "Brief description of current task"
+```
+
+This replaces a generic process name with the agent's current task in session lists.

--- a/mac/VibeTunnel/Core/Services/ConfigManager.swift
+++ b/mac/VibeTunnel/Core/Services/ConfigManager.swift
@@ -125,6 +125,7 @@ final class ConfigManager {
     private let defaultCommands = [
         QuickStartCommand(name: "✨ codex", command: "codex"),
         QuickStartCommand(name: "✨ claude", command: "claude"),
+        QuickStartCommand(name: "✨ auggie", command: "auggie"),
         QuickStartCommand(name: nil, command: "gemini3"),
         QuickStartCommand(name: nil, command: "opencode 4"),
         QuickStartCommand(name: nil, command: "zsh"),

--- a/mac/VibeTunnel/Presentation/Components/Menu/SessionRow.swift
+++ b/mac/VibeTunnel/Presentation/Components/Menu/SessionRow.swift
@@ -380,7 +380,7 @@ struct SessionRow: View {
 
     private var isAIAssistantSession: Bool {
         // Check if this is an AI assistant session by looking at the command
-        let aiAssistants = ["claude", "gemini", "openhands", "aider", "codex"]
+        let aiAssistants = ["claude", "gemini", "openhands", "aider", "codex", "auggie"]
         let cmd = self.commandName.lowercased()
 
         // Match exact executable names or at word boundaries

--- a/web/src/client/components/session-create-form.test.ts
+++ b/web/src/client/components/session-create-form.test.ts
@@ -156,7 +156,15 @@ describe('SessionCreateForm', () => {
 
       // The test environment may not render the buttons correctly due to lit-html issues
       // so we'll just verify the data structure exists
-      const expectedCommands = ['codex', 'claude', 'gemini3', 'opencode 4', 'zsh', 'node'];
+      const expectedCommands = [
+        'codex',
+        'claude',
+        'auggie',
+        'gemini3',
+        'opencode 4',
+        'zsh',
+        'node',
+      ];
       const actualCommands = element.quickStartCommands.map((item) => item.command);
 
       expectedCommands.forEach((cmd) => {

--- a/web/src/client/components/session-create-form.ts
+++ b/web/src/client/components/session-create-form.ts
@@ -99,6 +99,7 @@ export class SessionCreateForm extends LitElement {
   @state() private quickStartCommands: QuickStartItem[] = [
     { label: '✨ codex', command: 'codex' },
     { label: '✨ claude', command: 'claude' },
+    { label: '✨ auggie', command: 'auggie' },
     { label: 'gemini3', command: 'gemini3' },
     { label: 'opencode 4', command: 'opencode 4' },
     { label: 'zsh', command: 'zsh' },

--- a/web/src/client/utils/ai-sessions.test.ts
+++ b/web/src/client/utils/ai-sessions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { createTestSession } from '../../test/utils/test-factories';
+import { isAIAssistantSession } from './ai-sessions';
+
+describe('isAIAssistantSession', () => {
+  it('recognizes Auggie executables and wrappers', () => {
+    expect(isAIAssistantSession(createTestSession({ command: ['auggie'] }))).toBe(true);
+    expect(
+      isAIAssistantSession(createTestSession({ command: ['/usr/local/bin/auggie-wrapper'] }))
+    ).toBe(true);
+    expect(
+      isAIAssistantSession(createTestSession({ command: ['/bin/zsh', '-lc', 'auggie'] }))
+    ).toBe(true);
+  });
+
+  it('does not match unrelated commands containing the name', () => {
+    expect(isAIAssistantSession(createTestSession({ command: ['auggie-helper'] }))).toBe(false);
+  });
+});

--- a/web/src/client/utils/ai-sessions.ts
+++ b/web/src/client/utils/ai-sessions.ts
@@ -5,7 +5,7 @@ import { createLogger } from './logger.js';
 
 const logger = createLogger('ai-sessions');
 
-const AI_ASSISTANTS = ['claude', 'gemini', 'openhands', 'aider', 'codex'];
+const AI_ASSISTANTS = ['claude', 'gemini', 'openhands', 'aider', 'codex', 'auggie'];
 
 /**
  * Check if a session is an AI assistant based on command

--- a/web/src/types/config.ts
+++ b/web/src/types/config.ts
@@ -62,6 +62,7 @@ export interface VibeTunnelConfig {
 export const DEFAULT_QUICK_START_COMMANDS: QuickStartCommand[] = [
   { name: '✨ codex', command: 'codex' },
   { name: '✨ claude', command: 'claude' },
+  { name: '✨ auggie', command: 'auggie' },
   { command: 'gemini3' },
   { command: 'opencode 4' },
   { command: 'zsh' },


### PR DESCRIPTION
## Summary

- recognize Augment Code's Auggie CLI as an AI assistant in web and macOS session lists
- add Auggie to default Quick Start commands
- document installation, authentication, VibeTunnel usage, and terminal-title behavior

## Proof

- 56 focused client tests
- 32 server configuration tests
- client, server, and service-worker TypeScript checks
- Biome, SwiftFormat, SwiftLint, docs JSON, and diff checks
- unsigned arm64 Debug macOS build with repository-supported Zig 0.15.2
- autoreview clean with no accepted/actionable findings

Fixes #526