### PR TITLE
Add --remote-url to override the advertised remote URL for HQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Let HQ remotes advertise a reachable callback origin with `--remote-url`, including validated IPv6 and tailnet addresses (thanks [@Ebonsignori](https://github.com/Ebonsignori)) (#699).
+
 ### Fixed
 
 - Restored macOS Release builds on Xcode 16.4 by making Pangolin connection-state handling compatible with Swift 6.1.

--- a/docs/hq.md
+++ b/docs/hq.md
@@ -75,6 +75,14 @@ vibetunnel-server \
   --hq-password secret \
   --name dev-remote \
   --allow-insecure-hq
+
+# Advertise an address that the HQ can resolve and reach
+vibetunnel-server \
+  --hq-url https://hq.example.com \
+  --hq-username admin \
+  --hq-password secret \
+  --name tailnet-remote \
+  --remote-url http://100.64.0.5:4020
 ```
 
 ### Command-Line Options
@@ -89,6 +97,7 @@ vibetunnel-server \
 - `--hq-username` - Username to authenticate with HQ
 - `--hq-password` - Password to authenticate with HQ
 - `--name` - Unique name for this remote server
+- `--remote-url` - HTTP(S) origin the HQ uses to connect back to this remote; defaults to the bind address or hostname
 - `--allow-insecure-hq` - Allow HTTP connections to HQ (dev only)
 - `--no-hq-auth` - Disable HQ authentication (testing only)
 
@@ -218,6 +227,7 @@ The e2e tests in `src/test/e2e/hq-mode.e2e.test.ts` demonstrate:
 ## Limitations
 
 - Remotes must be network-accessible from the HQ server
+- If the default hostname is not resolvable from HQ, set `--remote-url` to a reachable origin such as a tailnet address
 - Health checks use a fixed 15-second interval
 - No built-in load balancing (clients must specify remoteId)
 - Bearer tokens are generated per server startup (not persistent)
@@ -226,6 +236,7 @@ The e2e tests in `src/test/e2e/hq-mode.e2e.test.ts` demonstrate:
 ## Security Considerations
 
 - Always use HTTPS in production (use `--allow-insecure-hq` only for local dev)
+- Use HTTPS for `--remote-url` on untrusted networks because HQ sends the remote bearer token on callback requests
 - Bearer tokens are sensitive - they allow HQ to execute commands on remotes
 - HQ credentials should be strong and kept secure
 - Consider network isolation between HQ and remotes

--- a/web/src/server/server-remote-url.test.ts
+++ b/web/src/server/server-remote-url.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRemoteUrl } from './server.js';
+
+describe('resolveRemoteUrl', () => {
+  const host = () => 'My-Laptop'; // a mixed-case hostname the HQ may not resolve
+
+  it('uses an explicit --remote-url verbatim, ignoring bind/hostname', () => {
+    expect(resolveRemoteUrl('http://100.64.0.5:4020', '0.0.0.0', 4020, host)).toBe(
+      'http://100.64.0.5:4020'
+    );
+    // Even a non-default bind is overridden by the explicit URL.
+    expect(resolveRemoteUrl('http://hq-knows-me:9999', '10.0.0.2', 4020, host)).toBe(
+      'http://hq-knows-me:9999'
+    );
+  });
+
+  it('derives from the bind address when no --remote-url is given', () => {
+    expect(resolveRemoteUrl(null, '10.0.0.2', 4020, host)).toBe('http://10.0.0.2:4020');
+    expect(resolveRemoteUrl(undefined, '192.168.1.50', 4021, host)).toBe(
+      'http://192.168.1.50:4021'
+    );
+  });
+
+  it('falls back to the hostname when bound to 0.0.0.0', () => {
+    // This is the problematic default the flag exists to override: the HQ may
+    // not be able to resolve "My-Laptop".
+    expect(resolveRemoteUrl(null, '0.0.0.0', 4020, host)).toBe('http://My-Laptop:4020');
+  });
+
+  it('defaults the hostname resolver to os.hostname() (smoke)', () => {
+    // Without an injected resolver it should still produce a well-formed URL.
+    const url = resolveRemoteUrl(null, '0.0.0.0', 4020);
+    expect(url).toMatch(/^http:\/\/.+:4020$/);
+  });
+});

--- a/web/src/server/server-remote-url.test.ts
+++ b/web/src/server/server-remote-url.test.ts
@@ -4,13 +4,27 @@ import { resolveRemoteUrl } from './server.js';
 describe('resolveRemoteUrl', () => {
   const host = () => 'My-Laptop'; // a mixed-case hostname the HQ may not resolve
 
-  it('uses an explicit --remote-url verbatim, ignoring bind/hostname', () => {
+  it('uses and normalizes an explicit --remote-url, ignoring bind/hostname', () => {
     expect(resolveRemoteUrl('http://100.64.0.5:4020', '0.0.0.0', 4020, host)).toBe(
       'http://100.64.0.5:4020'
     );
-    // Even a non-default bind is overridden by the explicit URL.
-    expect(resolveRemoteUrl('http://hq-knows-me:9999', '10.0.0.2', 4020, host)).toBe(
+    expect(resolveRemoteUrl('http://HQ-KNOWS-ME:9999/', '10.0.0.2', 4020, host)).toBe(
       'http://hq-knows-me:9999'
+    );
+  });
+
+  it('rejects advertised URLs that are unsafe or cannot be used as a base origin', () => {
+    expect(() => resolveRemoteUrl('ssh://remote:4020', '0.0.0.0', 4020, host)).toThrow(
+      'must use HTTP or HTTPS'
+    );
+    expect(() => resolveRemoteUrl('http://user:pass@remote:4020', '0.0.0.0', 4020, host)).toThrow(
+      'must not include credentials'
+    );
+    expect(() => resolveRemoteUrl('http://remote:4020/base', '0.0.0.0', 4020, host)).toThrow(
+      'must not include a path, query, or fragment'
+    );
+    expect(() => resolveRemoteUrl('', '0.0.0.0', 4020, host)).toThrow(
+      'must be a valid HTTP or HTTPS URL'
     );
   });
 
@@ -25,6 +39,11 @@ describe('resolveRemoteUrl', () => {
     // This is the problematic default the flag exists to override: the HQ may
     // not be able to resolve "My-Laptop".
     expect(resolveRemoteUrl(null, '0.0.0.0', 4020, host)).toBe('http://My-Laptop:4020');
+    expect(resolveRemoteUrl(null, '::', 4020, host)).toBe('http://My-Laptop:4020');
+  });
+
+  it('brackets a concrete IPv6 bind address', () => {
+    expect(resolveRemoteUrl(null, '2001:db8::5', 4020, host)).toBe('http://[2001:db8::5]:4020');
   });
 
   it('defaults the hostname resolver to os.hostname() (smoke)', () => {

--- a/web/src/server/server.ts
+++ b/web/src/server/server.ts
@@ -146,9 +146,9 @@ interface Config {
  * Resolve the URL the HQ will use to connect back to a remote server.
  *
  * Precedence:
- *  1. An explicit `--remote-url` (`remoteUrl`) is used verbatim.
+ *  1. An explicit `--remote-url` (`remoteUrl`) is normalized to an origin.
  *  2. Otherwise the URL is derived from the bind address.
- *  3. When bound to all interfaces (`0.0.0.0`), the machine's hostname is used.
+ *  3. When bound to all interfaces (`0.0.0.0` or `::`), the machine's hostname is used.
  *
  * The hostname fallback (3) can be unreachable from the HQ — e.g. a mixed-case
  * or non-DNS local hostname like `My-Laptop.local` that the HQ can't resolve.
@@ -166,11 +166,34 @@ export function resolveRemoteUrl(
   port: number,
   hostname: () => string = os.hostname
 ): string {
-  if (remoteUrl) {
-    return remoteUrl;
+  if (remoteUrl !== null && remoteUrl !== undefined) {
+    return normalizeRemoteUrl(remoteUrl);
   }
-  const remoteHost = bindAddress === '0.0.0.0' ? hostname() : bindAddress;
-  return `http://${remoteHost}:${port}`;
+  const remoteHost = bindAddress === '0.0.0.0' || bindAddress === '::' ? hostname() : bindAddress;
+  const formattedHost =
+    remoteHost.includes(':') && !remoteHost.startsWith('[') ? `[${remoteHost}]` : remoteHost;
+  return `http://${formattedHost}:${port}`;
+}
+
+export function normalizeRemoteUrl(remoteUrl: string): string {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(remoteUrl);
+  } catch {
+    throw new Error('--remote-url must be a valid HTTP or HTTPS URL');
+  }
+
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    throw new Error('--remote-url must use HTTP or HTTPS');
+  }
+  if (parsedUrl.username || parsedUrl.password) {
+    throw new Error('--remote-url must not include credentials');
+  }
+  if (parsedUrl.pathname !== '/' || parsedUrl.search || parsedUrl.hash) {
+    throw new Error('--remote-url must not include a path, query, or fragment');
+  }
+
+  return parsedUrl.origin;
 }
 
 // Show help message
@@ -429,6 +452,20 @@ function validateConfig(config: ReturnType<typeof parseArgs>) {
     logger.error('Remote name required when --hq-url is specified');
     logger.error('Use --name to specify a unique name for this remote server');
     process.exit(1);
+  }
+
+  if (config.remoteUrl !== null && !config.hqUrl) {
+    logger.error('--remote-url requires --hq-url');
+    process.exit(1);
+  }
+
+  if (config.remoteUrl !== null) {
+    try {
+      config.remoteUrl = normalizeRemoteUrl(config.remoteUrl);
+    } catch (error) {
+      logger.error(error instanceof Error ? error.message : 'Invalid --remote-url');
+      process.exit(1);
+    }
   }
 
   // Validate HQ URL is HTTPS unless explicitly allowed

--- a/web/src/server/server.ts
+++ b/web/src/server/server.ts
@@ -112,6 +112,7 @@ interface Config {
   hqUsername: string | null;
   hqPassword: string | null;
   remoteName: string | null;
+  remoteUrl: string | null;
   allowInsecureHQ: boolean;
   showHelp: boolean;
   showVersion: boolean;
@@ -139,6 +140,37 @@ interface Config {
   ngrokRegion: string | null;
   // Cloudflare tunnel configuration
   enableCloudflare: boolean;
+}
+
+/**
+ * Resolve the URL the HQ will use to connect back to a remote server.
+ *
+ * Precedence:
+ *  1. An explicit `--remote-url` (`remoteUrl`) is used verbatim.
+ *  2. Otherwise the URL is derived from the bind address.
+ *  3. When bound to all interfaces (`0.0.0.0`), the machine's hostname is used.
+ *
+ * The hostname fallback (3) can be unreachable from the HQ — e.g. a mixed-case
+ * or non-DNS local hostname like `My-Laptop.local` that the HQ can't resolve.
+ * That is exactly what `--remote-url` is for: pass a tailnet IP or a resolvable
+ * name so the HQ's back-connection (session reads, input) actually works.
+ *
+ * @param remoteUrl  Explicit override (`--remote-url`), or null/undefined.
+ * @param bindAddress The address the server bound to (`--bind`, default 0.0.0.0).
+ * @param port        The actual listening port.
+ * @param hostname    Injectable for testing; defaults to os.hostname().
+ */
+export function resolveRemoteUrl(
+  remoteUrl: string | null | undefined,
+  bindAddress: string,
+  port: number,
+  hostname: () => string = os.hostname
+): string {
+  if (remoteUrl) {
+    return remoteUrl;
+  }
+  const remoteHost = bindAddress === '0.0.0.0' ? hostname() : bindAddress;
+  return `http://${remoteHost}:${port}`;
 }
 
 // Show help message
@@ -186,6 +218,8 @@ Remote Server Options:
   --hq-username <user>  Username for HQ authentication
   --hq-password <pass>  Password for HQ authentication
   --name <name>         Unique name for this remote server
+  --remote-url <url>    URL the HQ uses to reach this remote (default: derived
+                        from --bind, or the hostname when bound to 0.0.0.0)
   --allow-insecure-hq   Allow HTTP URLs for HQ (default: HTTPS only)
   --no-hq-auth          Disable HQ authentication (for testing only)
 
@@ -236,6 +270,7 @@ function parseArgs(): Config {
     hqUsername: null as string | null,
     hqPassword: null as string | null,
     remoteName: null as string | null,
+    remoteUrl: null as string | null,
     allowInsecureHQ: false,
     showHelp: false,
     showVersion: false,
@@ -306,6 +341,9 @@ function parseArgs(): Config {
     } else if (args[i] === '--name' && i + 1 < args.length) {
       config.remoteName = args[i + 1];
       i++; // Skip the name value in next iteration
+    } else if (args[i] === '--remote-url' && i + 1 < args.length) {
+      config.remoteUrl = args[i + 1];
+      i++; // Skip the URL value in next iteration
     } else if (args[i] === '--allow-insecure-hq') {
       config.allowInsecureHQ = true;
     } else if (args[i] === '--debug') {
@@ -1540,15 +1578,10 @@ export async function createApp(): Promise<AppInstance> {
         config.remoteName &&
         (config.noHqAuth || (config.hqUsername && config.hqPassword))
       ) {
-        // Use the actual bind address for HQ registration
-        // If bind is 0.0.0.0, we need to determine the actual network interface IP
-        let remoteHost = bindAddress;
-        if (bindAddress === '0.0.0.0') {
-          // When binding to all interfaces, use the machine's hostname
-          // This allows HQ to connect from the network
-          remoteHost = os.hostname();
-        }
-        const remoteUrl = `http://${remoteHost}:${actualPort}`;
+        // The URL the HQ will use to connect back to this remote. An explicit
+        // --remote-url wins; otherwise it's derived from --bind (see
+        // resolveRemoteUrl for the hostname-fallback caveat).
+        const remoteUrl = resolveRemoteUrl(config.remoteUrl, bindAddress, actualPort);
         hqClient = new HQClient(
           config.hqUrl,
           config.hqUsername || 'no-auth',


### PR DESCRIPTION
## Problem

When a remote binds to all interfaces, HQ registration falls back to the machine hostname. That hostname may not resolve from HQ, so the remote appears in the registry while every callback for health, sessions, input, and streaming fails.

## Fix

- add `--remote-url <url>` so a remote can advertise an explicit HTTP(S) origin reachable from HQ
- normalize origins and reject invalid schemes, credentials, paths, queries, and fragments before registration
- require `--hq-url` when the override is present
- handle wildcard and concrete IPv6 bind addresses correctly
- document callback reachability and bearer-token transport guidance
- add the contributor credit and user-facing changelog entry

Without the flag, existing IPv4/hostname derivation is unchanged.

## Proof

- `pnpm check` — passed
- `pnpm test:server` — 63 files passed, 628 tests passed, 6 files/75 tests skipped
- focused remote URL suite — 6/6 passed
- server TypeScript check — passed
- CLI rejection proof — orphaned and non-HTTP(S) `--remote-url` values exit 1 with targeted diagnostics
- live HQ proof — local HQ and remote started on distinct ports; HQ stored normalized `http://localhost:4123` and refreshed the remote heartbeat through that callback after the 15-second health interval
- structured autoreview — clean; no accepted/actionable findings
- Public Model Identifier Gate — PASS; no model-bearing code, fixtures, generated metadata, workflow text, or proof text changed

The live proof used `--no-auth`, `--no-hq-auth`, and loopback-only listeners in disposable local processes; both listeners were stopped after verification.
