### PR TITLE
feat: add Pinggy remote access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### ✨ Improvements
+- Add Pinggy CLI integration for public remote access, including optional Keychain token storage for persistent URLs (requested by [@empz](https://github.com/empz)) (#505)
 - Recognize Augment Code's Auggie CLI as an AI assistant, add it to default Quick Start commands, and document setup (requested by [@rishitank](https://github.com/rishitank)) (#526)
 - Expose a stable, labeled terminal input node for browser automation and accessibility tools (reported by [@bharath2020](https://github.com/bharath2020)) (#339)
 - Show line insertion and deletion counts alongside file changes in web session Git status badges (thanks [@abhinavgautam01](https://github.com/abhinavgautam01)) (#48)

--- a/README.md
+++ b/README.md
@@ -291,6 +291,14 @@ Both Private and Public modes automatically provide **HTTPS access**:
 2. Run `cloudflared tunnel --url http://localhost:4020`
 3. Access via the generated `*.trycloudflare.com` URL
 
+### Option 5: Pinggy
+1. Install the [Pinggy CLI](https://pinggy.io/docs/cli/): `npm install -g pinggy`
+2. Open VibeTunnel Settings → Remote → Pinggy Integration
+3. Optionally save a Pinggy access token for a persistent subdomain or custom domain
+4. Enable the tunnel and open the displayed public HTTPS URL
+
+Free tunnels use a new URL after reconnecting. A persistent subdomain or custom domain requires a Pinggy plan that supports it and must be assigned to the saved token in the [Pinggy dashboard](https://dashboard.pinggy.io/domains).
+
 ## Git Follow Mode
 
 Git Follow Mode keeps your main repository checkout synchronized with the branch you're working on in a Git worktree. This allows agents to work in worktrees while your IDE, server, and other tools stay open on the main repository - they'll automatically update when the worktree switches branches.

--- a/mac/VibeTunnel/Core/Constants/KeychainConstants.swift
+++ b/mac/VibeTunnel/Core/Constants/KeychainConstants.swift
@@ -9,6 +9,7 @@ enum KeychainConstants {
     // MARK: - Account Names
 
     static let ngrokAuthToken = "ngrokAuthToken"
+    static let pinggyAccessToken = "pinggy-access-token"
     static let authToken = "authToken"
     static let dashboardPassword = "dashboard-password"
 }

--- a/mac/VibeTunnel/Core/Constants/URLConstants.swift
+++ b/mac/VibeTunnel/Core/Constants/URLConstants.swift
@@ -35,6 +35,11 @@ enum URLConstants {
     static let cloudflareDocs =
         "https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/"
 
+    // MARK: - Pinggy
+
+    static let pinggyDocs = "https://pinggy.io/docs/cli/"
+    static let pinggyDashboard = "https://dashboard.pinggy.io/domains"
+
     // MARK: - Update Feed
 
     static let updateFeedStable = "https://stats.store/api/v1/appcast/appcast.xml"

--- a/mac/VibeTunnel/Core/Extensions/EnvironmentValues+Services.swift
+++ b/mac/VibeTunnel/Core/Extensions/EnvironmentValues+Services.swift
@@ -5,15 +5,17 @@ import SwiftUI
 extension EnvironmentValues {
     @Entry var serverManager: ServerManager?
 
-    @Entry var ngrokService: NgrokService? = nil
+    @Entry var ngrokService: NgrokService?
 
     @Entry var systemPermissionManager: SystemPermissionManager?
 
-    @Entry var terminalLauncher: TerminalLauncher? = nil
+    @Entry var terminalLauncher: TerminalLauncher?
 
     @Entry var tailscaleService: TailscaleService?
 
-    @Entry var cloudflareService: CloudflareService? = nil
+    @Entry var cloudflareService: CloudflareService?
+
+    @Entry var pinggyService: PinggyService?
 }
 
 // MARK: - View Extensions
@@ -27,7 +29,8 @@ extension View {
         systemPermissionManager: SystemPermissionManager? = nil,
         terminalLauncher: TerminalLauncher? = nil,
         tailscaleService: TailscaleService? = nil,
-        cloudflareService: CloudflareService? = nil)
+        cloudflareService: CloudflareService? = nil,
+        pinggyService: PinggyService? = nil)
         -> some View
     {
         self
@@ -39,5 +42,6 @@ extension View {
             .environment(\.terminalLauncher, terminalLauncher ?? TerminalLauncher.shared)
             .environment(\.tailscaleService, tailscaleService ?? TailscaleService.shared)
             .environment(\.cloudflareService, cloudflareService ?? CloudflareService.shared)
+            .environment(\.pinggyService, pinggyService ?? PinggyService.shared)
     }
 }

--- a/mac/VibeTunnel/Core/Services/PinggyService.swift
+++ b/mac/VibeTunnel/Core/Services/PinggyService.swift
@@ -1,0 +1,422 @@
+import AppKit
+import Foundation
+import Observation
+import os
+
+enum PinggyError: LocalizedError, Equatable {
+    case notInstalled
+    case tunnelAlreadyRunning
+    case tunnelCreationFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notInstalled:
+            "pinggy is not installed"
+        case .tunnelAlreadyRunning:
+            "A Pinggy tunnel is already running"
+        case let .tunnelCreationFailed(message):
+            "Failed to create Pinggy tunnel: \(message)"
+        }
+    }
+}
+
+/// Manages a Pinggy CLI process that exposes the local VibeTunnel dashboard.
+@Observable
+@MainActor
+final class PinggyService {
+    static let shared = PinggyService()
+    static var isTestMode = false
+
+    static var pinggySearchPaths: [String] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return [
+            "\(FilePathConstants.optHomebrewBin)/pinggy",
+            "\(FilePathConstants.usrLocalBin)/pinggy",
+            "\(FilePathConstants.usrBin)/pinggy",
+            "/etc/profiles/per-user/\(NSUserName())/bin/pinggy",
+            "\(home)/.local/bin/pinggy",
+            "\(home)/.npm-global/bin/pinggy",
+        ]
+    }
+
+    private(set) var isInstalled = false
+    private(set) var isRunning = false
+    private(set) var publicUrl: String?
+    private(set) var statusError: String?
+    private(set) var pinggyPath: String?
+
+    var accessToken: String? {
+        PinggyKeychain.getToken()
+    }
+
+    var hasAccessToken: Bool {
+        PinggyKeychain.hasToken()
+    }
+
+    private var pinggyProcess: Process?
+    private var outputHandles: [FileHandle] = []
+    private var outputBuffer = ""
+    private var isStopping = false
+    private var tokenConfigURL: URL?
+    private var tokenConfigCleanupTask: Task<Void, Never>?
+
+    private let logger = Logger(subsystem: BundleIdentifiers.main, category: "PinggyService")
+
+    private init() {
+        _ = self.checkCLIInstallation()
+    }
+
+    @discardableResult
+    func checkCLIInstallation() -> Bool {
+        for path in Self.pinggySearchPaths where FileManager.default.isExecutableFile(atPath: path) {
+            self.pinggyPath = path
+            self.isInstalled = true
+            return true
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: FilePathConstants.which)
+        process.arguments = ["pinggy"]
+
+        var environment = ProcessInfo.processInfo.environment
+        let currentPath = environment[EnvironmentKeys.path] ?? "\(FilePathConstants.usrBin):\(FilePathConstants.bin)"
+        let extraPaths = Self.pinggySearchPaths
+            .map { URL(fileURLWithPath: $0).deletingLastPathComponent().path }
+            .joined(separator: ":")
+        environment[EnvironmentKeys.path] = "\(extraPaths):\(currentPath)"
+        process.environment = environment
+
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let data = try outputPipe.fileHandleForReading.readToEnd() ?? Data()
+            let path = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if process.terminationStatus == 0,
+               let path,
+               !path.isEmpty,
+               FileManager.default.isExecutableFile(atPath: path)
+            {
+                self.pinggyPath = path
+                self.isInstalled = true
+                return true
+            }
+        } catch {
+            self.logger.debug("Failed to locate pinggy with which: \(error.localizedDescription)")
+        }
+
+        self.pinggyPath = nil
+        self.isInstalled = false
+        return false
+    }
+
+    @discardableResult
+    func saveAccessToken(_ token: String) -> Bool {
+        PinggyKeychain.setToken(token)
+    }
+
+    func deleteAccessToken() {
+        PinggyKeychain.deleteToken()
+    }
+
+    func startTunnel(port: Int) async throws {
+        guard self.checkCLIInstallation(), let binaryPath = pinggyPath else {
+            throw PinggyError.notInstalled
+        }
+        guard !self.isRunning else {
+            throw PinggyError.tunnelAlreadyRunning
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binaryPath)
+
+        do {
+            self.tokenConfigURL = try Self.createTemporaryTokenConfig(token: self.accessToken)
+        } catch {
+            throw PinggyError.tunnelCreationFailed("Could not prepare access token: \(error.localizedDescription)")
+        }
+        process.arguments = Self.startArguments(port: port, configPath: self.tokenConfigURL?.path)
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        process.terminationHandler = { [weak self] terminatedProcess in
+            Task { @MainActor in
+                guard let self, self.pinggyProcess === terminatedProcess else { return }
+                let stoppedIntentionally = self.isStopping
+                self.clearProcessState()
+                if !stoppedIntentionally, terminatedProcess.terminationStatus != 0 {
+                    self.statusError = "Pinggy exited with status \(terminatedProcess.terminationStatus)"
+                }
+            }
+        }
+
+        do {
+            self.isStopping = false
+            self.pinggyProcess = process
+            try process.run()
+            guard process.isRunning else {
+                let status = process.terminationStatus
+                self.clearProcessState()
+                throw PinggyError.tunnelCreationFailed("Pinggy exited with status \(status)")
+            }
+            self.isRunning = true
+            self.publicUrl = nil
+            self.statusError = nil
+            self.startOutputMonitoring(outputPipe: outputPipe, errorPipe: errorPipe)
+            self.scheduleTokenConfigCleanup()
+            self.logger.info("Started Pinggy tunnel on port \(port)")
+        } catch {
+            self.clearProcessState()
+            if let pinggyError = error as? PinggyError {
+                throw pinggyError
+            }
+            throw PinggyError.tunnelCreationFailed(error.localizedDescription)
+        }
+    }
+
+    func stopTunnel() async {
+        guard let process = pinggyProcess else {
+            self.clearProcessState()
+            return
+        }
+
+        self.isStopping = true
+        process.terminate()
+
+        for _ in 0..<20 where process.isRunning {
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+
+        self.clearProcessState()
+        self.logger.info("Stopped Pinggy tunnel")
+    }
+
+    /// Fast app-termination path. Pinggy handles SIGTERM by stopping its foreground tunnel.
+    func sendTerminationSignal() {
+        self.isStopping = true
+        self.pinggyProcess?.terminate()
+        self.clearProcessState()
+    }
+
+    func copyInstallCommand() {
+        guard !Self.isTestMode else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("npm install -g pinggy", forType: .string)
+    }
+
+    func openSetupGuide() {
+        guard !Self.isTestMode, let url = URL(string: URLConstants.pinggyDocs) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    func openDashboard() {
+        guard !Self.isTestMode, let url = URL(string: URLConstants.pinggyDashboard) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    nonisolated static func extractPublicURL(from output: String) -> String? {
+        guard let detector = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else {
+            return nil
+        }
+
+        let range = NSRange(output.startIndex..., in: output)
+        let ignoredHosts = ["pinggy.io", "dashboard.pinggy.io", "npmjs.com", "www.npmjs.com"]
+
+        return detector
+            .matches(in: output, options: [], range: range)
+            .compactMap(\.url)
+            .first { url in
+                guard url.scheme == "https", let host = url.host?.lowercased() else { return false }
+                return !ignoredHosts.contains(host) && !host.hasSuffix(".pinggy.io")
+            }?
+            .absoluteString
+    }
+
+    nonisolated static func startArguments(port: Int, configPath: String?) -> [String] {
+        var arguments = ["--noTui", "-l", "http://localhost:\(port)"]
+        if let configPath, !configPath.isEmpty {
+            arguments.append(contentsOf: ["--conf", configPath])
+        }
+        return arguments
+    }
+
+    nonisolated static func createTemporaryTokenConfig(token: String?) throws -> URL? {
+        guard let token = token?.trimmingCharacters(in: .whitespacesAndNewlines), !token.isEmpty else {
+            return nil
+        }
+
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeTunnel", isDirectory: true)
+            .appendingPathComponent("Pinggy", isDirectory: true)
+        try fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+
+        let configURL = directory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("json")
+        let data = try JSONSerialization.data(withJSONObject: ["token": token])
+        guard fileManager.createFile(
+            atPath: configURL.path,
+            contents: data,
+            attributes: [.posixPermissions: 0o600])
+        else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        return configURL
+    }
+
+    private func startOutputMonitoring(outputPipe: Pipe, errorPipe: Pipe) {
+        self.clearOutputHandlers()
+
+        let handles = [outputPipe.fileHandleForReading, errorPipe.fileHandleForReading]
+        self.outputHandles = handles
+
+        for handle in handles {
+            handle.readabilityHandler = { [weak self] readableHandle in
+                let data = readableHandle.availableData
+                guard !data.isEmpty else {
+                    readableHandle.readabilityHandler = nil
+                    return
+                }
+                guard let output = String(data: data, encoding: .utf8) else { return }
+
+                Task { @MainActor in
+                    self?.processOutput(output)
+                }
+            }
+        }
+    }
+
+    private func processOutput(_ output: String) {
+        guard self.isRunning else { return }
+
+        self.clearTemporaryTokenConfig()
+        self.outputBuffer.append(output)
+        if self.outputBuffer.count > 32768 {
+            self.outputBuffer = String(self.outputBuffer.suffix(32768))
+        }
+
+        if let url = Self.extractPublicURL(from: self.outputBuffer) {
+            self.publicUrl = url
+            self.statusError = nil
+            self.logger.info("Pinggy public URL: \(url)")
+        }
+    }
+
+    private func clearOutputHandlers() {
+        for handle in self.outputHandles {
+            handle.readabilityHandler = nil
+        }
+        self.outputHandles.removeAll()
+    }
+
+    private func scheduleTokenConfigCleanup() {
+        guard let tokenConfigURL else { return }
+
+        self.tokenConfigCleanupTask?.cancel()
+        self.tokenConfigCleanupTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled else { return }
+            self?.clearTemporaryTokenConfig(ifMatching: tokenConfigURL)
+        }
+    }
+
+    private func clearTemporaryTokenConfig(ifMatching expectedURL: URL? = nil) {
+        guard expectedURL == nil || self.tokenConfigURL == expectedURL else { return }
+
+        self.tokenConfigCleanupTask?.cancel()
+        self.tokenConfigCleanupTask = nil
+        if let tokenConfigURL {
+            try? FileManager.default.removeItem(at: tokenConfigURL)
+        }
+        self.tokenConfigURL = nil
+    }
+
+    private func clearProcessState() {
+        self.clearOutputHandlers()
+        self.clearTemporaryTokenConfig()
+        self.pinggyProcess = nil
+        self.isRunning = false
+        self.publicUrl = nil
+        self.statusError = nil
+        self.outputBuffer = ""
+        self.isStopping = false
+    }
+}
+
+private enum PinggyKeychain {
+    private static let service = KeychainConstants.vibeTunnelService
+    private static let account = KeychainConstants.pinggyAccessToken
+
+    static func getToken() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: self.service,
+            kSecAttrAccount as String: self.account,
+            kSecReturnData as String: true,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess,
+              let data = result as? Data
+        else {
+            return nil
+        }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func hasToken() -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: self.service,
+            kSecAttrAccount as String: self.account,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+            kSecReturnData as String: false,
+        ]
+
+        var result: AnyObject?
+        return SecItemCopyMatching(query as CFDictionary, &result) == errSecSuccess
+    }
+
+    @discardableResult
+    static func setToken(_ token: String) -> Bool {
+        guard let data = token.data(using: .utf8) else { return false }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: self.service,
+            kSecAttrAccount as String: self.account,
+        ]
+        let update = [kSecValueData as String: data]
+        var status = SecItemUpdate(query as CFDictionary, update as CFDictionary)
+
+        if status == errSecItemNotFound {
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            status = SecItemAdd(addQuery as CFDictionary, nil)
+        }
+        return status == errSecSuccess
+    }
+
+    static func deleteToken() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: self.service,
+            kSecAttrAccount as String: self.account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/mac/VibeTunnel/Presentation/Views/Settings/PinggyIntegrationSection.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/PinggyIntegrationSection.swift
@@ -1,0 +1,224 @@
+import SwiftUI
+
+struct PinggyIntegrationSection: View {
+    let pinggyService: PinggyService
+    let serverPort: String
+
+    @State private var tunnelEnabled = false
+    @State private var isTogglingTunnel = false
+    @State private var tokenInput = ""
+    @State private var tokenStored = false
+    @State private var isEditingToken = false
+    @State private var tokenError: String?
+    @State private var tunnelError: String?
+
+    var body: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Image(systemName: "circle.fill")
+                        .foregroundColor(self.statusColor)
+                        .font(.system(size: 10))
+                    Text(self.statusText)
+                        .font(.callout)
+                    Spacer()
+                }
+
+                if !self.pinggyService.isInstalled {
+                    HStack(spacing: 12) {
+                        Button("Copy Install Command") {
+                            self.pinggyService.copyInstallCommand()
+                        }
+                        .buttonStyle(.link)
+                        .controlSize(.small)
+
+                        Button("Setup Guide") {
+                            self.pinggyService.openSetupGuide()
+                        }
+                        .buttonStyle(.link)
+                        .controlSize(.small)
+                    }
+                } else {
+                    HStack {
+                        Toggle("Enable Pinggy tunnel", isOn: self.$tunnelEnabled)
+                            .disabled(self.isTogglingTunnel)
+                            .onChange(of: self.tunnelEnabled) { _, enabled in
+                                if enabled {
+                                    self.startTunnel()
+                                } else {
+                                    self.stopTunnel()
+                                }
+                            }
+
+                        if self.isTogglingTunnel {
+                            ProgressView()
+                                .scaleEffect(0.7)
+                        } else if self.pinggyService.isRunning {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(.green)
+                            Text("Connected")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+
+                    self.tokenControls
+
+                    if let publicUrl = pinggyService.publicUrl {
+                        ClickableURLView(label: "Public URL:", url: publicUrl)
+                    }
+
+                    if let error = pinggyService.statusError {
+                        self.errorView(error)
+                    }
+                    if let tunnelError {
+                        self.errorView(tunnelError)
+                    }
+                    if let tokenError {
+                        self.errorView(tokenError)
+                    }
+
+                    HStack {
+                        Image(systemName: "link")
+                        Button("Configure persistent URL") {
+                            self.pinggyService.openDashboard()
+                        }
+                        .buttonStyle(.link)
+                        .font(.caption)
+                    }
+                }
+            }
+        } header: {
+            Text("Pinggy Integration")
+                .font(.headline)
+        } footer: {
+            Text(
+                "Pinggy creates a public HTTPS tunnel. An access token is optional; assign a persistent subdomain or custom domain to the token in Pinggy for a fixed URL.")
+                .font(.caption)
+                .frame(maxWidth: .infinity)
+                .multilineTextAlignment(.center)
+        }
+        .task {
+            _ = self.pinggyService.checkCLIInstallation()
+            self.tokenStored = self.pinggyService.hasAccessToken
+            self.tunnelEnabled = self.pinggyService.isRunning
+        }
+        .onChange(of: self.pinggyService.isRunning) { _, isRunning in
+            self.tunnelEnabled = isRunning
+        }
+    }
+
+    @ViewBuilder
+    private var tokenControls: some View {
+        if self.tokenStored, !self.isEditingToken {
+            HStack {
+                Label("Access token saved", systemImage: "key.fill")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Spacer()
+                Button("Replace") {
+                    self.tokenInput = ""
+                    self.isEditingToken = true
+                }
+                .controlSize(.small)
+                Button("Remove") {
+                    self.pinggyService.deleteAccessToken()
+                    self.tokenStored = false
+                    self.tokenInput = ""
+                    self.tokenError = nil
+                }
+                .controlSize(.small)
+            }
+        } else {
+            HStack {
+                SecureField("Access token (optional)", text: self.$tokenInput)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit {
+                        self.saveToken()
+                    }
+
+                Button("Save") {
+                    self.saveToken()
+                }
+                .disabled(self.tokenInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .controlSize(.small)
+
+                if self.isEditingToken {
+                    Button("Cancel") {
+                        self.isEditingToken = false
+                        self.tokenInput = ""
+                        self.tokenError = nil
+                    }
+                    .controlSize(.small)
+                }
+            }
+        }
+    }
+
+    private var statusColor: Color {
+        if !self.pinggyService.isInstalled {
+            return .yellow
+        }
+        return self.pinggyService.isRunning ? .green : .orange
+    }
+
+    private var statusText: String {
+        if !self.pinggyService.isInstalled {
+            return "pinggy is not installed"
+        }
+        return self.pinggyService.isRunning ? "Pinggy tunnel is running" : "pinggy is installed"
+    }
+
+    private func saveToken() {
+        let token = self.tokenInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !token.isEmpty else { return }
+
+        if self.pinggyService.saveAccessToken(token) {
+            self.tokenStored = true
+            self.isEditingToken = false
+            self.tokenInput = ""
+            self.tokenError = nil
+        } else {
+            self.tokenError = "Failed to save Pinggy access token to Keychain"
+        }
+    }
+
+    private func startTunnel() {
+        guard !self.isTogglingTunnel else { return }
+        self.isTogglingTunnel = true
+        self.tunnelError = nil
+
+        Task {
+            defer { self.isTogglingTunnel = false }
+            do {
+                try await self.pinggyService.startTunnel(port: Int(self.serverPort) ?? 4020)
+                self.tunnelEnabled = self.pinggyService.isRunning
+            } catch {
+                self.tunnelEnabled = false
+                self.tunnelError = error.localizedDescription
+            }
+        }
+    }
+
+    private func stopTunnel() {
+        guard !self.isTogglingTunnel else { return }
+        self.isTogglingTunnel = true
+
+        Task {
+            await self.pinggyService.stopTunnel()
+            self.tunnelEnabled = false
+            self.isTogglingTunnel = false
+        }
+    }
+
+    private func errorView(_ error: String) -> some View {
+        HStack {
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundColor(.red)
+            Text(error)
+                .font(.caption)
+                .foregroundColor(.red)
+                .lineLimit(2)
+        }
+    }
+}

--- a/mac/VibeTunnel/Presentation/Views/Settings/RemoteAccessSettingsView.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/RemoteAccessSettingsView.swift
@@ -23,6 +23,8 @@ struct RemoteAccessSettingsView: View {
     private var tailscaleService
     @Environment(CloudflareService.self)
     private var cloudflareService
+    @Environment(PinggyService.self)
+    private var pinggyService
     @Environment(TailscaleServeStatusService.self)
     private var tailscaleServeStatus
     @Environment(ServerManager.self)
@@ -66,6 +68,10 @@ struct RemoteAccessSettingsView: View {
                     cloudflareService: self.cloudflareService,
                     serverPort: self.serverPort,
                     accessMode: self.accessMode)
+
+                PinggyIntegrationSection(
+                    pinggyService: self.pinggyService,
+                    serverPort: self.serverPort)
 
                 NgrokIntegrationSection(
                     ngrokEnabled: self.$ngrokEnabled,

--- a/mac/VibeTunnel/VibeTunnelApp.swift
+++ b/mac/VibeTunnel/VibeTunnelApp.swift
@@ -20,6 +20,7 @@ struct VibeTunnelApp: App {
     @State var ngrokService = NgrokService.shared
     @State var tailscaleService = TailscaleService.shared
     @State var cloudflareService = CloudflareService.shared
+    @State var pinggyService = PinggyService.shared
     @State var permissionManager = SystemPermissionManager.shared
     @State var terminalLauncher = TerminalLauncher.shared
     @State var gitRepositoryMonitor = GitRepositoryMonitor()
@@ -53,6 +54,7 @@ struct VibeTunnelApp: App {
                 .environment(self.ngrokService)
                 .environment(self.tailscaleService)
                 .environment(self.cloudflareService)
+                .environment(self.pinggyService)
                 .environment(self.permissionManager)
                 .environment(self.terminalLauncher)
                 .environment(self.gitRepositoryMonitor)
@@ -76,6 +78,7 @@ struct VibeTunnelApp: App {
                     .environment(self.ngrokService)
                     .environment(self.tailscaleService)
                     .environment(self.cloudflareService)
+                    .environment(self.pinggyService)
                     .environment(self.permissionManager)
                     .environment(self.terminalLauncher)
                     .environment(self.gitRepositoryMonitor)
@@ -102,6 +105,7 @@ struct VibeTunnelApp: App {
                 .environment(self.ngrokService)
                 .environment(self.tailscaleService)
                 .environment(self.cloudflareService)
+                .environment(self.pinggyService)
                 .environment(self.permissionManager)
                 .environment(self.terminalLauncher)
                 .environment(self.gitRepositoryMonitor)
@@ -441,6 +445,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let cloudflareService = app?.cloudflareService, cloudflareService.isRunning {
             self.logger.info("🔥 Sending quick termination signal to Cloudflare")
             cloudflareService.sendTerminationSignal()
+        }
+
+        if let pinggyService = app?.pinggyService, pinggyService.isRunning {
+            self.logger.info("Sending quick termination signal to Pinggy")
+            pinggyService.sendTerminationSignal()
         }
 
         // Stop HTTP server with very short timeout

--- a/mac/VibeTunnelTests/PinggyServiceTests.swift
+++ b/mac/VibeTunnelTests/PinggyServiceTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+@testable import VibeTunnel
+
+@Suite("Pinggy Service Tests", .tags(.networking))
+struct PinggyServiceTests {
+    @Test
+    @MainActor
+    func singletonInstance() {
+        #expect(PinggyService.shared === PinggyService.shared)
+    }
+
+    @Test
+    @MainActor
+    func searchPathsCoverCommonInstallLocations() {
+        #expect(PinggyService.pinggySearchPaths.contains("/opt/homebrew/bin/pinggy"))
+        #expect(PinggyService.pinggySearchPaths.contains("/usr/local/bin/pinggy"))
+        #expect(PinggyService.pinggySearchPaths.contains("/etc/profiles/per-user/\(NSUserName())/bin/pinggy"))
+    }
+
+    @Test
+    func startArgumentsWithoutToken() {
+        #expect(PinggyService.startArguments(port: 4020, configPath: nil) == [
+            "--noTui",
+            "-l",
+            "http://localhost:4020",
+        ])
+    }
+
+    @Test
+    func startArgumentsWithTokenConfig() {
+        #expect(PinggyService.startArguments(port: 4021, configPath: "/tmp/token.json") == [
+            "--noTui",
+            "-l",
+            "http://localhost:4021",
+            "--conf",
+            "/tmp/token.json",
+        ])
+    }
+
+    @Test
+    func createsProtectedTemporaryTokenConfig() throws {
+        let createdConfigURL = try PinggyService.createTemporaryTokenConfig(token: " token123 ")
+        let configURL = try #require(createdConfigURL)
+        defer { try? FileManager.default.removeItem(at: configURL) }
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: configURL.path)
+        #expect(attributes[.posixPermissions] as? Int == 0o600)
+
+        let data = try Data(contentsOf: configURL)
+        let config = try #require(JSONSerialization.jsonObject(with: data) as? [String: String])
+        #expect(config == ["token": "token123"])
+
+        let arguments = PinggyService.startArguments(port: 4020, configPath: configURL.path)
+        #expect(!arguments.contains("token123"))
+    }
+
+    @Test
+    func extractsPinggyAndCustomPublicURLs() {
+        #expect(PinggyService.extractPublicURL(from: "  https://demo.a.pinggy.link\n") ==
+            "https://demo.a.pinggy.link")
+        #expect(PinggyService.extractPublicURL(from: "Remote URLs: https://terminal.example.com") ==
+            "https://terminal.example.com")
+    }
+
+    @Test
+    func ignoresControlAndDocumentationURLs() {
+        #expect(PinggyService.extractPublicURL(from: "Visit https://dashboard.pinggy.io") == nil)
+        #expect(PinggyService.extractPublicURL(from: "Server https://pro.pinggy.io") == nil)
+        #expect(PinggyService.extractPublicURL(from: "No public URL yet") == nil)
+    }
+
+    @Test
+    func errorDescriptions() {
+        let errors: [PinggyError] = [
+            .notInstalled,
+            .tunnelAlreadyRunning,
+            .tunnelCreationFailed("test"),
+        ]
+        for error in errors {
+            #expect(error.errorDescription?.isEmpty == false)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Pinggy CLI discovery, tunnel lifecycle, HTTPS URL extraction, and app-termination cleanup
- add Remote settings controls with optional Keychain token storage and persistent URL guidance
- pass tokens through a protected temporary config instead of process arguments
- document setup and add focused regression tests

## Proof
- 8 focused `PinggyServiceTests` passed
- unsigned arm64 Debug app build passed with Zig 0.15.2
- SwiftFormat, strict SwiftLint, and `git diff --check` passed
- debug Remote settings verified through Peekaboo/Accessibility
- autoreview clean after fixing token exposure and immediate-exit lifecycle findings

No live tunnel was opened during validation because that would expose the local service publicly.

Fixes #505