### PR TITLE
Re-register HQ remotes on a heartbeat so slept/reconnected hosts rejoin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Let HQ remotes rejoin automatically after sleep or a network interruption without restarting VibeTunnel (thanks [@Ebonsignori](https://github.com/Ebonsignori)) (#698).
+- Stopped HQ registration diagnostics from logging Basic or bearer authentication material.
 - Restored macOS Release builds on Xcode 16.4 by making Pangolin connection-state handling compatible with Swift 6.1.
 
 ## [1.0.0-beta.16] - 2026-06-16

--- a/docs/hq.md
+++ b/docs/hq.md
@@ -37,6 +37,7 @@ When a remote server starts with HQ configuration:
 - HQ performs health checks every 15 seconds on all registered remotes
 - Health check: `GET /api/health` with 5-second timeout
 - Failed remotes are automatically unregistered
+- Remotes refresh their registration every 60 seconds and automatically rejoin after sleep or a network interruption
 
 ### 4. Session Discovery
 
@@ -231,7 +232,6 @@ The e2e tests in `src/test/e2e/hq-mode.e2e.test.ts` demonstrate:
 - Health checks use a fixed 15-second interval
 - No built-in load balancing (clients must specify remoteId)
 - Bearer tokens are generated per server startup (not persistent)
-- No automatic reconnection if remote temporarily fails
 
 ## Security Considerations
 

--- a/web/src/server/routes/remotes.ts
+++ b/web/src/server/routes/remotes.ts
@@ -51,7 +51,11 @@ export function createRemoteRoutes(config: RemoteRoutesConfig): Router {
     logger.debug(`attempting to register remote ${name} (${id}) from ${url}`);
 
     try {
-      const remote = remoteRegistry.register({ id, name, url, token });
+      const { remote, created } = remoteRegistry.register({ id, name, url, token });
+      if (!created) {
+        logger.debug(`remote registration refreshed: ${name} (${id})`);
+        return res.status(204).send();
+      }
       logger.log(chalk.green(`remote registered: ${name} (${id}) from ${url}`));
       res.json({ success: true, remote });
     } catch (error) {

--- a/web/src/server/server.ts
+++ b/web/src/server/server.ts
@@ -1653,6 +1653,11 @@ export async function createApp(): Promise<AppInstance> {
         hqClient.register().catch((err) => {
           logger.error('Failed to register with HQ:', err);
         });
+        // Keep the registration alive: if this host sleeps or briefly loses the
+        // network long enough for HQ to evict it, the heartbeat re-registers it
+        // once it's reachable again (no restart needed). A healthy heartbeat is a
+        // quiet 409 no-op. See HQClient.startHeartbeat.
+        hqClient.startHeartbeat();
       }
 
       // Start control directory watcher

--- a/web/src/server/server.ts
+++ b/web/src/server/server.ts
@@ -1637,7 +1637,7 @@ export async function createApp(): Promise<AppInstance> {
           logger.log(
             chalk.green(`Remote mode: ${config.remoteName} will accept Bearer token for HQ access`)
           );
-          logger.debug(`Bearer token: ${hqClient.getToken()}`);
+          logger.debug('Bearer authentication configured for HQ callbacks');
         }
       }
 
@@ -1650,13 +1650,9 @@ export async function createApp(): Promise<AppInstance> {
       // Register with HQ if configured
       if (hqClient) {
         logger.log(`Registering with HQ at ${config.hqUrl}`);
-        hqClient.register().catch((err) => {
-          logger.error('Failed to register with HQ:', err);
-        });
-        // Keep the registration alive: if this host sleeps or briefly loses the
-        // network long enough for HQ to evict it, the heartbeat re-registers it
-        // once it's reachable again (no restart needed). A healthy heartbeat is a
-        // quiet 409 no-op. See HQClient.startHeartbeat.
+        // Register immediately and keep retrying after each bounded request. If
+        // this host is evicted while asleep, it rejoins after waking without a
+        // VibeTunnel restart. See HQClient.startHeartbeat.
         hqClient.startHeartbeat();
       }
 

--- a/web/src/server/services/hq-client.test.ts
+++ b/web/src/server/services/hq-client.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Quiet logger so the heartbeat's debug/error lines don't clutter test output.
+vi.mock('../utils/logger.js', () => ({
+  createLogger: vi.fn(() => ({
+    warn: vi.fn(),
+    log: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  })),
+}));
+
+const { HQClient } = await import('./hq-client.js');
+
+function makeClient() {
+  return new HQClient(
+    'http://hq.test',
+    'hq-user',
+    'hq-pass',
+    'laptop',
+    'http://laptop.test:4020',
+    'bearer-token'
+  );
+}
+
+describe('HQClient re-registration heartbeat', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const ok = () => ({ ok: true, status: 200, text: async () => '' }) as unknown as Response;
+  const conflict = () =>
+    ({ ok: false, status: 409, text: async () => 'already registered' }) as unknown as Response;
+  const serverError = () =>
+    ({ ok: false, status: 500, text: async () => 'boom' }) as unknown as Response;
+
+  it('re-registers on each interval', async () => {
+    fetchMock.mockResolvedValue(ok());
+    const client = makeClient();
+
+    client.startHeartbeat(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(0);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    client.stopHeartbeat();
+  });
+
+  it('treats a 409 (already registered) as an idempotent success, not a throw', async () => {
+    // The steady state: the remote is still registered, HQ replies 409 every beat.
+    fetchMock.mockResolvedValue(conflict());
+    const client = makeClient();
+
+    // register() must resolve (not reject) on 409 so the heartbeat stays quiet.
+    await expect(client.register()).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1); // the manual register above
+
+    client.startHeartbeat(1000);
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(fetchMock).toHaveBeenCalledTimes(4); // 1 manual + 3 beats, no unhandled rejection
+    client.stopHeartbeat();
+  });
+
+  it('recovers after eviction: a later beat re-registers once HQ accepts again', async () => {
+    // While registered → 409; after the host slept and HQ evicted it, the POST
+    // succeeds again. The heartbeat must keep firing across that transition.
+    fetchMock
+      .mockResolvedValueOnce(conflict()) // beat 1 — still registered
+      .mockResolvedValueOnce(conflict()) // beat 2 — still registered
+      .mockResolvedValueOnce(ok()); // beat 3 — evicted, re-registered
+    const client = makeClient();
+
+    client.startHeartbeat(1000);
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    client.stopHeartbeat();
+  });
+
+  it('keeps beating through a transient HQ failure', async () => {
+    // A 500 / network blip on one beat must not stop the heartbeat.
+    fetchMock
+      .mockResolvedValueOnce(serverError())
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValue(ok());
+    const client = makeClient();
+
+    client.startHeartbeat(1000);
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    client.stopHeartbeat();
+  });
+
+  it('startHeartbeat is idempotent (a second call does not double the cadence)', async () => {
+    fetchMock.mockResolvedValue(ok());
+    const client = makeClient();
+
+    client.startHeartbeat(1000);
+    client.startHeartbeat(1000); // ignored — already running
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // one beat, not two
+    client.stopHeartbeat();
+  });
+
+  it('stopHeartbeat halts further beats', async () => {
+    fetchMock.mockResolvedValue(ok());
+    const client = makeClient();
+
+    client.startHeartbeat(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    client.stopHeartbeat();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fetchMock).toHaveBeenCalledTimes(1); // no more beats
+  });
+
+  it('destroy() stops the heartbeat (no beat after teardown)', async () => {
+    fetchMock.mockResolvedValue(ok());
+    const client = makeClient();
+
+    client.startHeartbeat(1000);
+    await client.destroy(); // unregisters + stops heartbeat
+    await vi.advanceTimersByTimeAsync(5000);
+
+    // The only fetch was destroy()'s DELETE; no heartbeat POSTs after.
+    const posts = fetchMock.mock.calls.filter(([, init]) => init?.method !== 'DELETE');
+    expect(posts).toHaveLength(0);
+  });
+});

--- a/web/src/server/services/hq-client.test.ts
+++ b/web/src/server/services/hq-client.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Quiet logger so the heartbeat's debug/error lines don't clutter test output.
 vi.mock('../utils/logger.js', () => ({
   createLogger: vi.fn(() => ({
     warn: vi.fn(),
@@ -23,6 +22,22 @@ function makeClient() {
   );
 }
 
+function response(status: number): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => `status ${status}`,
+  } as Response;
+}
+
+function deferredResponse() {
+  let resolve!: (response: Response) => void;
+  const promise = new Promise<Response>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe('HQClient re-registration heartbeat', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -38,106 +53,103 @@ describe('HQClient re-registration heartbeat', () => {
     vi.restoreAllMocks();
   });
 
-  const ok = () => ({ ok: true, status: 200, text: async () => '' }) as unknown as Response;
-  const conflict = () =>
-    ({ ok: false, status: 409, text: async () => 'already registered' }) as unknown as Response;
-  const serverError = () =>
-    ({ ok: false, status: 500, text: async () => 'boom' }) as unknown as Response;
-
-  it('re-registers on each interval', async () => {
-    fetchMock.mockResolvedValue(ok());
+  it('registers immediately and after each completed interval', async () => {
+    fetchMock.mockResolvedValue(response(200));
     const client = makeClient();
 
     client.startHeartbeat(1000);
-    expect(fetchMock).toHaveBeenCalledTimes(0);
-
-    await vi.advanceTimersByTimeAsync(1000);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-
     await vi.advanceTimersByTimeAsync(1000);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
 
     client.stopHeartbeat();
   });
 
-  it('treats a 409 (already registered) as an idempotent success, not a throw', async () => {
-    // The steady state: the remote is still registered, HQ replies 409 every beat.
-    fetchMock.mockResolvedValue(conflict());
+  it('accepts an idempotent 204 refresh but still rejects a name collision', async () => {
     const client = makeClient();
+    fetchMock.mockResolvedValueOnce(response(204)).mockResolvedValueOnce(response(409));
 
-    // register() must resolve (not reject) on 409 so the heartbeat stays quiet.
     await expect(client.register()).resolves.toBeUndefined();
-    expect(fetchMock).toHaveBeenCalledTimes(1); // the manual register above
-
-    client.startHeartbeat(1000);
-    await vi.advanceTimersByTimeAsync(3000);
-    expect(fetchMock).toHaveBeenCalledTimes(4); // 1 manual + 3 beats, no unhandled rejection
-    client.stopHeartbeat();
+    await expect(client.register()).rejects.toThrow('Registration failed (409)');
   });
 
-  it('recovers after eviction: a later beat re-registers once HQ accepts again', async () => {
-    // While registered → 409; after the host slept and HQ evicted it, the POST
-    // succeeds again. The heartbeat must keep firing across that transition.
+  it('recovers after eviction when a later registration is created again', async () => {
     fetchMock
-      .mockResolvedValueOnce(conflict()) // beat 1 — still registered
-      .mockResolvedValueOnce(conflict()) // beat 2 — still registered
-      .mockResolvedValueOnce(ok()); // beat 3 — evicted, re-registered
+      .mockResolvedValueOnce(response(204))
+      .mockResolvedValueOnce(response(204))
+      .mockResolvedValueOnce(response(200));
     const client = makeClient();
 
     client.startHeartbeat(1000);
-    await vi.advanceTimersByTimeAsync(3000);
+    await vi.advanceTimersByTimeAsync(2000);
     expect(fetchMock).toHaveBeenCalledTimes(3);
     client.stopHeartbeat();
   });
 
-  it('keeps beating through a transient HQ failure', async () => {
-    // A 500 / network blip on one beat must not stop the heartbeat.
+  it('keeps retrying through transient HQ failures', async () => {
     fetchMock
-      .mockResolvedValueOnce(serverError())
+      .mockResolvedValueOnce(response(500))
       .mockRejectedValueOnce(new Error('ECONNREFUSED'))
-      .mockResolvedValue(ok());
+      .mockResolvedValue(response(200));
     const client = makeClient();
 
     client.startHeartbeat(1000);
-    await vi.advanceTimersByTimeAsync(3000);
+    await vi.advanceTimersByTimeAsync(2000);
     expect(fetchMock).toHaveBeenCalledTimes(3);
     client.stopHeartbeat();
   });
 
-  it('startHeartbeat is idempotent (a second call does not double the cadence)', async () => {
-    fetchMock.mockResolvedValue(ok());
+  it('does not overlap registration requests', async () => {
+    const pending = deferredResponse();
+    fetchMock.mockReturnValueOnce(pending.promise).mockResolvedValue(response(204));
     const client = makeClient();
 
     client.startHeartbeat(1000);
-    client.startHeartbeat(1000); // ignored — already running
-    await vi.advanceTimersByTimeAsync(1000);
-    expect(fetchMock).toHaveBeenCalledTimes(1); // one beat, not two
-    client.stopHeartbeat();
-  });
-
-  it('stopHeartbeat halts further beats', async () => {
-    fetchMock.mockResolvedValue(ok());
-    const client = makeClient();
-
-    client.startHeartbeat(1000);
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(5000);
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
+    pending.resolve(response(200));
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     client.stopHeartbeat();
-    await vi.advanceTimersByTimeAsync(5000);
-    expect(fetchMock).toHaveBeenCalledTimes(1); // no more beats
   });
 
-  it('destroy() stops the heartbeat (no beat after teardown)', async () => {
-    fetchMock.mockResolvedValue(ok());
+  it('starts only one heartbeat loop', () => {
+    fetchMock.mockReturnValue(new Promise<Response>(() => {}));
     const client = makeClient();
 
     client.startHeartbeat(1000);
-    await client.destroy(); // unregisters + stops heartbeat
-    await vi.advanceTimersByTimeAsync(5000);
+    client.startHeartbeat(1000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    client.stopHeartbeat();
+  });
 
-    // The only fetch was destroy()'s DELETE; no heartbeat POSTs after.
-    const posts = fetchMock.mock.calls.filter(([, init]) => init?.method !== 'DELETE');
-    expect(posts).toHaveLength(0);
+  it('stops scheduled registrations', async () => {
+    fetchMock.mockResolvedValue(response(204));
+    const client = makeClient();
+
+    client.startHeartbeat(1000);
+    await vi.advanceTimersByTimeAsync(0);
+    client.stopHeartbeat();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('waits for an active registration before unregistering during teardown', async () => {
+    const pending = deferredResponse();
+    fetchMock.mockReturnValueOnce(pending.promise).mockResolvedValueOnce(response(200));
+    const client = makeClient();
+
+    client.startHeartbeat(1000);
+    const destroyPromise = client.destroy();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    pending.resolve(response(200));
+    await destroyPromise;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.map(([, init]) => init?.method)).toEqual(['POST', 'DELETE']);
   });
 });

--- a/web/src/server/services/hq-client.ts
+++ b/web/src/server/services/hq-client.ts
@@ -73,6 +73,7 @@ const logger = createLogger('hq-client');
  * of coming back online, without hammering the HQ while healthy.
  */
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 60_000;
+const HQ_REQUEST_TIMEOUT_MS = 10_000;
 
 export class HQClient {
   private readonly hqUrl: string;
@@ -82,7 +83,10 @@ export class HQClient {
   private readonly hqUsername: string;
   private readonly hqPassword: string;
   private readonly remoteUrl: string;
-  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private heartbeatTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatRequest: Promise<void> | null = null;
+  private heartbeatActive = false;
+  private heartbeatIntervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS;
 
   /**
    * Create a new HQ client
@@ -160,31 +164,28 @@ export class HQClient {
           url: this.remoteUrl,
           token: this.token, // Token for HQ to authenticate with this remote
         }),
+        signal: AbortSignal.timeout(HQ_REQUEST_TIMEOUT_MS),
       });
 
-      if (!response.ok) {
-        // 409 = a remote with this name is already registered. That's the steady
-        // state for the re-registration heartbeat (see startHeartbeat): treat it
-        // as an idempotent success rather than an error, so a healthy remote
-        // doesn't log a failure every heartbeat.
-        if (response.status === 409) {
-          logger.debug(`already registered with hq as ${this.remoteName} (${this.remoteId})`);
-          return;
-        }
+      if (response.status === 204) {
+        logger.debug(`registration refreshed with hq: ${this.remoteName} (${this.remoteId})`);
+        return;
+      }
 
+      if (!response.ok) {
         const errorText = await response.text();
         logger.error(`registration failed with status ${response.status}: ${errorText}`);
         logger.debug('registration request details:', {
           url: `${this.hqUrl}/api/remotes/register`,
           headers: {
             'Content-Type': 'application/json',
-            Authorization: `Basic ${Buffer.from(`${this.hqUsername}:${this.hqPassword}`).toString('base64')}`,
+            Authorization: '[redacted]',
           },
           body: {
             id: this.remoteId,
             name: this.remoteName,
             url: this.remoteUrl,
-            token: `${this.token.substring(0, 8)}...`,
+            token: '[redacted]',
           },
         });
         throw new Error(`Registration failed (${response.status}): ${errorText}`);
@@ -197,7 +198,6 @@ export class HQClient {
       logger.debug('registration details', {
         remoteId: this.remoteId,
         remoteName: this.remoteName,
-        token: `${this.token.substring(0, 8)}...`,
       });
     } catch (error) {
       logger.error('failed to register with hq:', error);
@@ -214,43 +214,64 @@ export class HQClient {
    * to be evicted, it never reappears in HQ until its process restarts — even
    * after the host wakes and is reachable again.
    *
-   * This heartbeat closes that gap: it re-calls {@link register} on an interval.
-   * While the remote is still registered the HQ replies 409, which `register`
-   * treats as an idempotent success, so healthy heartbeats are quiet no-ops. Once
-   * the remote has been evicted, the next heartbeat re-registers it (the name is
-   * freed on eviction), so a slept/reconnected host is picked back up within one
-   * interval — no restart required.
+   * This heartbeat closes that gap: it registers immediately, then re-calls
+   * {@link register} after each completed request. HQ accepts an identical remote
+   * ID as an idempotent refresh while rejecting another process that merely uses
+   * the same name. Once the remote has been evicted, the next heartbeat registers
+   * it again, so a slept/reconnected host is picked back up without a restart.
    *
    * Idempotent: calling it again while a heartbeat is running is a no-op.
    *
    * @param intervalMs - Milliseconds between heartbeats (default 60s).
    */
   startHeartbeat(intervalMs: number = DEFAULT_HEARTBEAT_INTERVAL_MS): void {
-    if (this.heartbeatTimer) {
+    if (this.heartbeatActive) {
       logger.debug('heartbeat already running; ignoring startHeartbeat');
       return;
     }
+    this.heartbeatActive = true;
+    this.heartbeatIntervalMs = intervalMs;
     logger.debug(`starting hq re-registration heartbeat every ${intervalMs}ms`);
-    this.heartbeatTimer = setInterval(() => {
-      this.register().catch((err) => {
+    this.runHeartbeat();
+  }
+
+  private runHeartbeat(): void {
+    if (!this.heartbeatActive) {
+      return;
+    }
+
+    const request = this.register()
+      .catch((err) => {
         // A transient failure (HQ briefly down, network blip) is expected to
         // recover on the next beat; log at debug so a flaky link doesn't spam.
         logger.debug('hq heartbeat re-registration failed (will retry):', err);
+      })
+      .finally(() => {
+        if (this.heartbeatRequest === request) {
+          this.heartbeatRequest = null;
+        }
+        if (!this.heartbeatActive) {
+          return;
+        }
+        this.heartbeatTimer = setTimeout(() => {
+          this.heartbeatTimer = null;
+          this.runHeartbeat();
+        }, this.heartbeatIntervalMs);
+        this.heartbeatTimer.unref?.();
       });
-    }, intervalMs);
-    // Don't let the heartbeat keep the process alive on its own.
-    this.heartbeatTimer.unref?.();
+    this.heartbeatRequest = request;
   }
 
   /**
    * Stop the re-registration heartbeat, if running.
    */
   stopHeartbeat(): void {
+    this.heartbeatActive = false;
     if (this.heartbeatTimer) {
-      clearInterval(this.heartbeatTimer);
+      clearTimeout(this.heartbeatTimer);
       this.heartbeatTimer = null;
-      logger.debug('stopped hq re-registration heartbeat');
     }
+    logger.debug('stopped hq re-registration heartbeat');
   }
 
   /**
@@ -281,6 +302,13 @@ export class HQClient {
     // below and immediately re-add this remote during shutdown.
     this.stopHeartbeat();
 
+    // An already-started registration cannot be cancelled without also
+    // cancelling unrelated fetches. It is timeout-bounded, so let it settle
+    // before unregistering to prevent a late POST from re-adding this remote.
+    if (this.heartbeatRequest) {
+      await this.heartbeatRequest;
+    }
+
     try {
       // Try to unregister
       const response = await fetch(`${this.hqUrl}/api/remotes/${this.remoteId}`, {
@@ -288,6 +316,7 @@ export class HQClient {
         headers: {
           Authorization: `Basic ${Buffer.from(`${this.hqUsername}:${this.hqPassword}`).toString('base64')}`,
         },
+        signal: AbortSignal.timeout(HQ_REQUEST_TIMEOUT_MS),
       });
 
       if (response.ok) {
@@ -311,19 +340,6 @@ export class HQClient {
    */
   getRemoteId(): string {
     return this.remoteId;
-  }
-
-  /**
-   * Get the bearer token for this remote
-   *
-   * This token is provided by the remote server and given to HQ during
-   * registration. HQ uses this token to authenticate when connecting
-   * back to this remote (e.g., for WebSocket buffer streaming).
-   *
-   * @returns The bearer token for HQ authentication
-   */
-  getToken(): string {
-    return this.token;
   }
 
   /**

--- a/web/src/server/services/hq-client.ts
+++ b/web/src/server/services/hq-client.ts
@@ -64,6 +64,16 @@ const logger = createLogger('hq-client');
  * @see web/src/server/services/buffer-aggregator.ts for cross-server buffer streaming
  * @see web/src/server/server.ts for HQ mode initialization
  */
+/**
+ * Default interval (ms) between re-registration heartbeats.
+ *
+ * Chosen to be comfortably longer than the HQ's eviction window
+ * (RemoteRegistry evicts a remote after 3 failed 15s health checks, i.e. ~45s),
+ * so a remote that was evicted while its host slept is re-added within one cycle
+ * of coming back online, without hammering the HQ while healthy.
+ */
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 60_000;
+
 export class HQClient {
   private readonly hqUrl: string;
   private readonly remoteId: string;
@@ -72,6 +82,7 @@ export class HQClient {
   private readonly hqUsername: string;
   private readonly hqPassword: string;
   private readonly remoteUrl: string;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
   /**
    * Create a new HQ client
@@ -152,6 +163,15 @@ export class HQClient {
       });
 
       if (!response.ok) {
+        // 409 = a remote with this name is already registered. That's the steady
+        // state for the re-registration heartbeat (see startHeartbeat): treat it
+        // as an idempotent success rather than an error, so a healthy remote
+        // doesn't log a failure every heartbeat.
+        if (response.status === 409) {
+          logger.debug(`already registered with hq as ${this.remoteName} (${this.remoteId})`);
+          return;
+        }
+
         const errorText = await response.text();
         logger.error(`registration failed with status ${response.status}: ${errorText}`);
         logger.debug('registration request details:', {
@@ -186,6 +206,54 @@ export class HQClient {
   }
 
   /**
+   * Start a periodic re-registration heartbeat.
+   *
+   * The HQ's {@link RemoteRegistry} health-checks each remote every 15s and
+   * evicts it after 3 consecutive failures (~45s). A remote registers only once
+   * at startup, so if its host sleeps (or briefly loses the network) long enough
+   * to be evicted, it never reappears in HQ until its process restarts — even
+   * after the host wakes and is reachable again.
+   *
+   * This heartbeat closes that gap: it re-calls {@link register} on an interval.
+   * While the remote is still registered the HQ replies 409, which `register`
+   * treats as an idempotent success, so healthy heartbeats are quiet no-ops. Once
+   * the remote has been evicted, the next heartbeat re-registers it (the name is
+   * freed on eviction), so a slept/reconnected host is picked back up within one
+   * interval — no restart required.
+   *
+   * Idempotent: calling it again while a heartbeat is running is a no-op.
+   *
+   * @param intervalMs - Milliseconds between heartbeats (default 60s).
+   */
+  startHeartbeat(intervalMs: number = DEFAULT_HEARTBEAT_INTERVAL_MS): void {
+    if (this.heartbeatTimer) {
+      logger.debug('heartbeat already running; ignoring startHeartbeat');
+      return;
+    }
+    logger.debug(`starting hq re-registration heartbeat every ${intervalMs}ms`);
+    this.heartbeatTimer = setInterval(() => {
+      this.register().catch((err) => {
+        // A transient failure (HQ briefly down, network blip) is expected to
+        // recover on the next beat; log at debug so a flaky link doesn't spam.
+        logger.debug('hq heartbeat re-registration failed (will retry):', err);
+      });
+    }, intervalMs);
+    // Don't let the heartbeat keep the process alive on its own.
+    this.heartbeatTimer.unref?.();
+  }
+
+  /**
+   * Stop the re-registration heartbeat, if running.
+   */
+  stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+      logger.debug('stopped hq re-registration heartbeat');
+    }
+  }
+
+  /**
    * Unregister from HQ and clean up
    *
    * Attempts to gracefully unregister this remote from the HQ server.
@@ -208,6 +276,10 @@ export class HQClient {
    */
   async destroy(): Promise<void> {
     logger.log(chalk.yellow(`unregistering from hq: ${this.remoteName} (${this.remoteId})`));
+
+    // Stop the re-registration heartbeat first so it can't race the unregister
+    // below and immediately re-add this remote during shutdown.
+    this.stopHeartbeat();
 
     try {
       // Try to unregister

--- a/web/src/server/services/remote-registry.test.ts
+++ b/web/src/server/services/remote-registry.test.ts
@@ -38,8 +38,45 @@ describe('RemoteRegistry health checks', () => {
       name: `remote-${id}`,
       url: `http://remote-${id}.example`,
       token: 'token',
-    });
+    }).remote;
   }
+
+  it('treats an identical remote id as an idempotent registration refresh', () => {
+    fetchMock.mockResolvedValue({ ok: true } as Response);
+    const original = registerRemote('same');
+    const refresh = registry.register({
+      id: original.id,
+      name: original.name,
+      url: original.url,
+      token: original.token,
+    });
+
+    expect(refresh).toEqual({ remote: original, created: false });
+    expect(registry.getRemotes()).toEqual([original]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a different remote that collides by name or id', () => {
+    fetchMock.mockResolvedValue({ ok: true } as Response);
+    const original = registerRemote('original');
+
+    expect(() =>
+      registry.register({
+        id: 'other-id',
+        name: original.name,
+        url: 'http://other.example',
+        token: 'other-token',
+      })
+    ).toThrow('already registered');
+    expect(() =>
+      registry.register({
+        id: original.id,
+        name: original.name,
+        url: 'http://other.example',
+        token: original.token,
+      })
+    ).toThrow('already registered');
+  });
 
   function deferredResponse() {
     let reject!: (reason?: unknown) => void;

--- a/web/src/server/services/remote-registry.ts
+++ b/web/src/server/services/remote-registry.ts
@@ -14,6 +14,11 @@ export interface RemoteServer {
   sessionIds: Set<string>; // Track which sessions belong to this remote
 }
 
+export interface RemoteRegistrationResult {
+  remote: RemoteServer;
+  created: boolean;
+}
+
 export class RemoteRegistry {
   private remotes: Map<string, RemoteServer> = new Map();
   private remotesByName: Map<string, RemoteServer> = new Map();
@@ -34,7 +39,19 @@ export class RemoteRegistry {
 
   register(
     remote: Omit<RemoteServer, 'registeredAt' | 'lastHeartbeat' | 'sessionIds'>
-  ): RemoteServer {
+  ): RemoteRegistrationResult {
+    const existingById = this.remotes.get(remote.id);
+    if (existingById) {
+      const isSameRemote =
+        existingById.name === remote.name &&
+        existingById.url === remote.url &&
+        existingById.token === remote.token;
+      if (!isSameRemote) {
+        throw new Error(`Remote with id '${remote.id}' is already registered`);
+      }
+      return { remote: existingById, created: false };
+    }
+
     // Check if a remote with the same name already exists
     if (this.remotesByName.has(remote.name)) {
       throw new Error(`Remote with name '${remote.name}' is already registered`);
@@ -55,7 +72,7 @@ export class RemoteRegistry {
     // Immediately check health of new remote
     this.checkRemoteHealth(registeredRemote);
 
-    return registeredRemote;
+    return { remote: registeredRemote, created: true };
   }
 
   unregister(remoteId: string): boolean {


### PR DESCRIPTION
## Problem

HQ evicts a remote after three failed callback health checks, but a remote previously registered only at startup. A laptop that slept or lost the network therefore disappeared from HQ permanently until VibeTunnel restarted.

## Fix

- register immediately and refresh the same remote ID every 60 seconds
- automatically re-register after HQ evicts an unreachable remote
- treat only an identical ID/name/URL/token tuple as an idempotent refresh; a different process using the same name remains a conflict
- schedule the next beat only after the prior request settles, with a 10-second timeout, so requests cannot overlap indefinitely
- wait for any active registration before unregistering during shutdown, preventing a late POST from re-adding the remote
- redact Basic and bearer authentication material from HQ diagnostics
- document automatic rejoin behavior and credit the contributor in the changelog

The unrelated HQ session-target picker from the earlier branch revision was split out for independent review and proof.

## Proof

- `pnpm check` — passed
- `pnpm test:server` — 64 files passed, 638 tests passed, 6 files/75 tests skipped
- focused HQ client and registry suites — 14/14 passed
- server TypeScript check — passed
- live eviction/rejoin — local HQ and remote registered; the remote was explicitly evicted, the registry became empty, and the same UUID reappeared at the next 60-second heartbeat
- live steady state — a following heartbeat preserved `registeredAt` and the single registry entry while callback health continued updating
- structured autoreview — clean; no accepted/actionable findings
- Public Model Identifier Gate — PASS; no model-bearing code, fixtures, generated metadata, workflow text, or proof text changed

Live proof used loopback-only disposable processes with authentication disabled; both listeners were stopped after verification.
