### PR TITLE
fix(hq): require a target machine for new sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Require the web session form to select a registered HQ machine, without exposing remote callback tokens or the HQ router's filesystem as machine-local data (thanks [@Ebonsignori](https://github.com/Ebonsignori)).
 - Let HQ remotes rejoin automatically after sleep or a network interruption without restarting VibeTunnel (thanks [@Ebonsignori](https://github.com/Ebonsignori)) (#698).
 - Stopped HQ registration diagnostics from logging Basic or bearer authentication material.
 - Restored macOS Release builds on Xcode 16.4 by making Pangolin connection-state handling compatible with Swift 6.1.

--- a/docs/hq.md
+++ b/docs/hq.md
@@ -22,10 +22,12 @@ When a remote server starts with HQ configuration:
 ### 2. Session Management
 
 **Creating Sessions:**
-- Clients can specify a `remoteId` when creating sessions
+- Clients must specify a `remoteId` when creating sessions through HQ
 - HQ forwards the request to the specified remote using the bearer token
 - The remote creates the session locally
 - HQ tracks which sessions belong to which remote
+
+The web New Session form lists registered machines and requires one as the target. Working-directory paths are interpreted on that selected machine. Because repository discovery, directory browsing, and Git worktree helpers are local filesystem operations, the form hides those HQ-router helpers in distributed mode; enter the machine's path directly.
 
 **Session Operations:**
 - All session operations (get info, send input, kill, etc.) are proxied through HQ
@@ -238,6 +240,7 @@ The e2e tests in `src/test/e2e/hq-mode.e2e.test.ts` demonstrate:
 - Always use HTTPS in production (use `--allow-insecure-hq` only for local dev)
 - Use HTTPS for `--remote-url` on untrusted networks because HQ sends the remote bearer token on callback requests
 - Bearer tokens are sensitive - they allow HQ to execute commands on remotes
+- Remote listing and registration responses expose only public machine metadata, never callback bearer tokens
 - HQ credentials should be strong and kept secure
 - Consider network isolation between HQ and remotes
 - Remotes should not be directly accessible from the internet

--- a/web/src/client/components/session-create-form.test.ts
+++ b/web/src/client/components/session-create-form.test.ts
@@ -70,6 +70,34 @@ describe('SessionCreateForm', () => {
   });
 
   describe('initialization', () => {
+    it('hides filesystem controls until server mode is known', async () => {
+      const loadingElement = await fixture<SessionCreateForm>(html`
+        <session-create-form .authClient=${mockAuthClient} .visible=${false}></session-create-form>
+      `);
+      let finishLoading!: (loaded: boolean) => void;
+      Object.defineProperty(loadingElement, 'loadFromLocalStorage', {
+        configurable: true,
+        value: vi.fn(
+          () =>
+            new Promise<boolean>((resolve) => {
+              finishLoading = resolve;
+            })
+        ),
+      });
+
+      loadingElement.visible = true;
+      await loadingElement.updateComplete;
+
+      expect(loadingElement.querySelector('[data-testid="machines-loading"]')).toBeTruthy();
+      expect(loadingElement.querySelector('[data-testid="working-dir-input"]')).toBeNull();
+      expect(loadingElement.querySelector('#session-browse-button')).toBeNull();
+      expect(loadingElement.querySelector('#session-autocomplete-button')).toBeNull();
+      expect(loadingElement.querySelector('git-branch-selector')).toBeNull();
+
+      finishLoading(false);
+      loadingElement.remove();
+    });
+
     it('should create component with default state', () => {
       expect(element).toBeDefined();
       expect(element.workingDir).toBe('~/Documents');

--- a/web/src/client/components/session-create-form.test.ts
+++ b/web/src/client/components/session-create-form.test.ts
@@ -216,7 +216,7 @@ describe('SessionCreateForm', () => {
     it('targets the selected machine in HQ mode', async () => {
       fetchMock.clear();
       fetchMock.mockResponse('/api/server/status', {
-        macAppConnected: false,
+        macAppConnected: true,
         isHQMode: true,
         version: 'test',
       });
@@ -240,6 +240,7 @@ describe('SessionCreateForm', () => {
       expect(hqElement.querySelector('#session-browse-button')).toBeNull();
       expect(hqElement.querySelector('#session-autocomplete-button')).toBeNull();
       expect(hqElement.querySelector('git-branch-selector')).toBeNull();
+      expect(hqElement.querySelector('[data-testid="spawn-window-toggle"]')).toBeNull();
 
       if (!machineSelect) {
         throw new Error('Expected HQ machine selector');
@@ -248,12 +249,14 @@ describe('SessionCreateForm', () => {
       machineSelect.dispatchEvent(new Event('change'));
       hqElement.command = 'zsh';
       hqElement.workingDir = '~/work';
+      hqElement.spawnWindow = true;
       await hqElement.handleCreate();
 
       const sessionCall = fetchMock.getCalls().find((call) => call[0] === '/api/sessions');
       expect(JSON.parse((sessionCall?.[1]?.body as string) || '{}')).toMatchObject({
         command: ['zsh'],
         workingDir: '~/work',
+        spawn_terminal: false,
         remoteId: 'remote-2',
       });
 

--- a/web/src/client/components/session-create-form.test.ts
+++ b/web/src/client/components/session-create-form.test.ts
@@ -260,6 +260,29 @@ describe('SessionCreateForm', () => {
       hqElement.remove();
     });
 
+    it('uses a remote-safe working directory instead of the HQ router default', async () => {
+      fetchMock.clear();
+      fetchMock.mockResponse('/api/config', {
+        repositoryBasePath: '/srv/hq-router',
+      });
+      fetchMock.mockResponse('/api/server/status', {
+        macAppConnected: false,
+        isHQMode: true,
+        version: 'test',
+      });
+      fetchMock.mockResponse('/api/remotes', [{ id: 'remote-1', name: 'Studio Mac' }]);
+
+      const hqElement = await fixture<SessionCreateForm>(html`
+        <session-create-form .authClient=${mockAuthClient} .visible=${true}></session-create-form>
+      `);
+      await waitForAsync();
+      await hqElement.updateComplete;
+
+      expect(hqElement.workingDir).toBe('~/');
+
+      hqElement.remove();
+    });
+
     it('blocks HQ creation when no machine is registered', async () => {
       fetchMock.clear();
       fetchMock.mockResponse('/api/server/status', {

--- a/web/src/client/components/session-create-form.test.ts
+++ b/web/src/client/components/session-create-form.test.ts
@@ -41,6 +41,11 @@ describe('SessionCreateForm', () => {
 
     // Setup fetch mock
     fetchMock = setupFetchMock();
+    fetchMock.mockResponse('/api/server/status', {
+      macAppConnected: false,
+      isHQMode: false,
+      version: 'test',
+    });
 
     // Create mock auth client
     mockAuthClient = {
@@ -53,6 +58,7 @@ describe('SessionCreateForm', () => {
       <session-create-form .authClient=${mockAuthClient} .visible=${true}></session-create-form>
     `);
 
+    await waitForAsync();
     await element.updateComplete;
   });
 
@@ -70,6 +76,7 @@ describe('SessionCreateForm', () => {
       expect(element.command).toBe('zsh');
       expect(element.sessionName).toBe('');
       expect(element.isCreating).toBe(false);
+      expect(fetchMock.getCalls().some((call) => call[0] === '/api/remotes')).toBe(false);
     });
 
     it('should load saved values from localStorage', async () => {
@@ -206,6 +213,112 @@ describe('SessionCreateForm', () => {
   });
 
   describe('session creation', () => {
+    it('targets the selected machine in HQ mode', async () => {
+      fetchMock.clear();
+      fetchMock.mockResponse('/api/server/status', {
+        macAppConnected: false,
+        isHQMode: true,
+        version: 'test',
+      });
+      fetchMock.mockResponse('/api/remotes', [
+        { id: 'remote-1', name: 'Studio Mac' },
+        { id: 'remote-2', name: 'Laptop' },
+      ]);
+      fetchMock.mockResponse('/api/sessions', { sessionId: 'remote-session' });
+
+      const hqElement = await fixture<SessionCreateForm>(html`
+        <session-create-form .authClient=${mockAuthClient} .visible=${true}></session-create-form>
+      `);
+      await waitForAsync();
+      await hqElement.updateComplete;
+
+      const machineSelect = hqElement.querySelector<HTMLSelectElement>(
+        '[data-testid="machine-select"]'
+      );
+      expect(machineSelect?.value).toBe('remote-1');
+      expect(hqElement.textContent).toContain('Working Directory on Machine:');
+      expect(hqElement.querySelector('#session-browse-button')).toBeNull();
+      expect(hqElement.querySelector('#session-autocomplete-button')).toBeNull();
+      expect(hqElement.querySelector('git-branch-selector')).toBeNull();
+
+      if (!machineSelect) {
+        throw new Error('Expected HQ machine selector');
+      }
+      machineSelect.value = 'remote-2';
+      machineSelect.dispatchEvent(new Event('change'));
+      hqElement.command = 'zsh';
+      hqElement.workingDir = '~/work';
+      await hqElement.handleCreate();
+
+      const sessionCall = fetchMock.getCalls().find((call) => call[0] === '/api/sessions');
+      expect(JSON.parse((sessionCall?.[1]?.body as string) || '{}')).toMatchObject({
+        command: ['zsh'],
+        workingDir: '~/work',
+        remoteId: 'remote-2',
+      });
+
+      hqElement.remove();
+    });
+
+    it('blocks HQ creation when no machine is registered', async () => {
+      fetchMock.clear();
+      fetchMock.mockResponse('/api/server/status', {
+        macAppConnected: false,
+        isHQMode: true,
+        version: 'test',
+      });
+      fetchMock.mockResponse('/api/remotes', []);
+
+      const hqElement = await fixture<SessionCreateForm>(html`
+        <session-create-form .authClient=${mockAuthClient} .visible=${true}></session-create-form>
+      `);
+      await waitForAsync();
+      await hqElement.updateComplete;
+
+      const errorHandler = vi.fn();
+      hqElement.addEventListener('error', errorHandler);
+      await hqElement.handleCreate();
+
+      expect(hqElement.querySelector('[data-testid="no-machines-warning"]')).toBeTruthy();
+      expect(
+        hqElement.querySelector<HTMLButtonElement>('[data-testid="create-session-submit"]')
+          ?.disabled
+      ).toBe(true);
+      expect(errorHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ detail: expect.stringContaining('No machines are registered') })
+      );
+      expect(fetchMock.getCalls().some((call) => call[0] === '/api/sessions')).toBe(false);
+
+      hqElement.remove();
+    });
+
+    it('blocks creation when machine discovery fails', async () => {
+      fetchMock.clear();
+      fetchMock.mockResponse('/api/server/status', {
+        macAppConnected: false,
+        isHQMode: true,
+        version: 'test',
+      });
+      fetchMock.mockResponse('/api/remotes', { error: 'offline' }, { status: 503 });
+
+      const hqElement = await fixture<SessionCreateForm>(html`
+        <session-create-form .authClient=${mockAuthClient} .visible=${true}></session-create-form>
+      `);
+      await waitForAsync();
+      await hqElement.updateComplete;
+
+      expect(hqElement.querySelector('[data-testid="machine-load-error"]')).toBeTruthy();
+      expect(
+        hqElement.querySelector<HTMLButtonElement>('[data-testid="create-session-submit"]')
+          ?.disabled
+      ).toBe(true);
+
+      await hqElement.handleCreate();
+      expect(fetchMock.getCalls().some((call) => call[0] === '/api/sessions')).toBe(false);
+
+      hqElement.remove();
+    });
+
     it('should create session with valid data', async () => {
       fetchMock.mockResponse('/api/sessions', {
         sessionId: 'new-session-123',

--- a/web/src/client/components/session-create-form.test.ts
+++ b/web/src/client/components/session-create-form.test.ts
@@ -283,6 +283,64 @@ describe('SessionCreateForm', () => {
       hqElement.remove();
     });
 
+    it('ignores a machine list response from an earlier form initialization', async () => {
+      fetchMock.clear();
+      fetchMock.mockResponse('/api/config', {
+        repositoryBasePath: '/srv/hq-router',
+      });
+      fetchMock.mockResponse('/api/server/status', {
+        macAppConnected: false,
+        isHQMode: true,
+        version: 'test',
+      });
+
+      let resolveStaleRemotes!: (remotes: Array<{ id: string; name: string }>) => void;
+      const staleRemotes = new Promise<Array<{ id: string; name: string }>>((resolve) => {
+        resolveStaleRemotes = resolve;
+      });
+      const listRemotes = vi
+        .fn()
+        .mockReturnValueOnce(staleRemotes)
+        .mockResolvedValueOnce([{ id: 'remote-current', name: 'Current Mac' }]);
+
+      const hqElement = await fixture<SessionCreateForm>(html`
+        <session-create-form .authClient=${mockAuthClient} .visible=${false}></session-create-form>
+      `);
+      Object.defineProperty(hqElement, 'remoteService', {
+        configurable: true,
+        value: { listRemotes },
+      });
+
+      hqElement.visible = true;
+      await hqElement.updateComplete;
+      await vi.waitFor(() => expect(listRemotes).toHaveBeenCalledTimes(1));
+
+      hqElement.visible = false;
+      await hqElement.updateComplete;
+      hqElement.visible = true;
+      await hqElement.updateComplete;
+      await vi.waitFor(() => expect(listRemotes).toHaveBeenCalledTimes(2));
+      await vi.waitFor(() => {
+        expect(
+          hqElement.querySelector<HTMLSelectElement>('[data-testid="machine-select"]')?.value
+        ).toBe('remote-current');
+      });
+
+      resolveStaleRemotes([{ id: 'remote-stale', name: 'Stale Mac' }]);
+      await waitForAsync();
+      await hqElement.updateComplete;
+
+      const machineSelect = hqElement.querySelector<HTMLSelectElement>(
+        '[data-testid="machine-select"]'
+      );
+      expect(machineSelect?.value).toBe('remote-current');
+      expect(Array.from(machineSelect?.options ?? []).map((option) => option.value)).toEqual([
+        'remote-current',
+      ]);
+
+      hqElement.remove();
+    });
+
     it('blocks HQ creation when no machine is registered', async () => {
       fetchMock.clear();
       fetchMock.mockResponse('/api/server/status', {

--- a/web/src/client/components/session-create-form.ts
+++ b/web/src/client/components/session-create-form.ts
@@ -53,6 +53,8 @@ import {
 } from './session-create-form/git-utils.js';
 import type { QuickStartItem } from './session-create-form/quick-start-section.js';
 
+const REMOTE_DEFAULT_WORKING_DIRECTORY = '~/';
+
 const logger = createLogger('session-create-form');
 
 @customElement('session-create-form')
@@ -132,7 +134,7 @@ export class SessionCreateForm extends LitElement {
   private gitService?: GitService;
   private visibleInitializationId = 0;
 
-  async connectedCallback() {
+  connectedCallback() {
     super.connectedCallback();
     // Initialize services - AutocompleteManager handles optional authClient
     this.autocompleteManager = new AutocompleteManager(this.authClient);
@@ -145,10 +147,8 @@ export class SessionCreateForm extends LitElement {
       this.sessionService = new SessionService(this.authClient);
       this.gitService = new GitService(this.authClient);
     }
-    // Load from localStorage when component is first created
-    await this.loadFromLocalStorage();
     // Load server configuration including quick start commands
-    this.loadServerConfig();
+    void this.loadServerConfig();
   }
 
   disconnectedCallback() {
@@ -396,6 +396,8 @@ export class SessionCreateForm extends LitElement {
       }
 
       if (isHQMode) {
+        // Router paths and saved paths may not exist on the selected machine.
+        this.workingDir = REMOTE_DEFAULT_WORKING_DIRECTORY;
         this.clearLocalRepositoryContext();
         return;
       }

--- a/web/src/client/components/session-create-form.ts
+++ b/web/src/client/components/session-create-form.ts
@@ -25,6 +25,7 @@ import { TitleMode } from '../../shared/types.js';
 import type { QuickStartCommand } from '../../types/config.js';
 import type { AuthClient } from '../services/auth-client.js';
 import { type GitRepoInfo, GitService } from '../services/git-service.js';
+import { RemoteService, type RemoteSummary } from '../services/remote-service.js';
 import { RepositoryService } from '../services/repository-service.js';
 import { ServerConfigService } from '../services/server-config-service.js';
 import { type SessionCreateData, SessionService } from '../services/session-service.js';
@@ -75,6 +76,9 @@ export class SessionCreateForm extends LitElement {
   @state() private showRepositoryDropdown = false;
   @state() private repositories: Repository[] = [];
   @state() private macAppConnected = false;
+  @state() private isHQMode = false;
+  @state() private remotes: RemoteSummary[] = [];
+  @state() private selectedRemoteId = '';
   @state() private showCompletions = false;
   @state() private completions: AutocompleteItem[] = [];
   @state() private selectedCompletionIndex = -1;
@@ -120,6 +124,7 @@ export class SessionCreateForm extends LitElement {
   private gitCheckDebounceTimer?: ReturnType<typeof setTimeout>;
   private autocompleteManager!: AutocompleteManager;
   private repositoryService?: RepositoryService;
+  private remoteService?: RemoteService;
   private sessionService?: SessionService;
   private serverConfigService?: ServerConfigService;
   private gitService?: GitService;
@@ -133,6 +138,7 @@ export class SessionCreateForm extends LitElement {
     // Initialize other services only if authClient is available
     if (this.authClient) {
       this.repositoryService = new RepositoryService(this.authClient, this.serverConfigService);
+      this.remoteService = new RemoteService(this.authClient);
       this.sessionService = new SessionService(this.authClient);
       this.gitService = new GitService(this.authClient);
     }
@@ -184,7 +190,11 @@ export class SessionCreateForm extends LitElement {
 
       // Check if form is valid (same conditions as Create button)
       const canCreate =
-        !this.disabled && !this.isCreating && this.workingDir?.trim() && this.command?.trim();
+        !this.disabled &&
+        !this.isCreating &&
+        this.workingDir?.trim() &&
+        this.command?.trim() &&
+        !(this.isHQMode && this.remotes.length === 0);
 
       if (canCreate) {
         e.preventDefault();
@@ -296,6 +306,7 @@ export class SessionCreateForm extends LitElement {
       if (response.ok) {
         const status = await response.json();
         this.macAppConnected = status.macAppConnected || false;
+        this.isHQMode = status.isHQMode || false;
         logger.debug('server status:', status);
       }
     } catch (error) {
@@ -313,6 +324,9 @@ export class SessionCreateForm extends LitElement {
       // Initialize services if they haven't been created yet
       if (!this.repositoryService && this.serverConfigService) {
         this.repositoryService = new RepositoryService(this.authClient, this.serverConfigService);
+      }
+      if (!this.remoteService) {
+        this.remoteService = new RemoteService(this.authClient);
       }
       if (!this.sessionService) {
         this.sessionService = new SessionService(this.authClient);
@@ -363,6 +377,9 @@ export class SessionCreateForm extends LitElement {
 
         // Discover repositories
         this.discoverRepositories();
+
+        // Discover registered machines (HQ mode) for the target picker
+        this.discoverRemotes();
       } else {
         // Remove global keyboard listener when hidden
         document.removeEventListener('keydown', this.handleGlobalKeyDown);
@@ -454,6 +471,17 @@ export class SessionCreateForm extends LitElement {
       return;
     }
 
+    // HQ mode never spawns locally: without a registered machine there's nowhere
+    // for the session to land. Block before the request (the server also 400s).
+    if (this.isHQMode && this.remotes.length === 0) {
+      this.dispatchEvent(
+        new CustomEvent('error', {
+          detail: 'No machines are registered with this HQ. Start VibeTunnel on a machine first.',
+        })
+      );
+      return;
+    }
+
     this.isCreating = true;
 
     // Determine if we're actually spawning a terminal window
@@ -519,6 +547,14 @@ export class SessionCreateForm extends LitElement {
     // Add session name if provided
     if (this.sessionName?.trim()) {
       sessionData.name = this.sessionName.trim();
+    }
+
+    // Target a registered machine when one is selected (HQ mode). The HQ never
+    // spawns locally — the server enforces this with a 400 — so a session must
+    // carry a remoteId there. Outside HQ mode there are no remotes and this is
+    // omitted, preserving local-spawn behavior.
+    if (this.selectedRemoteId) {
+      sessionData.remoteId = this.selectedRemoteId;
     }
 
     // Handle follow mode - only enable when a worktree is selected
@@ -750,6 +786,34 @@ export class SessionCreateForm extends LitElement {
     } finally {
       this.isDiscovering = false;
     }
+  }
+
+  private async discoverRemotes() {
+    // List the machines registered with this HQ. Outside HQ mode the endpoint
+    // 404s and the service returns [], leaving the picker hidden and local-spawn
+    // behavior unchanged.
+    if (!this.remoteService) {
+      this.remotes = [];
+      return;
+    }
+    try {
+      const remotes = await this.remoteService.listRemotes();
+      this.remotes = remotes;
+      // Preselect the first machine so a single-machine HQ needs no interaction,
+      // and the picker always has a valid target. Keep a still-valid selection.
+      if (!this.remotes.some((r) => r.id === this.selectedRemoteId)) {
+        this.selectedRemoteId = this.remotes[0]?.id ?? '';
+      }
+    } catch (error) {
+      logger.error('Failed to discover remotes:', error);
+      this.remotes = [];
+      this.selectedRemoteId = '';
+    }
+  }
+
+  private handleRemoteChange(e: Event) {
+    const select = e.target as HTMLSelectElement;
+    this.selectedRemoteId = select.value;
   }
 
   private handleToggleAutocomplete() {
@@ -1014,11 +1078,47 @@ export class SessionCreateForm extends LitElement {
     }
   }
 
+  private renderMachineSelector() {
+    // HQ with no machines: nowhere to spawn. Warn the user (Create is also
+    // disabled). The server enforces the same invariant with a 400.
+    if (this.isHQMode && this.remotes.length === 0) {
+      return html`
+        <div class="mb-2 sm:mb-3 p-2 sm:p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-lg" data-testid="no-machines-warning">
+          <p class="text-[10px] sm:text-xs text-yellow-200">
+            No machines registered. Start VibeTunnel on a machine to create a session.
+          </p>
+        </div>
+      `;
+    }
+
+    // No remotes and not HQ → a plain single-server deploy; no picker needed.
+    if (this.remotes.length === 0) {
+      return nothing;
+    }
+
+    return html`
+      <div class="mb-2 sm:mb-3">
+        <label class="form-label text-text-muted text-[10px] sm:text-xs lg:text-sm">Machine:</label>
+        <select
+          class="input-field py-1.5 sm:py-2 lg:py-3 text-xs sm:text-sm"
+          .value=${this.selectedRemoteId}
+          @change=${this.handleRemoteChange}
+          ?disabled=${this.disabled || this.isCreating}
+          data-testid="machine-select"
+        >
+          ${this.remotes.map(
+            (remote) =>
+              html`<option value=${remote.id} ?selected=${remote.id === this.selectedRemoteId}>${remote.name}</option>`
+          )}
+        </select>
+      </div>
+    `;
+  }
+
   render() {
     if (!this.visible) {
       return html``;
     }
-
     return html`
       <div class="modal-backdrop flex items-center justify-center py-4 sm:py-6 lg:py-8" @click=${this.handleBackdropClick} role="dialog" aria-modal="true">
         <div
@@ -1084,6 +1184,8 @@ export class SessionCreateForm extends LitElement {
                 data-testid="session-name-input"
               />
             </div>
+
+            ${this.renderMachineSelector()}
 
             <!-- Command -->
             <div class="mb-2 sm:mb-3">
@@ -1239,7 +1341,8 @@ export class SessionCreateForm extends LitElement {
                   this.disabled ||
                   this.isCreating ||
                   !this.workingDir?.trim() ||
-                  !this.command?.trim()
+                  !this.command?.trim() ||
+                  (this.isHQMode && this.remotes.length === 0)
                 }
                 data-testid="create-session-submit"
               >

--- a/web/src/client/components/session-create-form.ts
+++ b/web/src/client/components/session-create-form.ts
@@ -79,6 +79,8 @@ export class SessionCreateForm extends LitElement {
   @state() private isHQMode = false;
   @state() private remotes: RemoteSummary[] = [];
   @state() private selectedRemoteId = '';
+  @state() private isLoadingRemoteTargets = true;
+  @state() private remoteTargetError = '';
   @state() private showCompletions = false;
   @state() private completions: AutocompleteItem[] = [];
   @state() private selectedCompletionIndex = -1;
@@ -128,6 +130,7 @@ export class SessionCreateForm extends LitElement {
   private sessionService?: SessionService;
   private serverConfigService?: ServerConfigService;
   private gitService?: GitService;
+  private visibleInitializationId = 0;
 
   async connectedCallback() {
     super.connectedCallback();
@@ -144,8 +147,6 @@ export class SessionCreateForm extends LitElement {
     }
     // Load from localStorage when component is first created
     await this.loadFromLocalStorage();
-    // Check server status
-    this.checkServerStatus();
     // Load server configuration including quick start commands
     this.loadServerConfig();
   }
@@ -192,9 +193,11 @@ export class SessionCreateForm extends LitElement {
       const canCreate =
         !this.disabled &&
         !this.isCreating &&
+        !this.isLoadingRemoteTargets &&
+        !this.remoteTargetError &&
         this.workingDir?.trim() &&
         this.command?.trim() &&
-        !(this.isHQMode && this.remotes.length === 0);
+        !(this.isHQMode && !this.remotes.some((remote) => remote.id === this.selectedRemoteId));
 
       if (canCreate) {
         e.preventDefault();
@@ -291,29 +294,29 @@ export class SessionCreateForm extends LitElement {
     }
   }
 
-  private async checkServerStatus() {
+  private async checkServerStatus(): Promise<boolean> {
     // Defensive check - authClient should always be provided
     if (!this.authClient) {
       logger.warn('checkServerStatus called without authClient');
       this.macAppConnected = false;
-      return;
+      throw new Error('Authentication client is unavailable');
     }
 
-    try {
-      const response = await fetch('/api/server/status', {
-        headers: this.authClient.getAuthHeader(),
-      });
-      if (response.ok) {
-        const status = await response.json();
-        this.macAppConnected = status.macAppConnected || false;
-        this.isHQMode = status.isHQMode || false;
-        logger.debug('server status:', status);
-      }
-    } catch (error) {
-      logger.warn('failed to check server status:', error);
-      // Default to not connected if we can't check
-      this.macAppConnected = false;
+    const response = await fetch('/api/server/status', {
+      headers: this.authClient.getAuthHeader(),
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to load server status (${response.status})`);
     }
+
+    const status = await response.json();
+    if (!status || typeof status.isHQMode !== 'boolean') {
+      throw new Error('Failed to load server status: invalid response');
+    }
+    this.macAppConnected = status.macAppConnected || false;
+    this.isHQMode = status.isHQMode || false;
+    logger.debug('server status:', status);
+    return this.isHQMode;
   }
 
   updated(changedProperties: PropertyValues) {
@@ -352,21 +355,12 @@ export class SessionCreateForm extends LitElement {
         this.spawnWindow = false;
         this.titleMode = TitleMode.STATIC;
         this.branchSwitchWarning = undefined;
+        this.isLoadingRemoteTargets = true;
+        this.remoteTargetError = '';
 
-        // Then load from localStorage which may override the defaults
-        // Don't await since we're in updated() lifecycle method
-        this.loadFromLocalStorage()
-          .then(() => {
-            // Check if the loaded working directory is a Git repository
-            // This must happen AFTER localStorage is loaded
-            this.checkGitRepository();
-          })
-          .catch((error) => {
-            logger.error('Failed to load from localStorage:', error);
-          });
-
-        // Re-check server status when form becomes visible
-        this.checkServerStatus();
+        // Load saved values, establish whether this is an HQ, then query only
+        // the filesystem that actually owns the session.
+        void this.initializeVisibleForm();
 
         // Add global keyboard listener
         document.addEventListener('keydown', this.handleGlobalKeyDown);
@@ -374,13 +368,8 @@ export class SessionCreateForm extends LitElement {
         // Set data attributes for testing - both synchronously to avoid race conditions
         this.setAttribute('data-modal-state', 'open');
         this.setAttribute('data-modal-rendered', 'true');
-
-        // Discover repositories
-        this.discoverRepositories();
-
-        // Discover registered machines (HQ mode) for the target picker
-        this.discoverRemotes();
       } else {
+        this.visibleInitializationId += 1;
         // Remove global keyboard listener when hidden
         document.removeEventListener('keydown', this.handleGlobalKeyDown);
 
@@ -391,6 +380,47 @@ export class SessionCreateForm extends LitElement {
     }
   }
 
+  private async initializeVisibleForm() {
+    const initializationId = ++this.visibleInitializationId;
+
+    try {
+      await this.loadFromLocalStorage();
+      const isHQMode = await this.refreshRemoteTargets();
+      if (!this.visible || initializationId !== this.visibleInitializationId) {
+        return;
+      }
+
+      if (this.remoteTargetError) {
+        this.clearLocalRepositoryContext();
+        return;
+      }
+
+      if (isHQMode) {
+        this.clearLocalRepositoryContext();
+        return;
+      }
+
+      await Promise.all([this.checkGitRepository(), this.discoverRepositories()]);
+    } catch (error) {
+      logger.error('Failed to initialize session form:', error);
+    }
+  }
+
+  private clearLocalRepositoryContext() {
+    this.repositories = [];
+    this.showRepositoryDropdown = false;
+    this.showCompletions = false;
+    this.gitRepoInfo = null;
+    this.availableBranches = [];
+    this.currentBranch = '';
+    this.selectedBaseBranch = '';
+    this.availableWorktrees = [];
+    this.selectedWorktree = undefined;
+    this.followMode = false;
+    this.followBranch = null;
+    this.showFollowMode = false;
+  }
+
   private handleWorkingDirChange(e: Event) {
     const input = e.target as HTMLInputElement;
     this.workingDir = input.value;
@@ -399,6 +429,12 @@ export class SessionCreateForm extends LitElement {
         detail: this.workingDir,
       })
     );
+
+    // HQ paths belong to the selected machine. The filesystem helpers below
+    // run on the HTTP server, so using them in HQ mode would inspect the router.
+    if (this.isHQMode) {
+      return;
+    }
 
     // Hide repository dropdown when typing
     this.showRepositoryDropdown = false;
@@ -445,6 +481,9 @@ export class SessionCreateForm extends LitElement {
   }
 
   private handleBrowse() {
+    if (this.isHQMode) {
+      return;
+    }
     logger.debug('handleBrowse called, setting showFileBrowser to true');
     this.showFileBrowser = true;
     this.requestUpdate();
@@ -473,7 +512,25 @@ export class SessionCreateForm extends LitElement {
 
     // HQ mode never spawns locally: without a registered machine there's nowhere
     // for the session to land. Block before the request (the server also 400s).
-    if (this.isHQMode && this.remotes.length === 0) {
+    if (this.isLoadingRemoteTargets) {
+      this.dispatchEvent(
+        new CustomEvent('error', {
+          detail: 'Wait for VibeTunnel to finish loading the available machines.',
+        })
+      );
+      return;
+    }
+
+    if (this.remoteTargetError) {
+      this.dispatchEvent(
+        new CustomEvent('error', {
+          detail: this.remoteTargetError,
+        })
+      );
+      return;
+    }
+
+    if (this.isHQMode && !this.remotes.some((remote) => remote.id === this.selectedRemoteId)) {
       this.dispatchEvent(
         new CustomEvent('error', {
           detail: 'No machines are registered with this HQ. Start VibeTunnel on a machine first.',
@@ -772,6 +829,11 @@ export class SessionCreateForm extends LitElement {
   }
 
   private async discoverRepositories() {
+    if (this.isHQMode) {
+      this.repositories = [];
+      return;
+    }
+
     this.isDiscovering = true;
     try {
       // Only proceed if repositoryService is initialized
@@ -788,15 +850,22 @@ export class SessionCreateForm extends LitElement {
     }
   }
 
-  private async discoverRemotes() {
-    // List the machines registered with this HQ. Outside HQ mode the endpoint
-    // 404s and the service returns [], leaving the picker hidden and local-spawn
-    // behavior unchanged.
-    if (!this.remoteService) {
-      this.remotes = [];
-      return;
-    }
+  private async refreshRemoteTargets(): Promise<boolean> {
+    this.isLoadingRemoteTargets = true;
+    this.remoteTargetError = '';
+
     try {
+      const isHQMode = await this.checkServerStatus();
+      if (!isHQMode) {
+        this.remotes = [];
+        this.selectedRemoteId = '';
+        return false;
+      }
+
+      if (!this.remoteService) {
+        throw new Error('Machine service is unavailable');
+      }
+
       const remotes = await this.remoteService.listRemotes();
       this.remotes = remotes;
       // Preselect the first machine so a single-machine HQ needs no interaction,
@@ -804,10 +873,16 @@ export class SessionCreateForm extends LitElement {
       if (!this.remotes.some((r) => r.id === this.selectedRemoteId)) {
         this.selectedRemoteId = this.remotes[0]?.id ?? '';
       }
+      return true;
     } catch (error) {
-      logger.error('Failed to discover remotes:', error);
+      logger.error('Failed to load session targets:', error);
       this.remotes = [];
       this.selectedRemoteId = '';
+      this.remoteTargetError =
+        'Unable to load the available machines. Check the connection and try again.';
+      return this.isHQMode;
+    } finally {
+      this.isLoadingRemoteTargets = false;
     }
   }
 
@@ -817,6 +892,10 @@ export class SessionCreateForm extends LitElement {
   }
 
   private handleToggleAutocomplete() {
+    if (this.isHQMode) {
+      return;
+    }
+
     // If we have text input, toggle the autocomplete
     if (this.workingDir?.trim()) {
       if (this.showCompletions) {
@@ -839,6 +918,12 @@ export class SessionCreateForm extends LitElement {
   }
 
   private async fetchCompletions() {
+    if (this.isHQMode) {
+      this.completions = [];
+      this.showCompletions = false;
+      return;
+    }
+
     const path = this.workingDir?.trim();
     if (!path || path === '') {
       this.completions = [];
@@ -903,6 +988,11 @@ export class SessionCreateForm extends LitElement {
   }
 
   private async checkGitRepository() {
+    if (this.isHQMode) {
+      this.clearLocalRepositoryContext();
+      return;
+    }
+
     const path = this.workingDir?.trim();
     logger.log(`🔍 Checking Git repository for path: ${path}`);
 
@@ -1079,6 +1169,35 @@ export class SessionCreateForm extends LitElement {
   }
 
   private renderMachineSelector() {
+    if (this.isLoadingRemoteTargets) {
+      return html`
+        <div
+          class="mb-2 sm:mb-3 p-2 sm:p-3 bg-bg-elevated border border-border/50 rounded-lg"
+          data-testid="machines-loading"
+        >
+          <p class="text-[10px] sm:text-xs text-text-muted">Loading available machines…</p>
+        </div>
+      `;
+    }
+
+    if (this.remoteTargetError) {
+      return html`
+        <div
+          class="mb-2 sm:mb-3 p-2 sm:p-3 bg-red-500/10 border border-red-500/30 rounded-lg flex items-center justify-between gap-2"
+          data-testid="machine-load-error"
+        >
+          <p class="text-[10px] sm:text-xs text-red-200">${this.remoteTargetError}</p>
+          <button
+            type="button"
+            class="text-[10px] sm:text-xs text-primary hover:text-primary-hover"
+            @click=${() => void this.initializeVisibleForm()}
+          >
+            Retry
+          </button>
+        </div>
+      `;
+    }
+
     // HQ with no machines: nowhere to spawn. Warn the user (Create is also
     // disabled). The server enforces the same invariant with a 400.
     if (this.isHQMode && this.remotes.length === 0) {
@@ -1098,8 +1217,9 @@ export class SessionCreateForm extends LitElement {
 
     return html`
       <div class="mb-2 sm:mb-3">
-        <label class="form-label text-text-muted text-[10px] sm:text-xs lg:text-sm">Machine:</label>
+        <label for="session-machine-select" class="form-label text-text-muted text-[10px] sm:text-xs lg:text-sm">Machine:</label>
         <select
+          id="session-machine-select"
           class="input-field py-1.5 sm:py-2 lg:py-3 text-xs sm:text-sm"
           .value=${this.selectedRemoteId}
           @change=${this.handleRemoteChange}
@@ -1203,13 +1323,17 @@ export class SessionCreateForm extends LitElement {
 
             <!-- Working Directory -->
             <div class="mb-3 sm:mb-4">
-              <label class="form-label text-text-muted text-[10px] sm:text-xs lg:text-sm">Working Directory:</label>
+              <label class="form-label text-text-muted text-[10px] sm:text-xs lg:text-sm">
+                ${this.isHQMode ? 'Working Directory on Machine:' : 'Working Directory:'}
+              </label>
               <div class="relative">
                 <div class="flex gap-1.5 sm:gap-2">
                 <div class="relative flex-1">
                   <input
                     type="text"
-                    class="input-field py-1.5 sm:py-2 lg:py-3 text-xs sm:text-sm w-full pr-24"
+                    class="input-field py-1.5 sm:py-2 lg:py-3 text-xs sm:text-sm w-full ${
+                      this.isHQMode ? '' : 'pr-24'
+                    }"
                     .value=${this.workingDir}
                     @input=${this.handleWorkingDirChange}
                     @keydown=${this.handleWorkingDirKeydown}
@@ -1220,9 +1344,12 @@ export class SessionCreateForm extends LitElement {
                     data-testid="working-dir-input"
                     autocomplete="off"
                   />
-                  ${this.renderGitBranchIndicator()}
+                  ${this.isHQMode ? nothing : this.renderGitBranchIndicator()}
                 </div>
-                <button
+                ${
+                  this.isHQMode
+                    ? nothing
+                    : html`<button
                   id="session-browse-button"
                   class="bg-bg-tertiary border border-border/50 rounded-lg p-1.5 sm:p-2 lg:p-3 font-mono text-text-muted transition-all duration-200 hover:text-primary hover:bg-surface-hover hover:border-primary/50 hover:shadow-sm flex-shrink-0"
                   @click=${this.handleBrowse}
@@ -1260,24 +1387,34 @@ export class SessionCreateForm extends LitElement {
                       d="M5.22 1.22a.75.75 0 011.06 0l6.25 6.25a.75.75 0 010 1.06l-6.25 6.25a.75.75 0 01-1.06-1.06L10.94 8 5.22 2.28a.75.75 0 010-1.06z"
                     />
                   </svg>
-                </button>
+                </button>`
+                }
               </div>
-              <directory-autocomplete
-                .visible=${this.showCompletions}
-                .items=${this.completions}
-                .selectedIndex=${this.selectedCompletionIndex}
-                .isLoading=${this.isLoadingCompletions}
-                @item-selected=${this.handleAutocompleteItemSelected}
-              ></directory-autocomplete>
-              <repository-dropdown
-                .visible=${this.showRepositoryDropdown}
-                .repositories=${this.repositories}
-                @repository-selected=${this.handleRepositorySelected}
-              ></repository-dropdown>
+              ${
+                this.isHQMode
+                  ? nothing
+                  : html`
+                    <directory-autocomplete
+                      .visible=${this.showCompletions}
+                      .items=${this.completions}
+                      .selectedIndex=${this.selectedCompletionIndex}
+                      .isLoading=${this.isLoadingCompletions}
+                      @item-selected=${this.handleAutocompleteItemSelected}
+                    ></directory-autocomplete>
+                    <repository-dropdown
+                      .visible=${this.showRepositoryDropdown}
+                      .repositories=${this.repositories}
+                      @repository-selected=${this.handleRepositorySelected}
+                    ></repository-dropdown>
+                  `
+              }
             </div>
 
             <!-- Git Branch/Worktree Selection (shown when Git repository detected) -->
-            <git-branch-selector
+            ${
+              this.isHQMode
+                ? nothing
+                : html`<git-branch-selector
               .gitRepoInfo=${this.gitRepoInfo}
               .disabled=${this.disabled}
               .isCreating=${this.isCreating}
@@ -1295,7 +1432,8 @@ export class SessionCreateForm extends LitElement {
               @branch-changed=${this.handleBranchChanged}
               @worktree-changed=${this.handleWorktreeChanged}
               @create-worktree=${this.handleCreateWorktreeRequest}
-            ></git-branch-selector>
+            ></git-branch-selector>`
+            }
 
             <!-- Quick Start Section -->
             <quick-start-section
@@ -1340,9 +1478,12 @@ export class SessionCreateForm extends LitElement {
                 ?disabled=${
                   this.disabled ||
                   this.isCreating ||
+                  this.isLoadingRemoteTargets ||
+                  !!this.remoteTargetError ||
                   !this.workingDir?.trim() ||
                   !this.command?.trim() ||
-                  (this.isHQMode && this.remotes.length === 0)
+                  (this.isHQMode &&
+                    !this.remotes.some((remote) => remote.id === this.selectedRemoteId))
                 }
                 data-testid="create-session-submit"
               >

--- a/web/src/client/components/session-create-form.ts
+++ b/web/src/client/components/session-create-form.ts
@@ -207,7 +207,7 @@ export class SessionCreateForm extends LitElement {
     }
   };
 
-  private async loadFromLocalStorage() {
+  private async loadFromLocalStorage(initializationId: number): Promise<boolean> {
     const formData = loadSessionFormData();
 
     // Get repository base path from server config to use as default working dir
@@ -219,6 +219,10 @@ export class SessionCreateForm extends LitElement {
         logger.error('Failed to get repository base path from server:', error);
         appRepoBasePath = DEFAULT_REPOSITORY_BASE_PATH;
       }
+    }
+
+    if (!this.isCurrentVisibleInitialization(initializationId)) {
+      return false;
     }
 
     // Always set values, using saved values or defaults
@@ -237,6 +241,7 @@ export class SessionCreateForm extends LitElement {
 
     // Force re-render to update the input values
     this.requestUpdate();
+    return true;
   }
 
   private saveToLocalStorage() {
@@ -294,7 +299,7 @@ export class SessionCreateForm extends LitElement {
     }
   }
 
-  private async checkServerStatus(): Promise<boolean> {
+  private async checkServerStatus(initializationId?: number): Promise<boolean> {
     // Defensive check - authClient should always be provided
     if (!this.authClient) {
       logger.warn('checkServerStatus called without authClient');
@@ -312,6 +317,9 @@ export class SessionCreateForm extends LitElement {
     const status = await response.json();
     if (!status || typeof status.isHQMode !== 'boolean') {
       throw new Error('Failed to load server status: invalid response');
+    }
+    if (initializationId !== undefined && !this.isCurrentVisibleInitialization(initializationId)) {
+      return status.isHQMode;
     }
     this.macAppConnected = status.macAppConnected || false;
     this.isHQMode = status.isHQMode || false;
@@ -384,8 +392,10 @@ export class SessionCreateForm extends LitElement {
     const initializationId = ++this.visibleInitializationId;
 
     try {
-      await this.loadFromLocalStorage();
-      const isHQMode = await this.refreshRemoteTargets();
+      if (!(await this.loadFromLocalStorage(initializationId))) {
+        return;
+      }
+      const isHQMode = await this.refreshRemoteTargets(initializationId);
       if (!this.visible || initializationId !== this.visibleInitializationId) {
         return;
       }
@@ -421,6 +431,10 @@ export class SessionCreateForm extends LitElement {
     this.followMode = false;
     this.followBranch = null;
     this.showFollowMode = false;
+  }
+
+  private isCurrentVisibleInitialization(initializationId: number): boolean {
+    return this.visible && initializationId === this.visibleInitializationId;
   }
 
   private handleWorkingDirChange(e: Event) {
@@ -852,13 +866,17 @@ export class SessionCreateForm extends LitElement {
     }
   }
 
-  private async refreshRemoteTargets(): Promise<boolean> {
+  private async refreshRemoteTargets(initializationId: number): Promise<boolean> {
     this.isLoadingRemoteTargets = true;
     this.remoteTargetError = '';
+    let detectedHQMode = this.isHQMode;
 
     try {
-      const isHQMode = await this.checkServerStatus();
-      if (!isHQMode) {
+      detectedHQMode = await this.checkServerStatus(initializationId);
+      if (!this.isCurrentVisibleInitialization(initializationId)) {
+        return detectedHQMode;
+      }
+      if (!detectedHQMode) {
         this.remotes = [];
         this.selectedRemoteId = '';
         return false;
@@ -869,6 +887,9 @@ export class SessionCreateForm extends LitElement {
       }
 
       const remotes = await this.remoteService.listRemotes();
+      if (!this.isCurrentVisibleInitialization(initializationId)) {
+        return true;
+      }
       this.remotes = remotes;
       // Preselect the first machine so a single-machine HQ needs no interaction,
       // and the picker always has a valid target. Keep a still-valid selection.
@@ -877,14 +898,19 @@ export class SessionCreateForm extends LitElement {
       }
       return true;
     } catch (error) {
+      if (!this.isCurrentVisibleInitialization(initializationId)) {
+        return detectedHQMode;
+      }
       logger.error('Failed to load session targets:', error);
       this.remotes = [];
       this.selectedRemoteId = '';
       this.remoteTargetError =
         'Unable to load the available machines. Check the connection and try again.';
-      return this.isHQMode;
+      return detectedHQMode;
     } finally {
-      this.isLoadingRemoteTargets = false;
+      if (this.isCurrentVisibleInitialization(initializationId)) {
+        this.isLoadingRemoteTargets = false;
+      }
     }
   }
 

--- a/web/src/client/components/session-create-form.ts
+++ b/web/src/client/components/session-create-form.ts
@@ -558,7 +558,8 @@ export class SessionCreateForm extends LitElement {
     this.isCreating = true;
 
     // Determine if we're actually spawning a terminal window
-    const effectiveSpawnTerminal = this.spawnWindow && this.macAppConnected;
+    // HQ does not know whether the selected machine can open a native window.
+    const effectiveSpawnTerminal = !this.isHQMode && this.spawnWindow && this.macAppConnected;
 
     // Determine the working directory and branch
     let effectiveWorkingDir = this.workingDir?.trim() || '';
@@ -1475,7 +1476,7 @@ export class SessionCreateForm extends LitElement {
 
             <!-- Options Section (collapsible) -->
             <form-options-section
-              .macAppConnected=${this.macAppConnected}
+              .macAppConnected=${this.macAppConnected && !this.isHQMode}
               .spawnWindow=${this.spawnWindow}
               .titleMode=${this.titleMode}
               .gitRepoInfo=${this.gitRepoInfo}

--- a/web/src/client/components/session-create-form.ts
+++ b/web/src/client/components/session-create-form.ts
@@ -363,6 +363,7 @@ export class SessionCreateForm extends LitElement {
         this.spawnWindow = false;
         this.titleMode = TitleMode.STATIC;
         this.branchSwitchWarning = undefined;
+        this.showFileBrowser = false;
         this.isLoadingRemoteTargets = true;
         this.remoteTargetError = '';
 
@@ -1350,6 +1351,10 @@ export class SessionCreateForm extends LitElement {
               />
             </div>
 
+            ${
+              this.isLoadingRemoteTargets
+                ? nothing
+                : html`
             <!-- Working Directory -->
             <div class="mb-3 sm:mb-4">
               <label class="form-label text-text-muted text-[10px] sm:text-xs lg:text-sm">
@@ -1463,6 +1468,8 @@ export class SessionCreateForm extends LitElement {
               @create-worktree=${this.handleCreateWorktreeRequest}
             ></git-branch-selector>`
             }
+            `
+            }
 
             <!-- Quick Start Section -->
             <quick-start-section
@@ -1524,7 +1531,7 @@ export class SessionCreateForm extends LitElement {
       </div>
 
       <file-browser
-        .visible=${this.showFileBrowser}
+        .visible=${!this.isLoadingRemoteTargets && !this.isHQMode && this.showFileBrowser}
         .mode=${'select'}
         .session=${{ workingDir: this.workingDir } as Session}
         @directory-selected=${this.handleDirectorySelected}

--- a/web/src/client/services/remote-service.test.ts
+++ b/web/src/client/services/remote-service.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthClient } from './auth-client';
+import { RemoteService } from './remote-service';
+
+describe('RemoteService', () => {
+  let service: RemoteService;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    global.fetch = fetchMock;
+    service = new RemoteService({
+      getAuthHeader: vi.fn(() => ({ Authorization: 'Bearer test-token' })),
+    } as unknown as AuthClient);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns only the public fields needed by the machine picker', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { id: 'remote-1', name: 'Studio Mac', url: 'https://studio.example.com' },
+        { id: 2, name: 'Invalid' },
+      ],
+    });
+
+    await expect(service.listRemotes()).resolves.toEqual([{ id: 'remote-1', name: 'Studio Mac' }]);
+  });
+
+  it('rejects request failures instead of treating them as an empty HQ', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 503 });
+
+    await expect(service.listRemotes()).rejects.toThrow('Failed to load machines (503)');
+  });
+
+  it('rejects malformed responses', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => ({ remotes: [] }) });
+
+    await expect(service.listRemotes()).rejects.toThrow('invalid server response');
+  });
+});

--- a/web/src/client/services/remote-service.ts
+++ b/web/src/client/services/remote-service.ts
@@ -19,16 +19,11 @@ export interface RemoteSummary {
  * new session must target one of them by `remoteId` (the HQ never spawns locally).
  * This service backs the machine picker in the session-create form.
  *
- * `GET /api/remotes` returns 404 when the server is NOT in HQ mode (a plain
- * single-server deploy). That's not an error here — it simply means there are no
- * remotes to choose from, so we return an empty list and the caller falls back to
- * a local session.
- *
  * @example
  * ```typescript
  * const remoteService = new RemoteService(authClient);
  * const remotes = await remoteService.listRemotes();
- * // [] when not in HQ mode; otherwise the registered machines
+ * // Registered machines; callers only invoke this after confirming HQ mode
  * ```
  *
  * @see web/src/server/routes/remotes.ts - Server-side remote registry endpoints
@@ -43,35 +38,36 @@ export class RemoteService {
   /**
    * List the machines registered with this HQ server.
    *
-   * @returns Promise resolving to the registered remotes, or an empty array when
-   *          the server isn't in HQ mode (404) or the request fails.
+   * @returns Promise resolving to the registered remotes.
    *
-   * @throws Never throws - errors are logged and an empty array returned.
+   * @throws When the server cannot provide a valid remote list. Callers must not
+   *         treat transport or authorization failures as an empty HQ.
    */
   async listRemotes(): Promise<RemoteSummary[]> {
-    try {
-      const response = await fetch('/api/remotes', {
-        headers: this.authClient.getAuthHeader(),
-      });
+    const response = await fetch('/api/remotes', {
+      headers: this.authClient.getAuthHeader(),
+    });
 
-      if (response.ok) {
-        const remotes = await response.json();
-        if (!Array.isArray(remotes)) {
-          return [];
-        }
-        return remotes
-          .filter(
-            (r): r is RemoteSummary => r && typeof r.id === 'string' && typeof r.name === 'string'
-          )
-          .map((r) => ({ id: r.id, name: r.name }));
-      }
-
-      // 404 = not in HQ mode (single-server); any non-OK = no remotes to offer.
-      logger.debug(`remotes unavailable (status ${response.status}); treating as none`);
-      return [];
-    } catch (error) {
-      logger.error('Error listing remotes:', error);
-      return [];
+    if (!response.ok) {
+      logger.error(`Failed to list remotes (status ${response.status})`);
+      throw new Error(`Failed to load machines (${response.status})`);
     }
+
+    const remotes: unknown = await response.json();
+    if (!Array.isArray(remotes)) {
+      throw new Error('Failed to load machines: invalid server response');
+    }
+
+    return remotes
+      .filter(
+        (remote): remote is RemoteSummary =>
+          remote !== null &&
+          typeof remote === 'object' &&
+          'id' in remote &&
+          typeof remote.id === 'string' &&
+          'name' in remote &&
+          typeof remote.name === 'string'
+      )
+      .map((remote) => ({ id: remote.id, name: remote.name }));
   }
 }

--- a/web/src/client/services/remote-service.ts
+++ b/web/src/client/services/remote-service.ts
@@ -1,0 +1,77 @@
+import { createLogger } from '../utils/logger.js';
+import type { AuthClient } from './auth-client.js';
+
+const logger = createLogger('remote-service');
+
+/**
+ * A registered remote machine in HQ mode, narrowed to what the session-create UI
+ * needs: a stable id (sent to the server as `remoteId`) and a display name.
+ */
+export interface RemoteSummary {
+  id: string;
+  name: string;
+}
+
+/**
+ * Service for listing the machines registered with an HQ server.
+ *
+ * In HQ mode the server aggregates terminal sessions from registered remotes; a
+ * new session must target one of them by `remoteId` (the HQ never spawns locally).
+ * This service backs the machine picker in the session-create form.
+ *
+ * `GET /api/remotes` returns 404 when the server is NOT in HQ mode (a plain
+ * single-server deploy). That's not an error here — it simply means there are no
+ * remotes to choose from, so we return an empty list and the caller falls back to
+ * a local session.
+ *
+ * @example
+ * ```typescript
+ * const remoteService = new RemoteService(authClient);
+ * const remotes = await remoteService.listRemotes();
+ * // [] when not in HQ mode; otherwise the registered machines
+ * ```
+ *
+ * @see web/src/server/routes/remotes.ts - Server-side remote registry endpoints
+ */
+export class RemoteService {
+  private authClient: AuthClient;
+
+  constructor(authClient: AuthClient) {
+    this.authClient = authClient;
+  }
+
+  /**
+   * List the machines registered with this HQ server.
+   *
+   * @returns Promise resolving to the registered remotes, or an empty array when
+   *          the server isn't in HQ mode (404) or the request fails.
+   *
+   * @throws Never throws - errors are logged and an empty array returned.
+   */
+  async listRemotes(): Promise<RemoteSummary[]> {
+    try {
+      const response = await fetch('/api/remotes', {
+        headers: this.authClient.getAuthHeader(),
+      });
+
+      if (response.ok) {
+        const remotes = await response.json();
+        if (!Array.isArray(remotes)) {
+          return [];
+        }
+        return remotes
+          .filter(
+            (r): r is RemoteSummary => r && typeof r.id === 'string' && typeof r.name === 'string'
+          )
+          .map((r) => ({ id: r.id, name: r.name }));
+      }
+
+      // 404 = not in HQ mode (single-server); any non-OK = no remotes to offer.
+      logger.debug(`remotes unavailable (status ${response.status}); treating as none`);
+      return [];
+    } catch (error) {
+      logger.error('Error listing remotes:', error);
+      return [];
+    }
+  }
+}

--- a/web/src/client/services/session-service.ts
+++ b/web/src/client/services/session-service.ts
@@ -59,6 +59,7 @@ const logger = createLogger('session-service');
  * @property titleMode - How to handle terminal title updates from applications
  * @property gitRepoPath - Path to Git repository (enables Git integration features)
  * @property gitBranch - Current Git branch name (for display and tracking)
+ * @property remoteId - Target machine id in HQ mode (session is forwarded to that remote)
  */
 export interface SessionCreateData {
   command: string[];
@@ -70,6 +71,7 @@ export interface SessionCreateData {
   titleMode?: TitleMode;
   gitRepoPath?: string;
   gitBranch?: string;
+  remoteId?: string;
 }
 
 /**

--- a/web/src/server/routes/remotes.test.ts
+++ b/web/src/server/routes/remotes.test.ts
@@ -1,0 +1,84 @@
+import type { Express } from 'express';
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { RemoteRegistry } from '../services/remote-registry.js';
+import { createRemoteRoutes } from './remotes.js';
+
+describe('Remote Routes', () => {
+  let app: Express;
+  let remoteRegistry: RemoteRegistry;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+
+    remoteRegistry = {
+      getRemotes: vi.fn(() => [
+        {
+          id: 'remote-1',
+          name: 'Studio Mac',
+          url: 'https://studio.example.com',
+          token: 'callback-secret',
+          registeredAt: new Date('2026-07-01T08:00:00.000Z'),
+          lastHeartbeat: new Date('2026-07-01T08:01:00.000Z'),
+          sessionIds: new Set(['session-1']),
+        },
+      ]),
+      register: vi.fn(() => ({
+        created: true,
+        remote: {
+          id: 'remote-2',
+          name: 'Laptop',
+          url: 'https://laptop.example.com',
+          token: 'new-callback-secret',
+          registeredAt: new Date('2026-07-01T09:00:00.000Z'),
+          lastHeartbeat: new Date('2026-07-01T09:00:00.000Z'),
+          sessionIds: new Set<string>(),
+        },
+      })),
+    } as unknown as RemoteRegistry;
+
+    app.use('/api', createRemoteRoutes({ remoteRegistry, isHQMode: true }));
+  });
+
+  it('lists public remote metadata without callback bearer tokens', async () => {
+    const response = await request(app).get('/api/remotes');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual([
+      {
+        id: 'remote-1',
+        name: 'Studio Mac',
+        url: 'https://studio.example.com',
+        registeredAt: '2026-07-01T08:00:00.000Z',
+        lastHeartbeat: '2026-07-01T08:01:00.000Z',
+        sessionIds: ['session-1'],
+      },
+    ]);
+    expect(response.text).not.toContain('callback-secret');
+  });
+
+  it('does not reflect callback bearer tokens after registration', async () => {
+    const response = await request(app).post('/api/remotes/register').send({
+      id: 'remote-2',
+      name: 'Laptop',
+      url: 'https://laptop.example.com',
+      token: 'new-callback-secret',
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      success: true,
+      remote: {
+        id: 'remote-2',
+        name: 'Laptop',
+        url: 'https://laptop.example.com',
+        registeredAt: '2026-07-01T09:00:00.000Z',
+        lastHeartbeat: '2026-07-01T09:00:00.000Z',
+        sessionIds: [],
+      },
+    });
+    expect(response.text).not.toContain('new-callback-secret');
+  });
+});

--- a/web/src/server/routes/remotes.ts
+++ b/web/src/server/routes/remotes.ts
@@ -11,6 +11,17 @@ interface RemoteRoutesConfig {
   isHQMode: boolean;
 }
 
+function serializeRemote(remote: ReturnType<RemoteRegistry['getRemotes']>[number]) {
+  return {
+    id: remote.id,
+    name: remote.name,
+    url: remote.url,
+    registeredAt: remote.registeredAt,
+    lastHeartbeat: remote.lastHeartbeat,
+    sessionIds: Array.from(remote.sessionIds),
+  };
+}
+
 export function createRemoteRoutes(config: RemoteRoutesConfig): Router {
   const router = Router();
   const { remoteRegistry, isHQMode } = config;
@@ -24,12 +35,9 @@ export function createRemoteRoutes(config: RemoteRoutesConfig): Router {
 
     const remotes = remoteRegistry.getRemotes();
     logger.debug(`listing ${remotes.length} registered remotes`);
-    // Convert Set to Array for JSON serialization
-    const remotesWithArraySessionIds = remotes.map((remote) => ({
-      ...remote,
-      sessionIds: Array.from(remote.sessionIds),
-    }));
-    res.json(remotesWithArraySessionIds);
+    // The registry's bearer token authorizes command execution on a remote.
+    // Never serialize it to browser clients.
+    res.json(remotes.map(serializeRemote));
   });
 
   // HQ Mode: Register a new remote
@@ -57,7 +65,7 @@ export function createRemoteRoutes(config: RemoteRoutesConfig): Router {
         return res.status(204).send();
       }
       logger.log(chalk.green(`remote registered: ${name} (${id}) from ${url}`));
-      res.json({ success: true, remote });
+      res.json({ success: true, remote: serializeRemote(remote) });
     } catch (error) {
       if (error instanceof Error && error.message.includes('already registered')) {
         return res.status(409).json({ error: error.message });

--- a/web/src/server/routes/sessions.test.ts
+++ b/web/src/server/routes/sessions.test.ts
@@ -190,7 +190,7 @@ describe('sessions routes', () => {
       });
     });
 
-    it('should handle errors gracefully', async () => {
+    it('should preserve mode discovery when the Mac app connection check fails', async () => {
       // Mock an error in isMacAppConnected
       vi.mocked(controlUnixHandler.isMacAppConnected).mockImplementation(() => {
         throw new Error('Connection check failed');
@@ -200,7 +200,7 @@ describe('sessions routes', () => {
         ptyManager: mockPtyManager,
         terminalManager: mockTerminalManager,
         remoteRegistry: null,
-        isHQMode: false,
+        isHQMode: true,
       });
 
       const routes = (
@@ -226,10 +226,12 @@ describe('sessions routes', () => {
 
       await statusRoute.route.stack[0].handle(mockReq, mockRes);
 
-      expect(mockRes.status).toHaveBeenCalledWith(500);
       expect(mockRes.json).toHaveBeenCalledWith({
-        error: 'Failed to get server status',
+        macAppConnected: false,
+        isHQMode: true,
+        version: 'unknown',
       });
+      expect(mockRes.status).not.toHaveBeenCalled();
     });
   });
 

--- a/web/src/server/routes/sessions.test.ts
+++ b/web/src/server/routes/sessions.test.ts
@@ -1068,5 +1068,124 @@ describe('sessions routes', () => {
       });
       expect(requestBody.remoteId).toBeUndefined();
     });
+
+    it('should refuse to spawn locally in HQ mode when no remoteId is given (remotes registered)', async () => {
+      // One remote is registered, but the request omits remoteId. HQ must never
+      // spawn locally — reject with 400 and create nothing.
+      mockRemoteRegistry.getRemotes = vi
+        .fn()
+        .mockReturnValue([{ id: 'remote-1', name: 'mac-mini' }]);
+
+      const router = createSessionRoutes({
+        ptyManager: mockPtyManager,
+        terminalManager: mockTerminalManager,
+        remoteRegistry: mockRemoteRegistry,
+        isHQMode: true,
+      });
+
+      const routes = (
+        router as {
+          stack: Array<{
+            route?: {
+              path: string;
+              methods: { post?: boolean };
+              stack: Array<{ handle: (req: Request, res: Response) => Promise<void> }>;
+            };
+          }>;
+        }
+      ).stack;
+      const createRoute = routes.find(
+        (r) => r.route && r.route.path === '/sessions' && r.route.methods.post
+      );
+
+      const mockReq = {
+        body: {
+          command: ['bash'],
+          workingDir: '/test/dir',
+          // no remoteId
+        },
+      } as Request;
+
+      let statusCode = 0;
+      const mockRes = {
+        json: vi.fn(),
+        status: vi.fn((code: number) => {
+          statusCode = code;
+          return mockRes;
+        }),
+      } as unknown as Response;
+
+      if (createRoute?.route?.stack?.[0]) {
+        await createRoute.route.stack[0].handle(mockReq, mockRes);
+      } else {
+        throw new Error('Could not find POST /sessions route handler');
+      }
+
+      expect(statusCode).toBe(400);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error: 'A target machine (remoteId) is required in HQ mode.',
+      });
+      // Crucially, no local session was spawned.
+      expect(mockPtyManager.createSession).not.toHaveBeenCalled();
+      // And nothing was forwarded to a remote either.
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('should explain there are no machines when HQ has zero remotes and no remoteId', async () => {
+      // Zero remotes registered: the error guides the user to start VibeTunnel
+      // on a machine first, and still creates nothing.
+      mockRemoteRegistry.getRemotes = vi.fn().mockReturnValue([]);
+
+      const router = createSessionRoutes({
+        ptyManager: mockPtyManager,
+        terminalManager: mockTerminalManager,
+        remoteRegistry: mockRemoteRegistry,
+        isHQMode: true,
+      });
+
+      const routes = (
+        router as {
+          stack: Array<{
+            route?: {
+              path: string;
+              methods: { post?: boolean };
+              stack: Array<{ handle: (req: Request, res: Response) => Promise<void> }>;
+            };
+          }>;
+        }
+      ).stack;
+      const createRoute = routes.find(
+        (r) => r.route && r.route.path === '/sessions' && r.route.methods.post
+      );
+
+      const mockReq = {
+        body: {
+          command: ['bash'],
+          workingDir: '/test/dir',
+        },
+      } as Request;
+
+      let statusCode = 0;
+      const mockRes = {
+        json: vi.fn(),
+        status: vi.fn((code: number) => {
+          statusCode = code;
+          return mockRes;
+        }),
+      } as unknown as Response;
+
+      if (createRoute?.route?.stack?.[0]) {
+        await createRoute.route.stack[0].handle(mockReq, mockRes);
+      } else {
+        throw new Error('Could not find POST /sessions route handler');
+      }
+
+      expect(statusCode).toBe(400);
+      expect(mockRes.json).toHaveBeenCalledWith({
+        error:
+          'No machines are registered with this HQ, so no session can be created. Start VibeTunnel on a machine first.',
+      });
+      expect(mockPtyManager.createSession).not.toHaveBeenCalled();
+    });
   });
 });

--- a/web/src/server/routes/sessions.ts
+++ b/web/src/server/routes/sessions.ts
@@ -52,17 +52,22 @@ export function createSessionRoutes(config: SessionRoutesConfig): Router {
   // Server status endpoint
   router.get('/server/status', async (_req, res) => {
     logger.debug('[GET /server/status] Getting server status');
+
+    let macAppConnected = false;
     try {
-      const status: ServerStatus = {
-        macAppConnected: controlUnixHandler.isMacAppConnected(),
-        isHQMode,
-        version: process.env.VERSION || 'unknown',
-      };
-      res.json(status);
+      macAppConnected = controlUnixHandler.isMacAppConnected();
     } catch (error) {
-      logger.error('Failed to get server status:', error);
-      res.status(500).json({ error: 'Failed to get server status' });
+      // The Mac app connection is optional. Keep mode discovery available so a
+      // transient control-socket failure cannot block normal web sessions.
+      logger.warn('Failed to check Mac app connection; reporting disconnected:', error);
     }
+
+    const status: ServerStatus = {
+      macAppConnected,
+      isHQMode,
+      version: process.env.VERSION || 'unknown',
+    };
+    res.json(status);
   });
 
   // Tailscale Serve status endpoint

--- a/web/src/server/routes/sessions.ts
+++ b/web/src/server/routes/sessions.ts
@@ -367,6 +367,21 @@ export function createSessionRoutes(config: SessionRoutesConfig): Router {
         return;
       }
 
+      // HQ never spawns locally: a session must land on a registered remote. This
+      // covers BOTH local-spawn paths below (terminal spawn + web session) but not
+      // the forward-to-remote branch above (which already returned). On a Mac
+      // remote isHQMode is false, so the forwarded request still spawns normally.
+      if (isHQMode && !remoteId) {
+        const count = remoteRegistry?.getRemotes().length ?? 0;
+        logger.warn('session creation refused: HQ mode requires a target remote');
+        return res.status(400).json({
+          error:
+            count === 0
+              ? 'No machines are registered with this HQ, so no session can be created. Start VibeTunnel on a machine first.'
+              : 'A target machine (remoteId) is required in HQ mode.',
+        });
+      }
+
       // If spawn_terminal is true, use the control socket for terminal spawning
       if (spawn_terminal) {
         try {


### PR DESCRIPTION
## Summary

- prevent HQ from spawning a session locally when no target machine is supplied
- require the web New Session form to load and select a registered machine before creating
- hide HQ-router filesystem helpers because working-directory paths belong to the selected machine
- keep mode discovery available when the optional Mac app connection probe fails
- keep remote callback bearer tokens out of list and registration responses

This preserves and finishes the second, previously unrelated commit from https://github.com/amantus-ai/vibetunnel/pull/698. Thanks to @Ebonsignori, who authored the first commit in this branch.

## Proof

- `pnpm run check`
- `pnpm run test:server` — 65 files passed; 642 tests passed, 75 skipped
- `pnpm run test:client` — 44 files passed; 748 tests passed, 14 skipped
- `pnpm run build`
- focused HQ regressions — 82 tests passed, 1 skipped
- live HQ with two remotes — selected-machine creation appeared only on the chosen remote; output returned through HQ; untargeted creation returned HTTP 400
- live remote metadata — callback token absent from both public responses
- autoreview — clean, no accepted/actionable findings
- Public Model Identifier Gate — pass; no public model identifiers changed
