### PR TITLE
fix: restore Xcode 16.4 release builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Restored macOS Release builds on Xcode 16.4 by making Pangolin connection-state handling compatible with Swift 6.1.
+
 ## [1.0.0-beta.16] - 2026-06-16
 
 ### Fixed

--- a/mac/VibeTunnel/Core/Services/PangolinService.swift
+++ b/mac/VibeTunnel/Core/Services/PangolinService.swift
@@ -356,16 +356,11 @@ final class PangolinService {
             self.outputBuffer = String(self.outputBuffer.suffix(32768))
         }
 
-        switch Self.connectionState(from: self.outputBuffer) {
-        case true:
-            self.isConnected = true
-            self.statusError = nil
-        case false:
-            self.isConnected = false
-            self.statusError = "Newt could not connect. Check the Pangolin endpoint and site credentials."
-        case nil:
-            break
-        }
+        guard let isConnected = Self.connectionState(from: self.outputBuffer) else { return }
+        self.isConnected = isConnected
+        self.statusError = isConnected
+            ? nil
+            : "Newt could not connect. Check the Pangolin endpoint and site credentials."
     }
 
     private func clearOutputHandlers() {

--- a/mac/VibeTunnelTests/TailscaleFallbackRegressionTests.swift
+++ b/mac/VibeTunnelTests/TailscaleFallbackRegressionTests.swift
@@ -33,7 +33,7 @@ final class TailscaleFallbackRegressionTests {
     @Test(
         .tags(.critical),
         .timeLimit(.minutes(1)))
-    func tailscaleToggleDoesNotAutoDisableAfter10Seconds() async throws {
+    func tailscaleToggleDoesNotAutoDisableAfter10Seconds() async {
         self.logger.info("Testing that Tailscale toggle remains enabled in fallback mode")
 
         // Enable Tailscale Serve in settings


### PR DESCRIPTION
## Summary

- restore macOS Release compilation on the Xcode 16.4 / Swift 6.1.2 nightly runner
- preserve Pangolin connection-state behavior with explicit optional unwrapping
- remove one pre-existing redundant test `throws` declaration exposed by the required full-repo SwiftFormat gate
- document the release-build fix in the unreleased changelog

Fixes https://github.com/amantus-ai/vibetunnel/issues/703

## Root cause

Every nightly run from June 16 through July 1 failed on the same `db537b06` candidate in `Build Release (Universal Binary)`. Swift 6.1.2 rejected the `Bool?` pattern switch in `PangolinService.processOutput` as non-exhaustive. The equivalent `guard let` plus Boolean assignment compiles across supported toolchains while preserving the nil/true/false behavior.

Provenance: introduced with the Pangolin integration in commit `1791feebed94953cbfcda1a03d4edd47873ddd8a` on 2026-06-15.

## Proof

- `cd mac && swiftformat . --lint --config ../apple/.swiftformat`
- focused Pangolin and Tailscale regression tests: passed
- exact unsigned universal Release `build` and `archive`: both succeeded
- full macOS Release suite: passed
- structured autoreview: clean; no accepted/actionable findings
- built-artifact proof used because this is compiler compatibility only; no external runtime boundary changed
- Public Model Identifier Gate: PASS; no model-bearing code, fixtures, generated metadata, workflow text, or proof text changed
