### PR TITLE
fix(mac): stabilize Tailscale status timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+- Kept Tailscale CLI status timeouts responsive when the Swift concurrency executor is saturated.
 - Let HQ remotes rejoin automatically after sleep or a network interruption without restarting VibeTunnel (thanks [@Ebonsignori](https://github.com/Ebonsignori)) (#698).
 - Stopped HQ registration diagnostics from logging Basic or bearer authentication material.
 - Restored macOS Release builds on Xcode 16.4 by making Pangolin connection-state handling compatible with Swift 6.1.

--- a/mac/VibeTunnel/Core/Helpers/TailscaleCLI.swift
+++ b/mac/VibeTunnel/Core/Helpers/TailscaleCLI.swift
@@ -67,16 +67,23 @@ enum TailscaleCLI {
 
             do {
                 try process.run()
-                let timeoutTask = Task.detached(priority: .utility) {
-                    try? await Task.sleep(for: timeout)
-                    guard !Task.isCancelled, process.isRunning else { return }
+                let timeoutWorkItem = DispatchWorkItem {
+                    guard process.isRunning else { return }
                     process.terminate()
-                    try? await Task.sleep(for: .milliseconds(250))
-                    if process.isRunning {
-                        kill(process.processIdentifier, SIGKILL)
+                    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.25) {
+                        if process.isRunning {
+                            kill(process.processIdentifier, SIGKILL)
+                        }
                     }
                 }
-                defer { timeoutTask.cancel() }
+                let timeoutComponents = timeout.components
+                let timeoutSeconds = max(
+                    0,
+                    Double(timeoutComponents.seconds) + Double(timeoutComponents.attoseconds) / 1e18)
+                DispatchQueue.global(qos: .utility).asyncAfter(
+                    deadline: .now() + timeoutSeconds,
+                    execute: timeoutWorkItem)
+                defer { timeoutWorkItem.cancel() }
 
                 let data = outputPipe.fileHandleForReading.readDataToEndOfFile()
                 process.waitUntilExit()

--- a/mac/VibeTunnelTests/TailscaleCLITests.swift
+++ b/mac/VibeTunnelTests/TailscaleCLITests.swift
@@ -71,7 +71,7 @@ struct TailscaleCLITests {
         defer { try? FileManager.default.removeItem(at: directory) }
 
         let executable = directory.appendingPathComponent("tailscale")
-        try Data("#!/bin/sh\ntrap '' TERM\nwhile :; do :; done\n".utf8).write(to: executable)
+        try Data("#!/bin/sh\ntrap '' TERM\nexec /bin/sleep 30\n".utf8).write(to: executable)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
 
         let clock = ContinuousClock()


### PR DESCRIPTION
## Summary

- Keep Tailscale CLI status timeouts independent from Swift cooperative-executor availability.
- Preserve TERM followed by the existing SIGKILL fallback for unresponsive commands.
- Replace the CPU-burning timeout fixture with a sleeping process that still ignores TERM.

Closes #706

## Root cause

`fetchStatus` blocked a detached task while waiting for process output, then scheduled timeout enforcement on another Swift concurrency task. Under the heavily parallel Release test suite, executor saturation could delay that timeout task beyond the test's bound. The fixture's busy loop increased the same contention.

## Proof

- Exact nightly `Test Release Configuration` command passed on commit `1b9caddcf0a650630b581c97f470359914299f77` with code coverage enabled.
- `TailscaleCLITests.statusCommandTimesOut` completed in 0.242 seconds within the full parallel Release suite.
- The focused timeout test passed 10 consecutive Release runs.
- SwiftFormat and strict SwiftLint passed on both touched Swift files.
- Structured autoreview: no accepted or actionable findings; patch correct, confidence 0.87.
- Public Model Identifier Gate: PASS; no model-bearing identifiers introduced in the candidate, test output, generated result metadata, or this public proof.

## Risk

Low. The change preserves the existing timeout, TERM, and SIGKILL behavior while moving only timeout scheduling off the cooperative executor.
