### PR TITLE
fix: enable chat mode autocorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Enable native autocorrect for mobile Chat Mode while preserving case-sensitive terminal input and keeping command spellcheck disabled (reported by [@patrickjm](https://github.com/patrickjm)) (#423)
 - Require macOS releases to rebuild the server with the trimmed Node.js runtime instead of silently embedding the full system binary (#271)
 - Clarify whether browser login expects a system or configured VibeTunnel password, that verification happens on the host without saving it, and that SSH keys avoid browser password entry (reported by [@tleyden](https://github.com/tleyden)) (#555)
 - Guide first-time users from local access through Tailscale setup and directly into Remote settings (reported by [@carlosjunod](https://github.com/carlosjunod)) (#539)

--- a/web/src/client/components/terminal-chat-view.test.ts
+++ b/web/src/client/components/terminal-chat-view.test.ts
@@ -1,0 +1,42 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TerminalChatView } from './terminal-chat-view.js';
+
+describe('TerminalChatView', () => {
+  let component: TerminalChatView;
+
+  beforeEach(async () => {
+    component = new TerminalChatView();
+    document.body.append(component);
+    await component.updateComplete;
+  });
+
+  afterEach(() => {
+    component.remove();
+  });
+
+  it('enables native autocorrect for its delta-reconciling input', () => {
+    const input = component.shadowRoot?.querySelector<HTMLInputElement>('#chat-input-field');
+
+    expect(input?.getAttribute('autocorrect')).toBe('on');
+    expect(input?.getAttribute('spellcheck')).toBe('false');
+    expect(input?.getAttribute('autocapitalize')).toBe('off');
+  });
+
+  it('reconciles a corrected word with terminal backspaces', () => {
+    const onSend = vi.fn();
+    component.onSend = onSend;
+    const input = component.shadowRoot?.querySelector<HTMLInputElement>('#chat-input-field');
+    expect(input).not.toBeNull();
+
+    if (!input) return;
+    input.value = 'git chek';
+    input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    input.value = 'git check';
+    input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+
+    expect(onSend).toHaveBeenNthCalledWith(1, 'git chek');
+    expect(onSend).toHaveBeenNthCalledWith(2, '\x7fck');
+  });
+});

--- a/web/src/client/components/terminal-chat-view.ts
+++ b/web/src/client/components/terminal-chat-view.ts
@@ -1108,13 +1108,14 @@ export class TerminalChatView extends LitElement {
           @click=${(e: Event) => e.stopPropagation()}
           @keydown=${(e: KeyboardEvent) => e.stopPropagation()}
         >
+          <!-- Autocorrect is intentional; spellcheck stays off because commands may contain secrets. -->
           <input
             id="chat-input-field"
             type="text"
             class="chat-input"
             placeholder="Type a command..."
             autocomplete="off"
-            autocorrect="off"
+            autocorrect="on"
             autocapitalize="off"
             spellcheck="false"
             @keydown=${this.handleInputKeydown}


### PR DESCRIPTION
Fixes #423.

## Summary

- enable native iOS/Safari autocorrect for the Chat Mode command input
- retain disabled autocapitalization for case-sensitive shell input
- retain disabled spellcheck because terminal commands may contain secrets
- add regression coverage for browser word replacement translated into terminal backspaces

## Proof

- `pnpm exec vitest run --mode=client src/client/components/terminal-chat-view.test.ts`
- `pnpm exec tsc --noEmit --project tsconfig.client.json`
- `pnpm exec biome check src/client/components/terminal-chat-view.ts src/client/components/terminal-chat-view.test.ts`
- `git diff --check`
- existing Chrome profile, iPhone 390x844 emulation: rendered `autocorrect=on`, `spellcheck=false`, `autocapitalize=off`
- live replacement `git chek` to `git check`: emitted DEL + `ck`
- final Codex autoreview clean