### PR TITLE
feat: add Pangolin remote access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### ✨ Improvements
+- Add Pangolin Newt integration for managed remote access from the Mac app (#315)
 - Add Pinggy CLI integration for public remote access, including optional Keychain token storage for persistent URLs (requested by [@empz](https://github.com/empz)) (#505)
 - Recognize Augment Code's Auggie CLI as an AI assistant, add it to default Quick Start commands, and document setup (requested by [@rishitank](https://github.com/rishitank)) (#526)
 - Expose a stable, labeled terminal input node for browser automation and accessibility tools (reported by [@bharath2020](https://github.com/bharath2020)) (#339)

--- a/README.md
+++ b/README.md
@@ -299,6 +299,15 @@ Both Private and Public modes automatically provide **HTTPS access**:
 
 Free tunnels use a new URL after reconnecting. A persistent subdomain or custom domain requires a Pinggy plan that supports it and must be assigned to the saved token in the [Pinggy dashboard](https://dashboard.pinggy.io/domains).
 
+### Option 6: Pangolin
+1. Create a Site in [Pangolin](https://app.pangolin.net) and copy its Newt endpoint, ID, and secret
+2. Install [Newt](https://docs.pangolin.net/manage/sites/install-site): `curl -fsSL https://static.pangolin.net/get-newt.sh | bash`
+3. Open VibeTunnel Settings → Remote → Pangolin Integration and save the site credentials
+4. In Pangolin, create a public Resource targeting `http://localhost:4020`
+5. Connect the site in VibeTunnel and use the Resource URL configured by Pangolin
+
+VibeTunnel stores the Newt site credentials in Keychain and starts Newt with a protected temporary config file, keeping the secret out of process arguments and environment variables.
+
 ## Git Follow Mode
 
 Git Follow Mode keeps your main repository checkout synchronized with the branch you're working on in a Git worktree. This allows agents to work in worktrees while your IDE, server, and other tools stay open on the main repository - they'll automatically update when the worktree switches branches.

--- a/mac/VibeTunnel/Core/Constants/KeychainConstants.swift
+++ b/mac/VibeTunnel/Core/Constants/KeychainConstants.swift
@@ -10,6 +10,7 @@ enum KeychainConstants {
 
     static let ngrokAuthToken = "ngrokAuthToken"
     static let pinggyAccessToken = "pinggy-access-token"
+    static let pangolinSiteCredentials = "pangolin-site-credentials"
     static let authToken = "authToken"
     static let dashboardPassword = "dashboard-password"
 }

--- a/mac/VibeTunnel/Core/Constants/URLConstants.swift
+++ b/mac/VibeTunnel/Core/Constants/URLConstants.swift
@@ -40,6 +40,11 @@ enum URLConstants {
     static let pinggyDocs = "https://pinggy.io/docs/cli/"
     static let pinggyDashboard = "https://dashboard.pinggy.io/domains"
 
+    // MARK: - Pangolin
+
+    static let pangolinDocs = "https://docs.pangolin.net/manage/sites/install-site"
+    static let pangolinCloud = "https://app.pangolin.net"
+
     // MARK: - Update Feed
 
     static let updateFeedStable = "https://stats.store/api/v1/appcast/appcast.xml"

--- a/mac/VibeTunnel/Core/Extensions/EnvironmentValues+Services.swift
+++ b/mac/VibeTunnel/Core/Extensions/EnvironmentValues+Services.swift
@@ -16,6 +16,8 @@ extension EnvironmentValues {
     @Entry var cloudflareService: CloudflareService?
 
     @Entry var pinggyService: PinggyService?
+
+    @Entry var pangolinService: PangolinService?
 }
 
 // MARK: - View Extensions
@@ -30,7 +32,8 @@ extension View {
         terminalLauncher: TerminalLauncher? = nil,
         tailscaleService: TailscaleService? = nil,
         cloudflareService: CloudflareService? = nil,
-        pinggyService: PinggyService? = nil)
+        pinggyService: PinggyService? = nil,
+        pangolinService: PangolinService? = nil)
         -> some View
     {
         self
@@ -43,5 +46,6 @@ extension View {
             .environment(\.tailscaleService, tailscaleService ?? TailscaleService.shared)
             .environment(\.cloudflareService, cloudflareService ?? CloudflareService.shared)
             .environment(\.pinggyService, pinggyService ?? PinggyService.shared)
+            .environment(\.pangolinService, pangolinService ?? PangolinService.shared)
     }
 }

--- a/mac/VibeTunnel/Core/Services/PangolinService.swift
+++ b/mac/VibeTunnel/Core/Services/PangolinService.swift
@@ -1,0 +1,447 @@
+import AppKit
+import Foundation
+import Observation
+import os
+
+enum PangolinError: LocalizedError, Equatable {
+    case notInstalled
+    case credentialsMissing
+    case alreadyRunning
+    case connectionFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .notInstalled:
+            "Newt is not installed"
+        case .credentialsMissing:
+            "Pangolin site credentials are missing"
+        case .alreadyRunning:
+            "A Pangolin Newt connection is already running"
+        case let .connectionFailed(message):
+            "Failed to start Pangolin Newt: \(message)"
+        }
+    }
+}
+
+struct PangolinCredentials: Codable, Equatable {
+    let endpoint: String
+    let siteID: String
+    let secret: String
+}
+
+/// Manages the Newt process that connects this Mac to a Pangolin site.
+@Observable
+@MainActor
+final class PangolinService {
+    static let shared = PangolinService()
+    static var isTestMode = false
+
+    static var newtSearchPaths: [String] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return [
+            "\(FilePathConstants.optHomebrewBin)/newt",
+            "\(FilePathConstants.usrLocalBin)/newt",
+            "\(FilePathConstants.usrBin)/newt",
+            "/etc/profiles/per-user/\(NSUserName())/bin/newt",
+            "\(home)/.local/bin/newt",
+        ]
+    }
+
+    private(set) var isInstalled = false
+    private(set) var isRunning = false
+    private(set) var isConnected = false
+    private(set) var statusError: String?
+    private(set) var newtPath: String?
+
+    var credentials: PangolinCredentials? {
+        PangolinKeychain.getCredentials()
+    }
+
+    var hasCredentials: Bool {
+        self.credentials != nil
+    }
+
+    private var newtProcess: Process?
+    private var outputHandles: [FileHandle] = []
+    private var outputBuffer = ""
+    private var isStopping = false
+    private var configURL: URL?
+
+    private let logger = Logger(subsystem: BundleIdentifiers.main, category: "PangolinService")
+
+    private init() {
+        _ = self.checkCLIInstallation()
+    }
+
+    @discardableResult
+    func checkCLIInstallation() -> Bool {
+        for path in Self.newtSearchPaths where FileManager.default.isExecutableFile(atPath: path) {
+            self.newtPath = path
+            self.isInstalled = true
+            return true
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: FilePathConstants.which)
+        process.arguments = ["newt"]
+
+        var environment = ProcessInfo.processInfo.environment
+        let currentPath = environment[EnvironmentKeys.path] ?? "\(FilePathConstants.usrBin):\(FilePathConstants.bin)"
+        let extraPaths = Self.newtSearchPaths
+            .map { URL(fileURLWithPath: $0).deletingLastPathComponent().path }
+            .joined(separator: ":")
+        environment[EnvironmentKeys.path] = "\(extraPaths):\(currentPath)"
+        process.environment = environment
+
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = Pipe()
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let data = try outputPipe.fileHandleForReading.readToEnd() ?? Data()
+            let path = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            if process.terminationStatus == 0,
+               let path,
+               !path.isEmpty,
+               FileManager.default.isExecutableFile(atPath: path)
+            {
+                self.newtPath = path
+                self.isInstalled = true
+                return true
+            }
+        } catch {
+            self.logger.debug("Failed to locate newt with which: \(error.localizedDescription)")
+        }
+
+        self.newtPath = nil
+        self.isInstalled = false
+        return false
+    }
+
+    @discardableResult
+    func saveCredentials(endpoint: String, siteID: String, secret: String) -> Bool {
+        guard let credentials = Self.normalizeCredentials(
+            endpoint: endpoint,
+            siteID: siteID,
+            secret: secret)
+        else {
+            return false
+        }
+        return PangolinKeychain.setCredentials(credentials)
+    }
+
+    func deleteCredentials() {
+        PangolinKeychain.deleteCredentials()
+    }
+
+    func start() async throws {
+        guard self.checkCLIInstallation(), let binaryPath = newtPath else {
+            throw PangolinError.notInstalled
+        }
+        guard let credentials else {
+            throw PangolinError.credentialsMissing
+        }
+        guard !self.isRunning else {
+            throw PangolinError.alreadyRunning
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: binaryPath)
+
+        do {
+            self.configURL = try Self.createTemporaryConfig(credentials: credentials)
+        } catch {
+            throw PangolinError.connectionFailed("Could not prepare site credentials: \(error.localizedDescription)")
+        }
+        process.arguments = Self.startArguments(configPath: self.configURL?.path)
+
+        let outputPipe = Pipe()
+        let errorPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = errorPipe
+
+        process.terminationHandler = { [weak self] terminatedProcess in
+            Task { @MainActor in
+                guard let self, self.newtProcess === terminatedProcess else { return }
+                let stoppedIntentionally = self.isStopping
+                let status = terminatedProcess.terminationStatus
+                self.clearProcessState()
+                if !stoppedIntentionally {
+                    self.statusError = "Newt exited with status \(status)"
+                }
+            }
+        }
+
+        do {
+            self.isStopping = false
+            self.newtProcess = process
+            try process.run()
+            guard process.isRunning else {
+                let status = process.terminationStatus
+                self.clearProcessState()
+                throw PangolinError.connectionFailed("Newt exited with status \(status)")
+            }
+            self.isRunning = true
+            self.isConnected = false
+            self.statusError = nil
+            self.startOutputMonitoring(outputPipe: outputPipe, errorPipe: errorPipe)
+            self.logger.info("Started Pangolin Newt")
+        } catch {
+            self.clearProcessState()
+            if let pangolinError = error as? PangolinError {
+                throw pangolinError
+            }
+            throw PangolinError.connectionFailed(error.localizedDescription)
+        }
+    }
+
+    func stop() async {
+        guard let process = newtProcess else {
+            self.clearProcessState()
+            return
+        }
+
+        self.isStopping = true
+        process.terminate()
+
+        for _ in 0..<20 where process.isRunning {
+            try? await Task.sleep(for: .milliseconds(100))
+        }
+
+        self.clearProcessState()
+        self.logger.info("Stopped Pangolin Newt")
+    }
+
+    /// Fast app-termination path. Newt handles SIGTERM and closes its tunnel.
+    func sendTerminationSignal() {
+        self.isStopping = true
+        self.newtProcess?.terminate()
+        self.clearProcessState()
+    }
+
+    func copyInstallCommand() {
+        guard !Self.isTestMode else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(
+            "curl -fsSL https://static.pangolin.net/get-newt.sh | bash",
+            forType: .string)
+    }
+
+    func openSetupGuide() {
+        guard !Self.isTestMode, let url = URL(string: URLConstants.pangolinDocs) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    func openDashboard() {
+        guard !Self.isTestMode else { return }
+        let endpoint = self.credentials?.endpoint ?? URLConstants.pangolinCloud
+        guard let url = URL(string: endpoint) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    nonisolated static func normalizeCredentials(
+        endpoint: String,
+        siteID: String,
+        secret: String)
+        -> PangolinCredentials?
+    {
+        let endpoint = endpoint.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let siteID = siteID.trimmingCharacters(in: .whitespacesAndNewlines)
+        let secret = secret.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard let url = URL(string: endpoint),
+              let scheme = url.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              url.host != nil,
+              !siteID.isEmpty,
+              !secret.isEmpty
+        else {
+            return nil
+        }
+        return PangolinCredentials(endpoint: endpoint, siteID: siteID, secret: secret)
+    }
+
+    nonisolated static func startArguments(configPath: String?) -> [String] {
+        guard let configPath, !configPath.isEmpty else { return [] }
+        return ["--config-file", configPath]
+    }
+
+    nonisolated static func createTemporaryConfig(credentials: PangolinCredentials) throws -> URL {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("VibeTunnel", isDirectory: true)
+            .appendingPathComponent("Pangolin", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700])
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+
+        let configURL = directory.appendingPathComponent("config.json")
+        let data = try JSONSerialization.data(withJSONObject: [
+            "endpoint": credentials.endpoint,
+            "id": credentials.siteID,
+            "secret": credentials.secret,
+            "tlsClientCert": "",
+        ])
+        guard fileManager.createFile(
+            atPath: configURL.path,
+            contents: data,
+            attributes: [.posixPermissions: 0o600])
+        else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        return configURL
+    }
+
+    nonisolated static func connectionState(from output: String) -> Bool? {
+        let connected = [
+            "Tunnel connection to server established successfully!",
+            "Connection to server restored after",
+        ]
+            .compactMap { output.range(of: $0, options: .backwards)?.lowerBound }
+            .max()
+        let disconnected = [
+            "Failed to connect:",
+            "Connection to server lost after",
+        ]
+            .compactMap { output.range(of: $0, options: .backwards)?.lowerBound }
+            .max()
+
+        switch (connected, disconnected) {
+        case let (.some(connected), .some(disconnected)):
+            return connected > disconnected
+        case (.some, .none):
+            return true
+        case (.none, .some):
+            return false
+        case (.none, .none):
+            return nil
+        }
+    }
+
+    private func startOutputMonitoring(outputPipe: Pipe, errorPipe: Pipe) {
+        self.clearOutputHandlers()
+
+        let handles = [outputPipe.fileHandleForReading, errorPipe.fileHandleForReading]
+        self.outputHandles = handles
+
+        for handle in handles {
+            handle.readabilityHandler = { [weak self] readableHandle in
+                let data = readableHandle.availableData
+                guard !data.isEmpty else {
+                    readableHandle.readabilityHandler = nil
+                    return
+                }
+                guard let output = String(data: data, encoding: .utf8) else { return }
+
+                Task { @MainActor in
+                    self?.processOutput(output)
+                }
+            }
+        }
+    }
+
+    private func processOutput(_ output: String) {
+        guard self.isRunning else { return }
+
+        self.outputBuffer.append(output)
+        if self.outputBuffer.count > 32768 {
+            self.outputBuffer = String(self.outputBuffer.suffix(32768))
+        }
+
+        switch Self.connectionState(from: self.outputBuffer) {
+        case true:
+            self.isConnected = true
+            self.statusError = nil
+        case false:
+            self.isConnected = false
+            self.statusError = "Newt could not connect. Check the Pangolin endpoint and site credentials."
+        case nil:
+            break
+        }
+    }
+
+    private func clearOutputHandlers() {
+        for handle in self.outputHandles {
+            handle.readabilityHandler = nil
+        }
+        self.outputHandles.removeAll()
+    }
+
+    private func clearTemporaryConfig() {
+        if let configURL {
+            try? FileManager.default.removeItem(at: configURL.deletingLastPathComponent())
+        }
+        self.configURL = nil
+    }
+
+    private func clearProcessState() {
+        self.clearOutputHandlers()
+        self.clearTemporaryConfig()
+        self.newtProcess = nil
+        self.isRunning = false
+        self.isConnected = false
+        self.statusError = nil
+        self.outputBuffer = ""
+        self.isStopping = false
+    }
+}
+
+private enum PangolinKeychain {
+    private static let service = KeychainConstants.vibeTunnelService
+    private static let account = KeychainConstants.pangolinSiteCredentials
+
+    static func getCredentials() -> PangolinCredentials? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: self.service,
+            kSecAttrAccount as String: self.account,
+            kSecReturnData as String: true,
+        ]
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess,
+              let data = result as? Data
+        else {
+            return nil
+        }
+        return try? JSONDecoder().decode(PangolinCredentials.self, from: data)
+    }
+
+    @discardableResult
+    static func setCredentials(_ credentials: PangolinCredentials) -> Bool {
+        guard let data = try? JSONEncoder().encode(credentials) else { return false }
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: self.service,
+            kSecAttrAccount as String: self.account,
+        ]
+        let update = [kSecValueData as String: data]
+        var status = SecItemUpdate(query as CFDictionary, update as CFDictionary)
+
+        if status == errSecItemNotFound {
+            var addQuery = query
+            addQuery[kSecValueData as String] = data
+            status = SecItemAdd(addQuery as CFDictionary, nil)
+        }
+        return status == errSecSuccess
+    }
+
+    static func deleteCredentials() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: self.service,
+            kSecAttrAccount as String: self.account,
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/mac/VibeTunnel/Presentation/Views/Settings/PangolinIntegrationSection.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/PangolinIntegrationSection.swift
@@ -1,0 +1,261 @@
+import SwiftUI
+
+struct PangolinIntegrationSection: View {
+    let pangolinService: PangolinService
+    let serverPort: String
+
+    @State private var connectionEnabled = false
+    @State private var isTogglingConnection = false
+    @State private var endpointInput = URLConstants.pangolinCloud
+    @State private var siteIDInput = ""
+    @State private var secretInput = ""
+    @State private var credentialsStored = false
+    @State private var isEditingCredentials = false
+    @State private var credentialsError: String?
+    @State private var connectionError: String?
+
+    var body: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Image(systemName: "circle.fill")
+                        .foregroundColor(self.statusColor)
+                        .font(.system(size: 10))
+                    Text(self.statusText)
+                        .font(.callout)
+                    Spacer()
+                }
+
+                if !self.pangolinService.isInstalled {
+                    HStack(spacing: 12) {
+                        Button("Copy Install Command") {
+                            self.pangolinService.copyInstallCommand()
+                        }
+                        .buttonStyle(.link)
+                        .controlSize(.small)
+                    }
+                } else {
+                    self.credentialsControls
+
+                    if self.credentialsStored {
+                        HStack {
+                            Toggle("Connect Pangolin site", isOn: self.$connectionEnabled)
+                                .disabled(self.isTogglingConnection)
+                                .onChange(of: self.connectionEnabled) { _, enabled in
+                                    if enabled {
+                                        self.startConnection()
+                                    } else {
+                                        self.stopConnection()
+                                    }
+                                }
+
+                            if self.isTogglingConnection {
+                                ProgressView()
+                                    .scaleEffect(0.7)
+                            } else if self.pangolinService.isConnected {
+                                Image(systemName: "checkmark.circle.fill")
+                                    .foregroundColor(.green)
+                                Text("Connected")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+
+                    if let error = pangolinService.statusError {
+                        self.errorView(error)
+                    }
+                    if let connectionError {
+                        self.errorView(connectionError)
+                    }
+                    if let credentialsError {
+                        self.errorView(credentialsError)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Pangolin resource target")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text("http://localhost:\(self.serverPort)")
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                }
+
+                HStack(spacing: 12) {
+                    Button("Open Pangolin") {
+                        self.pangolinService.openDashboard()
+                    }
+                    .buttonStyle(.link)
+                    .font(.caption)
+
+                    Button("Setup Guide") {
+                        self.pangolinService.openSetupGuide()
+                    }
+                    .buttonStyle(.link)
+                    .font(.caption)
+                }
+            }
+        } header: {
+            Text("Pangolin Integration")
+                .font(.headline)
+        } footer: {
+            Text(
+                "Newt connects this Mac as a Pangolin site. Create a public Resource in Pangolin with the target shown above; Pangolin owns the public URL and access policy.")
+                .font(.caption)
+                .frame(maxWidth: .infinity)
+                .multilineTextAlignment(.center)
+        }
+        .task {
+            _ = self.pangolinService.checkCLIInstallation()
+            self.credentialsStored = self.pangolinService.hasCredentials
+            self.connectionEnabled = self.pangolinService.isRunning
+            if let credentials = pangolinService.credentials {
+                self.endpointInput = credentials.endpoint
+            }
+        }
+        .onChange(of: self.pangolinService.isRunning) { _, isRunning in
+            self.connectionEnabled = isRunning
+        }
+    }
+
+    @ViewBuilder
+    private var credentialsControls: some View {
+        if self.credentialsStored, !self.isEditingCredentials {
+            HStack {
+                Label("Site credentials saved", systemImage: "key.fill")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Spacer()
+                Button("Replace") {
+                    if let credentials = pangolinService.credentials {
+                        self.endpointInput = credentials.endpoint
+                        self.siteIDInput = credentials.siteID
+                    }
+                    self.secretInput = ""
+                    self.isEditingCredentials = true
+                }
+                .controlSize(.small)
+                .disabled(self.pangolinService.isRunning)
+
+                Button("Remove") {
+                    self.pangolinService.deleteCredentials()
+                    self.credentialsStored = false
+                    self.siteIDInput = ""
+                    self.secretInput = ""
+                    self.credentialsError = nil
+                }
+                .controlSize(.small)
+                .disabled(self.pangolinService.isRunning)
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                TextField("Pangolin endpoint", text: self.$endpointInput)
+                    .textFieldStyle(.roundedBorder)
+                TextField("Newt site ID", text: self.$siteIDInput)
+                    .textFieldStyle(.roundedBorder)
+                SecureField("Newt secret", text: self.$secretInput)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit {
+                        self.saveCredentials()
+                    }
+
+                HStack {
+                    Button("Save Credentials") {
+                        self.saveCredentials()
+                    }
+                    .disabled(
+                        self.endpointInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                            self.siteIDInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ||
+                            self.secretInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    .controlSize(.small)
+
+                    if self.isEditingCredentials {
+                        Button("Cancel") {
+                            self.isEditingCredentials = false
+                            self.siteIDInput = ""
+                            self.secretInput = ""
+                            self.credentialsError = nil
+                        }
+                        .controlSize(.small)
+                    }
+                }
+            }
+        }
+    }
+
+    private var statusColor: Color {
+        if !self.pangolinService.isInstalled {
+            return .yellow
+        }
+        if self.pangolinService.isConnected {
+            return .green
+        }
+        return self.pangolinService.isRunning ? .blue : .orange
+    }
+
+    private var statusText: String {
+        if !self.pangolinService.isInstalled {
+            return "Newt is not installed"
+        }
+        if self.pangolinService.isConnected {
+            return "Pangolin site is connected"
+        }
+        return self.pangolinService.isRunning ? "Connecting Pangolin site..." : "Newt is installed"
+    }
+
+    private func saveCredentials() {
+        if self.pangolinService.saveCredentials(
+            endpoint: self.endpointInput,
+            siteID: self.siteIDInput,
+            secret: self.secretInput)
+        {
+            self.credentialsStored = true
+            self.isEditingCredentials = false
+            self.siteIDInput = ""
+            self.secretInput = ""
+            self.credentialsError = nil
+        } else {
+            self.credentialsError = "Enter a valid HTTP(S) endpoint, site ID, and secret."
+        }
+    }
+
+    private func startConnection() {
+        guard !self.isTogglingConnection else { return }
+        self.isTogglingConnection = true
+        self.connectionError = nil
+
+        Task {
+            defer { self.isTogglingConnection = false }
+            do {
+                try await self.pangolinService.start()
+                self.connectionEnabled = self.pangolinService.isRunning
+            } catch {
+                self.connectionEnabled = false
+                self.connectionError = error.localizedDescription
+            }
+        }
+    }
+
+    private func stopConnection() {
+        guard !self.isTogglingConnection else { return }
+        self.isTogglingConnection = true
+
+        Task {
+            await self.pangolinService.stop()
+            self.connectionEnabled = false
+            self.isTogglingConnection = false
+        }
+    }
+
+    private func errorView(_ error: String) -> some View {
+        HStack {
+            Image(systemName: "exclamationmark.triangle")
+                .foregroundColor(.red)
+            Text(error)
+                .font(.caption)
+                .foregroundColor(.red)
+                .lineLimit(2)
+        }
+    }
+}

--- a/mac/VibeTunnel/Presentation/Views/Settings/RemoteAccessSettingsView.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/RemoteAccessSettingsView.swift
@@ -25,6 +25,8 @@ struct RemoteAccessSettingsView: View {
     private var cloudflareService
     @Environment(PinggyService.self)
     private var pinggyService
+    @Environment(PangolinService.self)
+    private var pangolinService
     @Environment(TailscaleServeStatusService.self)
     private var tailscaleServeStatus
     @Environment(ServerManager.self)
@@ -71,6 +73,10 @@ struct RemoteAccessSettingsView: View {
 
                 PinggyIntegrationSection(
                     pinggyService: self.pinggyService,
+                    serverPort: self.serverPort)
+
+                PangolinIntegrationSection(
+                    pangolinService: self.pangolinService,
                     serverPort: self.serverPort)
 
                 NgrokIntegrationSection(

--- a/mac/VibeTunnel/VibeTunnelApp.swift
+++ b/mac/VibeTunnel/VibeTunnelApp.swift
@@ -21,6 +21,7 @@ struct VibeTunnelApp: App {
     @State var tailscaleService = TailscaleService.shared
     @State var cloudflareService = CloudflareService.shared
     @State var pinggyService = PinggyService.shared
+    @State var pangolinService = PangolinService.shared
     @State var permissionManager = SystemPermissionManager.shared
     @State var terminalLauncher = TerminalLauncher.shared
     @State var gitRepositoryMonitor = GitRepositoryMonitor()
@@ -55,6 +56,7 @@ struct VibeTunnelApp: App {
                 .environment(self.tailscaleService)
                 .environment(self.cloudflareService)
                 .environment(self.pinggyService)
+                .environment(self.pangolinService)
                 .environment(self.permissionManager)
                 .environment(self.terminalLauncher)
                 .environment(self.gitRepositoryMonitor)
@@ -79,6 +81,7 @@ struct VibeTunnelApp: App {
                     .environment(self.tailscaleService)
                     .environment(self.cloudflareService)
                     .environment(self.pinggyService)
+                    .environment(self.pangolinService)
                     .environment(self.permissionManager)
                     .environment(self.terminalLauncher)
                     .environment(self.gitRepositoryMonitor)
@@ -106,6 +109,7 @@ struct VibeTunnelApp: App {
                 .environment(self.tailscaleService)
                 .environment(self.cloudflareService)
                 .environment(self.pinggyService)
+                .environment(self.pangolinService)
                 .environment(self.permissionManager)
                 .environment(self.terminalLauncher)
                 .environment(self.gitRepositoryMonitor)
@@ -450,6 +454,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         if let pinggyService = app?.pinggyService, pinggyService.isRunning {
             self.logger.info("Sending quick termination signal to Pinggy")
             pinggyService.sendTerminationSignal()
+        }
+
+        if let pangolinService = app?.pangolinService, pangolinService.isRunning {
+            self.logger.info("Sending quick termination signal to Pangolin Newt")
+            pangolinService.sendTerminationSignal()
         }
 
         // Stop HTTP server with very short timeout

--- a/mac/VibeTunnelTests/PangolinServiceTests.swift
+++ b/mac/VibeTunnelTests/PangolinServiceTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+@testable import VibeTunnel
+
+@Suite("Pangolin Service Tests", .tags(.networking))
+struct PangolinServiceTests {
+    @Test
+    @MainActor
+    func singletonInstance() {
+        #expect(PangolinService.shared === PangolinService.shared)
+    }
+
+    @Test
+    @MainActor
+    func searchPathsCoverCommonInstallLocations() {
+        #expect(PangolinService.newtSearchPaths.contains("/opt/homebrew/bin/newt"))
+        #expect(PangolinService.newtSearchPaths.contains("/usr/local/bin/newt"))
+        #expect(PangolinService.newtSearchPaths.contains("/etc/profiles/per-user/\(NSUserName())/bin/newt"))
+    }
+
+    @Test
+    func normalizesCredentials() throws {
+        let credentials = try #require(PangolinService.normalizeCredentials(
+            endpoint: " https://app.pangolin.net/ ",
+            siteID: " site-id ",
+            secret: " site-secret "))
+
+        #expect(credentials == PangolinCredentials(
+            endpoint: "https://app.pangolin.net",
+            siteID: "site-id",
+            secret: "site-secret"))
+    }
+
+    @Test
+    func rejectsInvalidCredentials() {
+        #expect(PangolinService.normalizeCredentials(
+            endpoint: "javascript:alert(1)",
+            siteID: "site-id",
+            secret: "secret") == nil)
+        #expect(PangolinService.normalizeCredentials(
+            endpoint: "https://app.pangolin.net",
+            siteID: "",
+            secret: "secret") == nil)
+    }
+
+    @Test
+    func createsProtectedTemporaryConfig() throws {
+        let credentials = PangolinCredentials(
+            endpoint: "https://app.pangolin.net",
+            siteID: "site-id",
+            secret: "site-secret")
+        let configURL = try PangolinService.createTemporaryConfig(credentials: credentials)
+        defer { try? FileManager.default.removeItem(at: configURL.deletingLastPathComponent()) }
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: configURL.path)
+        #expect(attributes[.posixPermissions] as? Int == 0o600)
+        let directoryAttributes = try FileManager.default.attributesOfItem(
+            atPath: configURL.deletingLastPathComponent().path)
+        #expect(directoryAttributes[.posixPermissions] as? Int == 0o700)
+
+        let data = try Data(contentsOf: configURL)
+        let config = try #require(JSONSerialization.jsonObject(with: data) as? [String: String])
+        #expect(config["endpoint"] == credentials.endpoint)
+        #expect(config["id"] == credentials.siteID)
+        #expect(config["secret"] == credentials.secret)
+
+        let arguments = PangolinService.startArguments(configPath: configURL.path)
+        #expect(arguments == ["--config-file", configURL.path])
+        #expect(!arguments.contains(credentials.siteID))
+        #expect(!arguments.contains(credentials.secret))
+    }
+
+    @Test
+    func tracksLatestConnectionEvent() {
+        #expect(PangolinService.connectionState(from: "Websocket connected") == nil)
+        #expect(PangolinService.connectionState(
+            from: "Failed to connect: unauthorized. Retrying") == false)
+        #expect(PangolinService.connectionState(
+            from: "Failed to connect:\nTunnel connection to server established successfully!") == true)
+        #expect(PangolinService.connectionState(
+            from: "Tunnel connection to server established successfully!\nFailed to connect: timeout") == false)
+        #expect(PangolinService.connectionState(
+            from: "Tunnel connection to server established successfully!\nConnection to server lost after 5 failures") ==
+            false)
+        #expect(PangolinService.connectionState(
+            from: "Connection to server lost after 5 failures\nConnection to server restored after 7 failures!") ==
+            true)
+    }
+
+    @Test
+    func errorDescriptions() {
+        let errors: [PangolinError] = [
+            .notInstalled,
+            .credentialsMissing,
+            .alreadyRunning,
+            .connectionFailed("test"),
+        ]
+        for error in errors {
+            #expect(error.errorDescription?.isEmpty == false)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Pangolin Newt discovery, lifecycle, connection-state monitoring, and app shutdown handling
- store Pangolin site credentials in Keychain and pass them through a mode-0600 temporary config instead of argv/environment
- add Remote settings controls, setup guidance, README documentation, changelog entry, and focused tests

## Proof
- 7 focused `PangolinServiceTests` pass
- unsigned arm64 Debug build passes
- full SwiftFormat lint and strict SwiftLint pass
- live Remote settings inspected through macOS accessibility; install state, resource target, and setup links render correctly
- structured autoreview clean

No public tunnel was opened because no Pangolin site credentials were used.

Fixes #315