### PR TITLE
fix: detect nix Tailscale installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Default macOS build script to universal binaries with optional arch override (via [@rothnic](https://github.com/rothnic)) (#557)
 
 ### 🐛 Bug Fixes
+- Detect nix-darwin and other CLI-based Tailscale installations, including daemon status when the macOS app API is unavailable (reported by [@teehemkay](https://github.com/teehemkay)) (#259)
 - Enable native autocorrect for mobile Chat Mode while preserving case-sensitive terminal input and keeping command spellcheck disabled (reported by [@patrickjm](https://github.com/patrickjm)) (#423)
 - Require macOS releases to rebuild the server with the trimmed Node.js runtime instead of silently embedding the full system binary (#271)
 - Clarify whether browser login expects a system or configured VibeTunnel password, that verification happens on the host without saving it, and that SSH keys avoid browser password entry (reported by [@tleyden](https://github.com/tleyden)) (#555)

--- a/README.md
+++ b/README.md
@@ -188,15 +188,17 @@ The server runs as a standalone Node.js executable with embedded modules, provid
 **How it works**: Tailscale creates an encrypted WireGuard tunnel between your devices, allowing them to communicate as if they were on the same local network, regardless of their physical location.
 
 #### Basic Setup
-1. Install Tailscale on your Mac: [Download from Mac App Store](https://apps.apple.com/us/app/tailscale/id1475387142) or [Direct Download](https://tailscale.com/download/macos)
+1. Install Tailscale on your Mac: [Download from Mac App Store](https://apps.apple.com/us/app/tailscale/id1475387142), [Direct Download](https://tailscale.com/download/macos), or a CLI/daemon package such as nix-darwin
 2. Install Tailscale on your remote device:
    - **iOS**: [Download from App Store](https://apps.apple.com/us/app/tailscale/id1470499037)
    - **Android**: [Download from Google Play](https://play.google.com/store/apps/details?id=com.tailscale.ipn)
    - **Other platforms**: [All Downloads](https://tailscale.com/download)
 3. Sign in to both devices with the same account
 4. If using VibeTunnel's Tailscale Serve integration, ensure Tailscale Serve is enabled in your [tailnet settings](https://login.tailscale.com/f/serve)
-5. Find your Mac's Tailscale hostname in the Tailscale menu bar app (e.g., `my-mac.tailnet-name.ts.net`)
+5. Find your Mac's Tailscale hostname in the menu bar app or with `tailscale status` (e.g., `my-mac.tailnet-name.ts.net`)
 6. Access VibeTunnel at `http://[your-tailscale-hostname]:4020`
+
+VibeTunnel detects standard CLI locations and nix-darwin system/user profiles, and falls back to `tailscale status --json` when the macOS app API is unavailable.
 
 #### Enhanced Tailscale Features
 

--- a/mac/VibeTunnel/Core/Helpers/TailscaleCLI.swift
+++ b/mac/VibeTunnel/Core/Helpers/TailscaleCLI.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+enum TailscaleCLI {
+    struct Status: Equatable {
+        let isRunning: Bool
+        let hostname: String?
+        let ipv4: String?
+    }
+
+    static var searchPaths: [String] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return [
+            "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+            "/run/current-system/sw/bin/tailscale",
+            "/etc/profiles/per-user/\(NSUserName())/bin/tailscale",
+            "\(home)/.nix-profile/bin/tailscale",
+            "/opt/homebrew/bin/tailscale",
+            "/usr/local/bin/tailscale",
+            "/usr/bin/tailscale",
+        ]
+    }
+
+    static func findExecutable(
+        searchPaths: [String]? = nil,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default)
+        -> String?
+    {
+        let configuredPaths = searchPaths ?? Self.searchPaths
+        let pathCandidates = (environment[EnvironmentKeys.path] ?? "")
+            .split(separator: ":")
+            .map { "\($0)/tailscale" }
+
+        var seen = Set<String>()
+        return (configuredPaths + pathCandidates).first { path in
+            seen.insert(path).inserted && fileManager.isExecutableFile(atPath: path)
+        }
+    }
+
+    static func parseStatus(_ data: Data) throws -> Status {
+        let response = try JSONDecoder().decode(StatusResponse.self, from: data)
+        let trimmedHostname = response.selfNode?.dnsName?
+            .trimmingCharacters(in: CharacterSet(charactersIn: "."))
+        let hostname = trimmedHostname?.isEmpty == false ? trimmedHostname : nil
+        let addresses = if let topLevelAddresses = response.tailscaleIPs, !topLevelAddresses.isEmpty {
+            topLevelAddresses
+        } else {
+            response.selfNode?.tailscaleIPs ?? []
+        }
+
+        return Status(
+            isRunning: response.backendState.caseInsensitiveCompare("running") == .orderedSame,
+            hostname: hostname,
+            ipv4: addresses.first(where: Self.isIPv4Address))
+    }
+
+    static func fetchStatus(executablePath: String) async -> Status? {
+        await Task.detached(priority: .utility) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: executablePath)
+            process.arguments = ["status", "--json"]
+
+            let outputPipe = Pipe()
+            process.standardOutput = outputPipe
+            process.standardError = Pipe()
+
+            do {
+                try process.run()
+                let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
+                process.waitUntilExit()
+                guard process.terminationStatus == 0 else { return nil }
+                return try Self.parseStatus(data)
+            } catch {
+                return nil
+            }
+        }.value
+    }
+
+    private static func isIPv4Address(_ value: String) -> Bool {
+        let components = value.split(separator: ".", omittingEmptySubsequences: false)
+        return components.count == 4 && components.allSatisfy { component in
+            guard let number = Int(component) else { return false }
+            return (0...255).contains(number)
+        }
+    }
+
+    private struct StatusResponse: Decodable {
+        let backendState: String
+        let tailscaleIPs: [String]?
+        let selfNode: SelfNode?
+
+        enum CodingKeys: String, CodingKey {
+            case backendState = "BackendState"
+            case tailscaleIPs = "TailscaleIPs"
+            case selfNode = "Self"
+        }
+    }
+
+    private struct SelfNode: Decodable {
+        let dnsName: String?
+        let tailscaleIPs: [String]?
+
+        enum CodingKeys: String, CodingKey {
+            case dnsName = "DNSName"
+            case tailscaleIPs = "TailscaleIPs"
+        }
+    }
+}

--- a/mac/VibeTunnel/Core/Helpers/TailscaleCLI.swift
+++ b/mac/VibeTunnel/Core/Helpers/TailscaleCLI.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 enum TailscaleCLI {
@@ -54,7 +55,7 @@ enum TailscaleCLI {
             ipv4: addresses.first(where: Self.isIPv4Address))
     }
 
-    static func fetchStatus(executablePath: String) async -> Status? {
+    static func fetchStatus(executablePath: String, timeout: Duration = .seconds(5)) async -> Status? {
         await Task.detached(priority: .utility) {
             let process = Process()
             process.executableURL = URL(fileURLWithPath: executablePath)
@@ -66,6 +67,17 @@ enum TailscaleCLI {
 
             do {
                 try process.run()
+                let timeoutTask = Task.detached(priority: .utility) {
+                    try? await Task.sleep(for: timeout)
+                    guard !Task.isCancelled, process.isRunning else { return }
+                    process.terminate()
+                    try? await Task.sleep(for: .milliseconds(250))
+                    if process.isRunning {
+                        kill(process.processIdentifier, SIGKILL)
+                    }
+                }
+                defer { timeoutTask.cancel() }
+
                 let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
                 process.waitUntilExit()
                 guard process.terminationStatus == 0 else { return nil }

--- a/mac/VibeTunnel/Core/Helpers/TailscaleURLHelper.swift
+++ b/mac/VibeTunnel/Core/Helpers/TailscaleURLHelper.swift
@@ -7,20 +7,7 @@ private let logger = Logger(subsystem: "sh.vibetunnel.vibetunnel", category: "Ta
 enum TailscaleURLHelper {
     /// Gets the Tailscale IPv4 address for this machine
     static func getTailscaleIP() -> String? {
-        // Try multiple locations for the tailscale binary
-        let possiblePaths = [
-            "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
-            "/opt/homebrew/bin/tailscale",
-            "/usr/local/bin/tailscale",
-        ]
-
-        var tailscalePath: String?
-        for path in possiblePaths where FileManager.default.fileExists(atPath: path) {
-            tailscalePath = path
-            break
-        }
-
-        guard let executablePath = tailscalePath else {
+        guard let executablePath = TailscaleCLI.findExecutable() else {
             logger.info("Tailscale binary not found in any expected location")
             return nil
         }

--- a/mac/VibeTunnel/Core/Services/TailscaleService.swift
+++ b/mac/VibeTunnel/Core/Services/TailscaleService.swift
@@ -159,7 +159,9 @@ final class TailscaleService {
             self.isRunning = false
             self.tailscaleHostname = nil
             self.tailscaleIP = nil
-            self.statusError = "Please start Tailscale"
+            self.statusError = self.hasGUIApp
+                ? "Please start Tailscale"
+                : "Start Tailscale with your system service manager"
             self.logger.info("Tailscale API and CLI status checks failed")
         }
     }

--- a/mac/VibeTunnel/Core/Services/TailscaleService.swift
+++ b/mac/VibeTunnel/Core/Services/TailscaleService.swift
@@ -23,8 +23,14 @@ final class TailscaleService {
     /// Logger instance for debugging
     private let logger = Logger(subsystem: BundleIdentifiers.loggerSubsystem, category: "TailscaleService")
 
-    /// Indicates if Tailscale app is installed on the system
+    /// Indicates if a supported Tailscale installation is available on the system
     private(set) var isInstalled = false
+
+    /// Indicates if the GUI app can be opened directly
+    private(set) var hasGUIApp = false
+
+    /// Path to the Tailscale CLI used for daemon and non-App-Store installations
+    private(set) var tailscaleExecutablePath: String?
 
     /// Indicates if Tailscale is currently running
     private(set) var isRunning = false
@@ -44,11 +50,13 @@ final class TailscaleService {
         }
     }
 
-    /// Checks if Tailscale app is installed
+    /// Checks for the GUI app or a Tailscale CLI installation.
     func checkAppInstallation() -> Bool {
-        let isAppInstalled = FileManager.default.fileExists(atPath: "/Applications/Tailscale.app")
-        self.logger.info("Tailscale app installed: \(isAppInstalled)")
-        return isAppInstalled
+        self.hasGUIApp = FileManager.default.fileExists(atPath: "/Applications/Tailscale.app")
+        self.tailscaleExecutablePath = TailscaleCLI.findExecutable()
+        let installed = self.tailscaleExecutablePath != nil
+        self.logger.info("Tailscale installed: \(installed), GUI app: \(self.hasGUIApp)")
+        return installed
     }
 
     /// Struct to decode Tailscale API response
@@ -135,19 +143,30 @@ final class TailscaleService {
                 self.tailscaleIP = nil
                 self.statusError = "Tailscale is not running"
             }
+        } else if let executablePath = tailscaleExecutablePath,
+                  let cliStatus = await TailscaleCLI.fetchStatus(executablePath: executablePath)
+        {
+            // Open-source daemon installs do not expose the macOS GUI app API.
+            self.isRunning = cliStatus.isRunning
+            self.tailscaleHostname = cliStatus.hostname
+            self.tailscaleIP = cliStatus.ipv4
+            self.statusError = cliStatus.isRunning ? nil : "Tailscale is not running"
+            self.logger
+                .info(
+                    "Tailscale CLI status: running=\(cliStatus.isRunning), hostname=\(cliStatus.hostname ?? "nil"), IP=\(cliStatus.ipv4 ?? "nil")")
         } else {
-            // API not responding - Tailscale not running
+            // Neither the API nor CLI reported a running Tailscale instance.
             self.isRunning = false
             self.tailscaleHostname = nil
             self.tailscaleIP = nil
-            self.statusError = "Please start the Tailscale app"
-            self.logger.info("Tailscale API not responding - app likely not running")
+            self.statusError = "Please start Tailscale"
+            self.logger.info("Tailscale API and CLI status checks failed")
         }
     }
 
     /// Opens the Tailscale app
     func openTailscaleApp() {
-        if let url = URL(string: "file:///Applications/Tailscale.app") {
+        if self.hasGUIApp, let url = URL(string: "file:///Applications/Tailscale.app") {
             NSWorkspace.shared.open(url)
         }
     }

--- a/mac/VibeTunnel/Presentation/Views/Settings/RemoteAccessSettingsView.swift
+++ b/mac/VibeTunnel/Presentation/Views/Settings/RemoteAccessSettingsView.swift
@@ -395,8 +395,8 @@ private struct TailscaleIntegrationSection: View {
                             }
                         }
 
-                        // Show action button to start Tailscale
-                        if self.tailscaleService.isInstalled, !self.tailscaleService.isRunning {
+                        // GUI installs can be opened directly; daemon installs use their service manager.
+                        if self.tailscaleService.hasGUIApp {
                             Button(action: {
                                 self.tailscaleService.openTailscaleApp()
                             }, label: {
@@ -407,6 +407,10 @@ private struct TailscaleIntegrationSection: View {
                             })
                             .buttonStyle(.borderedProminent)
                             .controlSize(.small)
+                        } else {
+                            Text("Start Tailscale with your system service manager, then reopen this page.")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
                         }
 
                         // Show help text about what will happen when enabled

--- a/mac/VibeTunnelTests/TailscaleCLITests.swift
+++ b/mac/VibeTunnelTests/TailscaleCLITests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+@testable import VibeTunnel
+
+@Suite("Tailscale CLI Tests", .tags(.networking))
+struct TailscaleCLITests {
+    @Test
+    func searchPathsIncludeNixDarwinLocations() {
+        #expect(TailscaleCLI.searchPaths.contains("/run/current-system/sw/bin/tailscale"))
+        #expect(TailscaleCLI.searchPaths.contains("/etc/profiles/per-user/\(NSUserName())/bin/tailscale"))
+    }
+
+    @Test
+    func findsExecutableFromPath() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tailscale-cli-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let executable = directory.appendingPathComponent("tailscale")
+        try Data("#!/bin/sh\n".utf8).write(to: executable)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        #expect(TailscaleCLI.findExecutable(
+            searchPaths: [],
+            environment: [EnvironmentKeys.path: directory.path]) == executable.path)
+    }
+
+    @Test
+    func parsesRunningDaemonStatus() throws {
+        let data = Data(
+            """
+            {
+              "BackendState": "Running",
+              "TailscaleIPs": ["100.64.12.34", "fd7a:115c:a1e0::1"],
+              "Self": {
+                "DNSName": "nix-mac.example.ts.net.",
+                "TailscaleIPs": ["100.64.12.34"]
+              }
+            }
+            """.utf8)
+
+        #expect(try TailscaleCLI.parseStatus(data) == .init(
+            isRunning: true,
+            hostname: "nix-mac.example.ts.net",
+            ipv4: "100.64.12.34"))
+    }
+
+    @Test
+    func parsesStoppedDaemonStatusWithoutAddresses() throws {
+        let data = Data(
+            """
+            {
+              "BackendState": "Stopped",
+              "TailscaleIPs": null,
+              "Self": null
+            }
+            """.utf8)
+
+        #expect(try TailscaleCLI.parseStatus(data) == .init(
+            isRunning: false,
+            hostname: nil,
+            ipv4: nil))
+    }
+}

--- a/mac/VibeTunnelTests/TailscaleCLITests.swift
+++ b/mac/VibeTunnelTests/TailscaleCLITests.swift
@@ -62,4 +62,25 @@ struct TailscaleCLITests {
             hostname: nil,
             ipv4: nil))
     }
+
+    @Test
+    func statusCommandTimesOut() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("tailscale-timeout-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let executable = directory.appendingPathComponent("tailscale")
+        try Data("#!/bin/sh\ntrap '' TERM\nwhile :; do :; done\n".utf8).write(to: executable)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+
+        let clock = ContinuousClock()
+        let elapsed = await clock.measure {
+            let status = await TailscaleCLI.fetchStatus(
+                executablePath: executable.path,
+                timeout: .milliseconds(100))
+            #expect(status == nil)
+        }
+        #expect(elapsed < .seconds(2))
+    }
 }

--- a/web/src/server/routes/sessions.test.ts
+++ b/web/src/server/routes/sessions.test.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from 'express';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { tailscaleServeService } from '../services/tailscale-serve-service';
 import { detectGitInfo } from '../utils/git-info';
 import { controlUnixHandler } from '../websocket/control-unix-handler';
 import { createSessionRoutes, requestTerminalSpawn } from './sessions';
@@ -95,6 +96,7 @@ describe('sessions routes', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
@@ -228,6 +230,60 @@ describe('sessions routes', () => {
       expect(mockRes.json).toHaveBeenCalledWith({
         error: 'Failed to get server status',
       });
+    });
+  });
+
+  describe('GET /sessions/tailscale/test', () => {
+    it('returns diagnostics when Tailscale is not installed', async () => {
+      vi.spyOn(tailscaleServeService, 'getExecutablePath').mockRejectedValue(
+        new Error('Tailscale command not found')
+      );
+      vi.spyOn(tailscaleServeService, 'getStatus').mockResolvedValue({
+        isRunning: false,
+        lastError: 'Tailscale command not found',
+      });
+
+      const router = createSessionRoutes({
+        ptyManager: mockPtyManager,
+        terminalManager: mockTerminalManager,
+        remoteRegistry: null,
+        isHQMode: false,
+      });
+      const routes = (
+        router as unknown as {
+          stack: Array<{
+            route?: {
+              path: string;
+              methods: { get?: boolean };
+              stack: Array<{ handle: (req: Request, res: Response) => Promise<void> }>;
+            };
+          }>;
+        }
+      ).stack;
+      const testRoute = routes.find(
+        (route) =>
+          route.route && route.route.path === '/sessions/tailscale/test' && route.route.methods.get
+      );
+      const mockRes = {
+        json: vi.fn(),
+        status: vi.fn().mockReturnThis(),
+      } as unknown as Response;
+
+      await testRoute?.route?.stack[0].handle({} as Request, mockRes);
+
+      expect(mockRes.status).not.toHaveBeenCalled();
+      expect(mockRes.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tailscale: {
+            installed: false,
+            status: 'Tailscale command not found',
+          },
+          tailscaleServe: expect.objectContaining({
+            configured: false,
+            error: 'Tailscale command not found',
+          }),
+        })
+      );
     });
   });
 

--- a/web/src/server/routes/sessions.ts
+++ b/web/src/server/routes/sessions.ts
@@ -109,53 +109,57 @@ export function createSessionRoutes(config: SessionRoutesConfig): Router {
     logger.debug('[GET /sessions/tailscale/test] Testing Tailscale connection');
     try {
       const { spawn } = await import('child_process');
+      const tailscaleExecutable = await tailscaleServeService.getExecutablePath().catch(() => null);
 
       // Test 1: Check if Tailscale is installed and running
-      const tailscaleStatus = await new Promise<{ isRunning: boolean; output: string }>(
-        (resolve) => {
-          const statusProcess = spawn('tailscale', ['status'], {
-            stdio: ['ignore', 'pipe', 'pipe'],
-          });
-
-          let stdout = '';
-          let stderr = '';
-
-          if (statusProcess.stdout) {
-            statusProcess.stdout.on('data', (data) => {
-              stdout += data.toString();
+      const tailscaleStatus = tailscaleExecutable
+        ? await new Promise<{ isRunning: boolean; output: string }>((resolve) => {
+            const statusProcess = spawn(tailscaleExecutable, ['status'], {
+              stdio: ['ignore', 'pipe', 'pipe'],
             });
-          }
 
-          if (statusProcess.stderr) {
-            statusProcess.stderr.on('data', (data) => {
-              stderr += data.toString();
-            });
-          }
+            let stdout = '';
+            let stderr = '';
 
-          statusProcess.on('exit', (code) => {
-            const output = stdout || stderr;
-            resolve({
-              isRunning: code === 0,
-              output: output.trim(),
-            });
-          });
+            if (statusProcess.stdout) {
+              statusProcess.stdout.on('data', (data) => {
+                stdout += data.toString();
+              });
+            }
 
-          statusProcess.on('error', () => {
-            resolve({
-              isRunning: false,
-              output: 'Tailscale command not found',
-            });
-          });
+            if (statusProcess.stderr) {
+              statusProcess.stderr.on('data', (data) => {
+                stderr += data.toString();
+              });
+            }
 
-          setTimeout(() => {
-            statusProcess.kill('SIGTERM');
-            resolve({
-              isRunning: false,
-              output: 'Tailscale status check timeout',
+            statusProcess.on('exit', (code) => {
+              const output = stdout || stderr;
+              resolve({
+                isRunning: code === 0,
+                output: output.trim(),
+              });
             });
-          }, 5000);
-        }
-      );
+
+            statusProcess.on('error', () => {
+              resolve({
+                isRunning: false,
+                output: 'Tailscale command not found',
+              });
+            });
+
+            setTimeout(() => {
+              statusProcess.kill('SIGTERM');
+              resolve({
+                isRunning: false,
+                output: 'Tailscale status check timeout',
+              });
+            }, 5000);
+          })
+        : {
+            isRunning: false,
+            output: 'Tailscale command not found',
+          };
 
       // Test 2: Check Tailscale Serve configuration
       const serveStatus = await tailscaleServeService.getStatus();

--- a/web/src/server/server.ts
+++ b/web/src/server/server.ts
@@ -878,8 +878,11 @@ export async function createApp(): Promise<AppInstance> {
         if (tailscaleStatus.isRunning && !tailscaleStatus.isPermanentlyDisabled) {
           try {
             // Get Tailscale hostname from status
-            const { execSync } = await import('child_process');
-            const statusJson = execSync('tailscale status --json', { encoding: 'utf8' });
+            const { execFileSync } = await import('child_process');
+            const tailscaleExecutable = await tailscaleServeService.getExecutablePath();
+            const statusJson = execFileSync(tailscaleExecutable, ['status', '--json'], {
+              encoding: 'utf8',
+            });
             const status = JSON.parse(statusJson);
 
             if (status.Self?.DNSName) {

--- a/web/src/server/services/tailscale-serve-service.test.ts
+++ b/web/src/server/services/tailscale-serve-service.test.ts
@@ -1,5 +1,12 @@
+import { chmod, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getTailscaleSearchPaths, TailscaleServeServiceImpl } from './tailscale-serve-service.js';
+import {
+  findTailscaleExecutable,
+  getTailscaleSearchPaths,
+  TailscaleServeServiceImpl,
+} from './tailscale-serve-service.js';
 
 // Mock the logger
 vi.mock('../../server/utils/logger.js', () => ({
@@ -49,6 +56,20 @@ describe('TailscaleServeService Integration Tests', () => {
           '/Users/alice/.nix-profile/bin/tailscale',
         ])
       );
+    });
+
+    it('resolves an executable from an explicit path outside PATH', async () => {
+      const directory = await mkdtemp(join(tmpdir(), 'vibetunnel-tailscale-'));
+      const executablePath = join(directory, 'tailscale');
+
+      try {
+        await writeFile(executablePath, '#!/bin/sh\nexit 0\n');
+        await chmod(executablePath, 0o755);
+
+        await expect(findTailscaleExecutable([executablePath])).resolves.toBe(executablePath);
+      } finally {
+        await rm(directory, { recursive: true, force: true });
+      }
     });
   });
 

--- a/web/src/server/services/tailscale-serve-service.test.ts
+++ b/web/src/server/services/tailscale-serve-service.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { TailscaleServeServiceImpl } from './tailscale-serve-service.js';
+import { getTailscaleSearchPaths, TailscaleServeServiceImpl } from './tailscale-serve-service.js';
 
 // Mock the logger
 vi.mock('../../server/utils/logger.js', () => ({
@@ -33,6 +33,23 @@ describe('TailscaleServeService Integration Tests', () => {
       process.env.VIBETUNNEL_SKIP_TAILSCALE = originalSkipTailscale;
     }
     vi.clearAllMocks();
+  });
+
+  describe('Executable discovery', () => {
+    it('includes nix-darwin system and user profile paths', () => {
+      expect(
+        getTailscaleSearchPaths('darwin', {
+          USER: 'alice',
+          HOME: '/Users/alice',
+        })
+      ).toEqual(
+        expect.arrayContaining([
+          '/run/current-system/sw/bin/tailscale',
+          '/etc/profiles/per-user/alice/bin/tailscale',
+          '/Users/alice/.nix-profile/bin/tailscale',
+        ])
+      );
+    });
   });
 
   describe('Exit Code Handling', () => {

--- a/web/src/server/services/tailscale-serve-service.test.ts
+++ b/web/src/server/services/tailscale-serve-service.test.ts
@@ -130,10 +130,12 @@ describe('TailscaleServeService Integration Tests', () => {
     it('reports a clean idle status before Serve has been configured', async () => {
       const internals = service as unknown as {
         currentPort: number | null;
+        getExecutablePath(): Promise<string>;
         verifyServeConfiguration(port: number): Promise<boolean>;
         checkServeAvailability(): Promise<string>;
       };
       internals.currentPort = null;
+      internals.getExecutablePath = vi.fn().mockRejectedValue(new Error('Tailscale not installed'));
       internals.verifyServeConfiguration = vi.fn().mockResolvedValue(false);
       internals.checkServeAvailability = vi.fn().mockResolvedValue('');
       delete process.env.VIBETUNNEL_SKIP_TAILSCALE;

--- a/web/src/server/services/tailscale-serve-service.ts
+++ b/web/src/server/services/tailscale-serve-service.ts
@@ -3,6 +3,38 @@ import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('tailscale-serve');
 
+export function getTailscaleSearchPaths(
+  platform = process.platform,
+  environment: NodeJS.ProcessEnv = process.env
+): string[] {
+  const nixPaths = [
+    '/run/current-system/sw/bin/tailscale',
+    environment.USER ? `/etc/profiles/per-user/${environment.USER}/bin/tailscale` : undefined,
+    environment.HOME ? `${environment.HOME}/.nix-profile/bin/tailscale` : undefined,
+  ].filter((path): path is string => path !== undefined);
+
+  if (platform === 'darwin') {
+    return [
+      '/Applications/Tailscale.app/Contents/MacOS/Tailscale',
+      '/usr/local/bin/tailscale',
+      '/opt/homebrew/bin/tailscale',
+      ...nixPaths,
+    ];
+  }
+
+  if (platform === 'linux') {
+    return [
+      '/usr/bin/tailscale',
+      '/usr/local/bin/tailscale',
+      '/opt/tailscale/bin/tailscale',
+      '/snap/bin/tailscale',
+      ...nixPaths,
+    ];
+  }
+
+  return nixPaths;
+}
+
 export interface TailscaleServeService {
   start(port: number, enableFunnel?: boolean): Promise<void>;
   stop(): Promise<void>;
@@ -1046,25 +1078,7 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
   private async checkTailscaleAvailable(): Promise<void> {
     const fs = await import('fs/promises');
 
-    // Platform-specific paths to check
-    let tailscalePaths: string[] = [];
-
-    if (process.platform === 'darwin') {
-      // macOS paths
-      tailscalePaths = [
-        '/Applications/Tailscale.app/Contents/MacOS/Tailscale',
-        '/usr/local/bin/tailscale',
-        '/opt/homebrew/bin/tailscale',
-      ];
-    } else if (process.platform === 'linux') {
-      // Linux paths
-      tailscalePaths = [
-        '/usr/bin/tailscale',
-        '/usr/local/bin/tailscale',
-        '/opt/tailscale/bin/tailscale',
-        '/snap/bin/tailscale',
-      ];
-    }
+    const tailscalePaths = getTailscaleSearchPaths();
 
     // Check platform-specific paths first
     for (const path of tailscalePaths) {

--- a/web/src/server/services/tailscale-serve-service.ts
+++ b/web/src/server/services/tailscale-serve-service.ts
@@ -1,4 +1,7 @@
 import { type ChildProcess, spawn } from 'child_process';
+import { constants as fsConstants } from 'fs';
+import { access } from 'fs/promises';
+import { delimiter, join } from 'path';
 import { createLogger } from '../utils/logger.js';
 
 const logger = createLogger('tailscale-serve');
@@ -7,6 +10,9 @@ export function getTailscaleSearchPaths(
   platform = process.platform,
   environment: NodeJS.ProcessEnv = process.env
 ): string[] {
+  const pathEntries = (environment.PATH?.split(delimiter) ?? [])
+    .filter((entry) => entry.length > 0)
+    .map((entry) => join(entry, platform === 'win32' ? 'tailscale.exe' : 'tailscale'));
   const nixPaths = [
     '/run/current-system/sw/bin/tailscale',
     environment.USER ? `/etc/profiles/per-user/${environment.USER}/bin/tailscale` : undefined,
@@ -14,25 +20,46 @@ export function getTailscaleSearchPaths(
   ].filter((path): path is string => path !== undefined);
 
   if (platform === 'darwin') {
-    return [
-      '/Applications/Tailscale.app/Contents/MacOS/Tailscale',
-      '/usr/local/bin/tailscale',
-      '/opt/homebrew/bin/tailscale',
-      ...nixPaths,
-    ];
+    return Array.from(
+      new Set([
+        '/Applications/Tailscale.app/Contents/MacOS/Tailscale',
+        '/usr/local/bin/tailscale',
+        '/opt/homebrew/bin/tailscale',
+        ...nixPaths,
+        ...pathEntries,
+      ])
+    );
   }
 
   if (platform === 'linux') {
-    return [
-      '/usr/bin/tailscale',
-      '/usr/local/bin/tailscale',
-      '/opt/tailscale/bin/tailscale',
-      '/snap/bin/tailscale',
-      ...nixPaths,
-    ];
+    return Array.from(
+      new Set([
+        '/usr/bin/tailscale',
+        '/usr/local/bin/tailscale',
+        '/opt/tailscale/bin/tailscale',
+        '/snap/bin/tailscale',
+        ...nixPaths,
+        ...pathEntries,
+      ])
+    );
   }
 
-  return nixPaths;
+  return Array.from(new Set([...nixPaths, ...pathEntries]));
+}
+
+export async function findTailscaleExecutable(
+  searchPaths = getTailscaleSearchPaths()
+): Promise<string | null> {
+  for (const executablePath of searchPaths) {
+    try {
+      await access(executablePath, fsConstants.X_OK);
+      return executablePath;
+    } catch {
+      // Continue checking other paths.
+    }
+  }
+
+  return null;
 }
 
 export interface TailscaleServeService {
@@ -41,6 +68,7 @@ export interface TailscaleServeService {
   isRunning(): boolean;
   isFunnelEnabled(): boolean;
   getStatus(): Promise<TailscaleServeStatus>;
+  getExecutablePath(): Promise<string>;
 }
 
 export interface TailscaleServeStatus {
@@ -572,6 +600,22 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
       };
     }
 
+    if (this.currentPort === null) {
+      try {
+        await this.getExecutablePath();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          isRunning: false,
+          lastError: message,
+          isPermanentlyDisabled: false,
+          funnelEnabled: false,
+          desiredMode: this.desiredFunnel ? 'public' : 'private',
+          actualMode: 'private',
+        };
+      }
+    }
+
     // IMPROVED CHECK: First verify if Tailscale Serve is actually configured and working
     // Only mark as permanently disabled if we can't detect any working configuration
     if (!this.isPermanentlyDisabled) {
@@ -1076,41 +1120,18 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
   }
 
   private async checkTailscaleAvailable(): Promise<void> {
-    const fs = await import('fs/promises');
+    await this.getExecutablePath();
+  }
 
-    const tailscalePaths = getTailscaleSearchPaths();
-
-    // Check platform-specific paths first
-    for (const path of tailscalePaths) {
-      try {
-        await fs.access(path, fs.constants.X_OK);
-        this.tailscaleExecutable = path;
-        logger.debug(`Found Tailscale at: ${path}`);
-        return;
-      } catch {
-        // Continue checking other paths
-      }
+  async getExecutablePath(): Promise<string> {
+    const executablePath = await findTailscaleExecutable();
+    if (!executablePath) {
+      throw new Error('Tailscale command not found. Please install Tailscale first.');
     }
 
-    // Fallback to checking PATH
-    return new Promise<void>((resolve, reject) => {
-      const checkProcess = spawn('which', ['tailscale'], {
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-
-      checkProcess.on('exit', (code) => {
-        if (code === 0) {
-          // Keep default 'tailscale' which will use PATH
-          resolve();
-        } else {
-          reject(new Error('Tailscale command not found. Please install Tailscale first.'));
-        }
-      });
-
-      checkProcess.on('error', (error) => {
-        reject(new Error(`Failed to check Tailscale availability: ${error.message}`));
-      });
-    });
+    this.tailscaleExecutable = executablePath;
+    logger.debug(`Found Tailscale at: ${executablePath}`);
+    return executablePath;
   }
 }
 

--- a/web/src/server/services/tailscale-serve-service.ts
+++ b/web/src/server/services/tailscale-serve-service.ts
@@ -604,10 +604,11 @@ export class TailscaleServeServiceImpl implements TailscaleServeService {
       try {
         await this.getExecutablePath();
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        logger.debug(`Tailscale executable unavailable while Serve is idle: ${error}`);
         return {
           isRunning: false,
-          lastError: message,
+          port: undefined,
+          lastError: undefined,
           isPermanentlyDisabled: false,
           funnelEnabled: false,
           desiredMode: this.desiredFunnel ? 'public' : 'private',


### PR DESCRIPTION
## Summary
- discover Tailscale CLI installs in nix-darwin system and user profiles
- fall back to `tailscale status --json` when the macOS app API is unavailable
- bound CLI status checks to five seconds with forced cleanup
- keep daemon installs usable in the Mac UI and embedded server
- document CLI/daemon setup and add regression coverage

## Verification
- `swift test --package-path mac --filter TailscaleCLITests` (5 passed, including hanging-command timeout)
- `pnpm exec vitest run src/server/services/tailscale-serve-service.test.ts` (23 passed)
- `pnpm run typecheck`
- Biome, SwiftFormat, strict SwiftLint, `git diff --check`
- unsigned arm64 Debug app build with checksum-verified Zig 0.15.2
- final autoreview clean

The full Swift package suite reached 292 tests; four unrelated existing keychain/config tests fail independently in NotificationService, NgrokService, and DashboardKeychain.

Closes #259